### PR TITLE
Feat/#13

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/application/dto/request/PwdResetRequest.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/application/dto/request/PwdResetRequest.java
@@ -1,0 +1,13 @@
+package com.whereyouad.WhereYouAd.domains.user.application.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record PwdResetRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        String email,
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/constant/Provider.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/constant/Provider.java
@@ -1,6 +1,6 @@
 package com.whereyouad.WhereYouAd.domains.user.domain.constant;
 
-import com.whereyouad.WhereYouAd.domains.user.exception.UserSignUpException;
+import com.whereyouad.WhereYouAd.domains.user.exception.UserException;
 import com.whereyouad.WhereYouAd.domains.user.exception.code.UserErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +22,6 @@ public enum Provider {
         return Arrays.stream(Provider.values())
                 .filter(socialType -> socialType.getRegistrationId().equals(registrationId))
                 .findFirst()
-                .orElseThrow(() -> new UserSignUpException(UserErrorCode.NOT_PROVIDE_SOCIAL));
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_PROVIDE_SOCIAL));
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/constant/Provider.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/constant/Provider.java
@@ -1,6 +1,6 @@
 package com.whereyouad.WhereYouAd.domains.user.domain.constant;
 
-import com.whereyouad.WhereYouAd.domains.user.exception.UserException;
+import com.whereyouad.WhereYouAd.domains.user.exception.handler.UserHandler;
 import com.whereyouad.WhereYouAd.domains.user.exception.code.UserErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +22,6 @@ public enum Provider {
         return Arrays.stream(Provider.values())
                 .filter(socialType -> socialType.getRegistrationId().equals(registrationId))
                 .findFirst()
-                .orElseThrow(() -> new UserException(UserErrorCode.NOT_PROVIDE_SOCIAL));
+                .orElseThrow(() -> new UserHandler(UserErrorCode.NOT_PROVIDE_SOCIAL));
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/EmailService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/EmailService.java
@@ -39,7 +39,7 @@ public class EmailService {
 
     //비밀번호 재설정을 위한 인증코드 이메일 발송 로직 (이미 회원가입 된 상태에서 비밀번호 재설정)
     public EmailSentResponse sendEmailForPwd(String toEmail) {
-        if (!userRepository.existsByEmail(toEmail)) { //이미 회원가입 되어있는 것이 확인되면
+        if (userRepository.existsByEmail(toEmail)) { //이미 회원가입 되어있는 것이 확인되면
             return emailSendTemplate(toEmail); //정상적으로 이메일 발송
         } else { //만약 회원가입 되어있지 않다면
             throw new UserException(UserErrorCode.USER_NOT_FOUND); //예외발생

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/EmailService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/EmailService.java
@@ -28,25 +28,26 @@ public class EmailService {
     @Value("${spring.mail.username}")
     private String senderEmail;
 
-    //인증코드 이메일 발송 로직
+    //인증코드 이메일 발송 로직 (최초 회원가입 시)
     public EmailSentResponse sendEmail(String toEmail) {
+        if (userRepository.existsByEmail(toEmail)) { //이미 해당 이메일로 생성한 계정이 있으면
+            throw new UserException(UserErrorCode.USER_EMAIL_DUPLICATE); //이메일 중복 예외(회원가입 시 사용했던 예외)
+        }
 
         return emailSendTemplate(toEmail);
     }
 
+    //비밀번호 재설정을 위한 인증코드 이메일 발송 로직 (이미 회원가입 된 상태에서 비밀번호 재설정)
     public EmailSentResponse sendEmailForPwd(String toEmail) {
-        if (userRepository.existsByEmail(toEmail)) {
-            return emailSendTemplate(toEmail);
-        } else {
-            throw new UserException(UserErrorCode.EMAIL_USER_NOT_FOUND);
+        if (!userRepository.existsByEmail(toEmail)) { //이미 회원가입 되어있는 것이 확인되면
+            return emailSendTemplate(toEmail); //정상적으로 이메일 발송
+        } else { //만약 회원가입 되어있지 않다면
+            throw new UserException(UserErrorCode.USER_NOT_FOUND); //예외발생
         }
     }
 
     //기존 이메일 발송 로직 템플릿 화
     private EmailSentResponse emailSendTemplate(String toEmail) {
-        if (userRepository.existsByEmail(toEmail)) { //이미 해당 이메일로 생성한 계정이 있으면
-            throw new UserException(UserErrorCode.USER_EMAIL_DUPLICATE); //이메일 중복 예외(회원가입 시 사용했던 예외)
-        }
 
         //인증코드 재전송 로직 -> 이미 Redis 에 해당 이메일 인증코드가 있을시 삭제
         String redisKey = "CODE:" + toEmail;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/EmailService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/EmailService.java
@@ -75,8 +75,8 @@ public class EmailService {
                 //실제 인증 코드가 담긴 이메일 전송
                 SimpleMailMessage message = new SimpleMailMessage();
                 message.setTo(toEmail);
-                message.setSubject("whereyouad 회원가입 인증번호");
                 //어떤 유형의 인증(최초 회원가입 or 비밀번호 재설정) 인지 구분하여 인증코드 발송
+                message.setSubject("whereyouad " + type + " 인증번호");
                 message.setText("[Where You Ad] " + type +  "\n 인증 번호는 [" + authCode + "] 입니다.");
                 message.setFrom(senderEmail);
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/EmailService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/EmailService.java
@@ -1,7 +1,7 @@
 package com.whereyouad.WhereYouAd.domains.user.domain.service;
 
 import com.whereyouad.WhereYouAd.domains.user.application.dto.response.EmailSentResponse;
-import com.whereyouad.WhereYouAd.domains.user.exception.UserSignUpException;
+import com.whereyouad.WhereYouAd.domains.user.exception.UserException;
 import com.whereyouad.WhereYouAd.domains.user.exception.code.UserErrorCode;
 import com.whereyouad.WhereYouAd.domains.user.persistence.repository.UserRepository;
 import com.whereyouad.WhereYouAd.global.utils.RedisUtil;
@@ -31,8 +31,21 @@ public class EmailService {
     //인증코드 이메일 발송 로직
     public EmailSentResponse sendEmail(String toEmail) {
 
+        return emailSendTemplate(toEmail);
+    }
+
+    public EmailSentResponse sendEmailForPwd(String toEmail) {
+        if (userRepository.existsByEmail(toEmail)) {
+            return emailSendTemplate(toEmail);
+        } else {
+            throw new UserException(UserErrorCode.EMAIL_USER_NOT_FOUND);
+        }
+    }
+
+    //기존 이메일 발송 로직 템플릿 화
+    private EmailSentResponse emailSendTemplate(String toEmail) {
         if (userRepository.existsByEmail(toEmail)) { //이미 해당 이메일로 생성한 계정이 있으면
-            throw new UserSignUpException(UserErrorCode.USER_EMAIL_DUPLICATE); //이메일 중복 예외(회원가입 시 사용했던 예외)
+            throw new UserException(UserErrorCode.USER_EMAIL_DUPLICATE); //이메일 중복 예외(회원가입 시 사용했던 예외)
         }
 
         //인증코드 재전송 로직 -> 이미 Redis 에 해당 이메일 인증코드가 있을시 삭제
@@ -64,7 +77,7 @@ public class EmailService {
 
                 emailSender.send(message); //만약 실제 존재하는 이메일인데 사용자가 오타를 냈다면
             } catch (MailException e) { //예외 발생
-                throw new UserSignUpException(UserErrorCode.USER_EMAIL_NOT_VALID); //통합 응답 처리 예외로 반환
+                throw new UserException(UserErrorCode.USER_EMAIL_NOT_VALID); //통합 응답 처리 예외로 반환
             }
 
         }
@@ -85,7 +98,7 @@ public class EmailService {
 
         //만약 인증코드가 없거나 잘못 입력했다면,
         if (savedCode == null || !savedCode.equals(inputCode)) {
-            throw new UserSignUpException(UserErrorCode.USER_EMAIL_AUTH_INVALID); //예외 발생(BAD_REQUEST)
+            throw new UserException(UserErrorCode.USER_EMAIL_AUTH_INVALID); //예외 발생(BAD_REQUEST)
         }
 
         //정상적으로 인증코드를 입력했다면,

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/EmailService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/EmailService.java
@@ -31,7 +31,7 @@ public class EmailService {
     //인증코드 이메일 발송 로직 (최초 회원가입 시)
     public EmailSentResponse sendEmail(String toEmail) {
         if (userRepository.existsByEmail(toEmail)) { //이미 해당 이메일로 생성한 계정이 있으면
-            throw new UserException(UserErrorCode.USER_EMAIL_DUPLICATE); //이메일 중복 예외(회원가입 시 사용했던 예외)
+            throw new UserHandler(UserErrorCode.USER_EMAIL_DUPLICATE); //이메일 중복 예외(회원가입 시 사용했던 예외)
         }
 
         return emailSendTemplate(toEmail);
@@ -42,7 +42,7 @@ public class EmailService {
         if (userRepository.existsByEmail(toEmail)) { //이미 회원가입 되어있는 것이 확인되면
             return emailSendTemplate(toEmail); //정상적으로 이메일 발송
         } else { //만약 회원가입 되어있지 않다면
-            throw new UserException(UserErrorCode.USER_NOT_FOUND); //예외발생
+            throw new UserHandler(UserErrorCode.USER_NOT_FOUND); //예외발생
         }
     }
 
@@ -78,7 +78,7 @@ public class EmailService {
 
                 emailSender.send(message); //만약 실제 존재하는 이메일인데 사용자가 오타를 냈다면
             } catch (MailException e) { //예외 발생
-                throw new UserException(UserErrorCode.USER_EMAIL_NOT_VALID); //통합 응답 처리 예외로 반환
+                throw new UserHandler(UserErrorCode.USER_EMAIL_NOT_VALID); //통합 응답 처리 예외로 반환
             }
 
         }
@@ -99,7 +99,7 @@ public class EmailService {
 
         //만약 인증코드가 없거나 잘못 입력했다면,
         if (savedCode == null || !savedCode.equals(inputCode)) {
-            throw new UserException(UserErrorCode.USER_EMAIL_AUTH_INVALID); //예외 발생(BAD_REQUEST)
+            throw new UserHandler(UserErrorCode.USER_EMAIL_AUTH_INVALID); //예외 발생(BAD_REQUEST)
         }
 
         //정상적으로 인증코드를 입력했다면,

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/EmailService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/EmailService.java
@@ -1,7 +1,7 @@
 package com.whereyouad.WhereYouAd.domains.user.domain.service;
 
 import com.whereyouad.WhereYouAd.domains.user.application.dto.response.EmailSentResponse;
-import com.whereyouad.WhereYouAd.domains.user.exception.UserException;
+import com.whereyouad.WhereYouAd.domains.user.exception.handler.UserHandler;
 import com.whereyouad.WhereYouAd.domains.user.exception.code.UserErrorCode;
 import com.whereyouad.WhereYouAd.domains.user.persistence.repository.UserRepository;
 import com.whereyouad.WhereYouAd.global.utils.RedisUtil;
@@ -34,20 +34,23 @@ public class EmailService {
             throw new UserHandler(UserErrorCode.USER_EMAIL_DUPLICATE); //이메일 중복 예외(회원가입 시 사용했던 예외)
         }
 
-        return emailSendTemplate(toEmail);
+        String type = "회원가입";
+
+        return emailSendTemplate(toEmail, type);
     }
 
     //비밀번호 재설정을 위한 인증코드 이메일 발송 로직 (이미 회원가입 된 상태에서 비밀번호 재설정)
     public EmailSentResponse sendEmailForPwd(String toEmail) {
         if (userRepository.existsByEmail(toEmail)) { //이미 회원가입 되어있는 것이 확인되면
-            return emailSendTemplate(toEmail); //정상적으로 이메일 발송
+            String type = "비밀번호 재설정";
+            return emailSendTemplate(toEmail, type); //정상적으로 이메일 발송
         } else { //만약 회원가입 되어있지 않다면
             throw new UserHandler(UserErrorCode.USER_NOT_FOUND); //예외발생
         }
     }
 
     //기존 이메일 발송 로직 템플릿 화
-    private EmailSentResponse emailSendTemplate(String toEmail) {
+    private EmailSentResponse emailSendTemplate(String toEmail, String type) {
 
         //인증코드 재전송 로직 -> 이미 Redis 에 해당 이메일 인증코드가 있을시 삭제
         String redisKey = "CODE:" + toEmail;
@@ -73,7 +76,8 @@ public class EmailService {
                 SimpleMailMessage message = new SimpleMailMessage();
                 message.setTo(toEmail);
                 message.setSubject("whereyouad 회원가입 인증번호");
-                message.setText("인증번호: " + authCode);
+                //어떤 유형의 인증(최초 회원가입 or 비밀번호 재설정) 인지 구분하여 인증코드 발송
+                message.setText("[Where You Ad] " + type +  "\n 인증 번호는 [" + authCode + "] 입니다.");
                 message.setFrom(senderEmail);
 
                 emailSender.send(message); //만약 실제 존재하는 이메일인데 사용자가 오타를 냈다면
@@ -83,12 +87,12 @@ public class EmailService {
 
         }
 
-        //Redis에 저장 (Key: "CODE:이메일", Value: "123456", 유효시간: 300초(5분))
+        //Redis에 저장 (Key: "CODE:이메일", Value: "123456", 유효시간: 180초(3분))
         //테스트 계정도 인증은 해야하니 Redis 에 코드가 저장 되어야 함.
         //테스트 계정의 인증은 서버 로그를 통해 인증코드를 얻어 입력.
-        redisUtil.setDataExpire("CODE:" + toEmail, authCode, 60 * 5L);
+        redisUtil.setDataExpire("CODE:" + toEmail, authCode, 60 * 3L);
 
-        return new EmailSentResponse("인증코드를 이메일로 전송했습니다.", toEmail, 300L);
+        return new EmailSentResponse("인증코드를 이메일로 전송했습니다.", toEmail, 180L);
     }
 
     //인증코드 검증 메서드

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
@@ -58,7 +58,9 @@ public class UserService {
         return UserConverter.toSignInResponse(savedUser);
     }
 
+    //이미 회원가입 된 회원의 비밀번호 재설정 메서드
     public void passwordReset(String email, String password) {
+        //이메일 인증이 되어있는지 확인
         String isEmailVerified = redisUtil.getData("VERIFIED:" + email);
 
         //인증이 안되었다면,
@@ -67,17 +69,17 @@ public class UserService {
         }
 
         //기존 비밀번호와 새 비밀번호가 일치할 시 예외 발생
-        String newPassword = passwordEncoder.encode(password);
-
         User user = userRepository.findUserByEmail(email)
-                .orElseThrow(() -> new UserException(UserErrorCode.EMAIL_USER_NOT_FOUND));
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         String oldPassword = user.getPassword();
 
-        if (passwordEncoder.matches(newPassword, oldPassword)) { //이전 비밀번호 == 새로운 비밀번호이면
+        if (passwordEncoder.matches(password, oldPassword)) { //새로운 비밀번호 == 이전 비밀번호이면
             throw new UserException(UserErrorCode.USER_PASSWORD_SAME_AS_OLD); //예외 발생
         }
 
+        //새 비밀번호 암호화 & 저장
+        String newPassword = passwordEncoder.encode(password);
         //비밀번호 변경 (JPA Dirty Checking)
         user.resetPassword(newPassword);
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
@@ -1,6 +1,6 @@
 package com.whereyouad.WhereYouAd.domains.user.domain.service;
 
-import com.whereyouad.WhereYouAd.domains.user.exception.UserSignUpException;
+import com.whereyouad.WhereYouAd.domains.user.exception.UserException;
 import com.whereyouad.WhereYouAd.domains.user.exception.code.UserErrorCode;
 import com.whereyouad.WhereYouAd.domains.user.domain.constant.UserStatus;
 import com.whereyouad.WhereYouAd.domains.user.application.mapper.UserConverter;
@@ -26,7 +26,7 @@ public class UserService {
     //회원가입 메서드
     public SignUpResponse signUpUser(SignUpRequest request) {
         if (userRepository.existsByEmail(request.email())) { //이미 이메일로 만든 계정이 존재할 시
-            throw new UserSignUpException(UserErrorCode.USER_EMAIL_DUPLICATE); //이메일 중복 예외
+            throw new UserException(UserErrorCode.USER_EMAIL_DUPLICATE); //이메일 중복 예외
         }
 
         //추가 : 이메일 인증되었는지 확인 -> 악의적 공격자가 이메일 인증을 건너뛰고 회원가입 URL 등으로 바로 들어왔을 경우
@@ -35,7 +35,7 @@ public class UserService {
 
         //인증이 안되었다면,
         if (isEmailVerified == null || !isEmailVerified.equals("TRUE")) {
-            throw new UserSignUpException(UserErrorCode.USER_EMAIL_NOT_VERIFIED); //예외 발생(UNAUTHORIZED)
+            throw new UserException(UserErrorCode.USER_EMAIL_NOT_VERIFIED); //예외 발생(UNAUTHORIZED)
         }
 
         //비밀번호 암호화 -> SecurityConfig 클래스 내 에서 BCryptPasswordEncoder 를 Bean 등록한거로 사용
@@ -56,5 +56,31 @@ public class UserService {
 
         //Response DTO 로 변환 및 반환
         return UserConverter.toSignInResponse(savedUser);
+    }
+
+    public void passwordReset(String email, String password) {
+        String isEmailVerified = redisUtil.getData("VERIFIED:" + email);
+
+        //인증이 안되었다면,
+        if (isEmailVerified == null || !isEmailVerified.equals("TRUE")) {
+            throw new UserException(UserErrorCode.USER_EMAIL_NOT_VERIFIED); //예외 발생
+        }
+
+        //기존 비밀번호와 새 비밀번호가 일치할 시 예외 발생
+        String newPassword = passwordEncoder.encode(password);
+
+        User user = userRepository.findUserByEmail(email)
+                .orElseThrow(() -> new UserException(UserErrorCode.EMAIL_USER_NOT_FOUND));
+
+        String oldPassword = user.getPassword();
+
+        if (passwordEncoder.matches(newPassword, oldPassword)) { //이전 비밀번호 == 새로운 비밀번호이면
+            throw new UserException(UserErrorCode.USER_PASSWORD_SAME_AS_OLD); //예외 발생
+        }
+
+        //비밀번호 변경 (JPA Dirty Checking)
+        user.resetPassword(newPassword);
+
+        redisUtil.deleteData("VERIFIED:" + email);
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
@@ -1,6 +1,6 @@
 package com.whereyouad.WhereYouAd.domains.user.domain.service;
 
-import com.whereyouad.WhereYouAd.domains.user.exception.UserException;
+import com.whereyouad.WhereYouAd.domains.user.exception.handler.UserHandler;
 import com.whereyouad.WhereYouAd.domains.user.exception.code.UserErrorCode;
 import com.whereyouad.WhereYouAd.domains.user.domain.constant.UserStatus;
 import com.whereyouad.WhereYouAd.domains.user.application.mapper.UserConverter;
@@ -26,7 +26,7 @@ public class UserService {
     //회원가입 메서드
     public SignUpResponse signUpUser(SignUpRequest request) {
         if (userRepository.existsByEmail(request.email())) { //이미 이메일로 만든 계정이 존재할 시
-            throw new UserException(UserErrorCode.USER_EMAIL_DUPLICATE); //이메일 중복 예외
+            throw new UserHandler(UserErrorCode.USER_EMAIL_DUPLICATE); //이메일 중복 예외
         }
 
         //추가 : 이메일 인증되었는지 확인 -> 악의적 공격자가 이메일 인증을 건너뛰고 회원가입 URL 등으로 바로 들어왔을 경우
@@ -35,7 +35,7 @@ public class UserService {
 
         //인증이 안되었다면,
         if (isEmailVerified == null || !isEmailVerified.equals("TRUE")) {
-            throw new UserException(UserErrorCode.USER_EMAIL_NOT_VERIFIED); //예외 발생(UNAUTHORIZED)
+            throw new UserHandler(UserErrorCode.USER_EMAIL_NOT_VERIFIED); //예외 발생(UNAUTHORIZED)
         }
 
         //비밀번호 암호화 -> SecurityConfig 클래스 내 에서 BCryptPasswordEncoder 를 Bean 등록한거로 사용
@@ -65,17 +65,17 @@ public class UserService {
 
         //인증이 안되었다면,
         if (isEmailVerified == null || !isEmailVerified.equals("TRUE")) {
-            throw new UserException(UserErrorCode.USER_EMAIL_NOT_VERIFIED); //예외 발생
+            throw new UserHandler(UserErrorCode.USER_EMAIL_NOT_VERIFIED); //예외 발생
         }
 
         //기존 비밀번호와 새 비밀번호가 일치할 시 예외 발생
         User user = userRepository.findUserByEmail(email)
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+                .orElseThrow(() -> new UserHandler(UserErrorCode.USER_NOT_FOUND));
 
         String oldPassword = user.getPassword();
 
         if (passwordEncoder.matches(password, oldPassword)) { //새로운 비밀번호 == 이전 비밀번호이면
-            throw new UserException(UserErrorCode.USER_PASSWORD_SAME_AS_OLD); //예외 발생
+            throw new UserHandler(UserErrorCode.USER_PASSWORD_SAME_AS_OLD); //예외 발생
         }
 
         //새 비밀번호 암호화 & 저장

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/exception/UserException.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/exception/UserException.java
@@ -3,8 +3,8 @@ package com.whereyouad.WhereYouAd.domains.user.exception;
 import com.whereyouad.WhereYouAd.global.exception.AppException;
 import com.whereyouad.WhereYouAd.global.exception.BaseErrorCode;
 
-public class UserSignUpException extends AppException {
-    public UserSignUpException(BaseErrorCode errorCode) {
+public class UserException extends AppException {
+    public UserException(BaseErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/exception/code/UserErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/exception/code/UserErrorCode.java
@@ -11,6 +11,8 @@ public enum UserErrorCode implements BaseErrorCode {
     USER_EMAIL_DUPLICATE(HttpStatus.BAD_REQUEST, "USER_400_1", "이미 사용중인 이메일 입니다."),
     USER_EMAIL_NOT_VALID(HttpStatus.BAD_REQUEST, "USER_400_2", "해당 이메일로 메일 전송에 실패했습니다."),
     USER_EMAIL_AUTH_INVALID(HttpStatus.BAD_REQUEST, "USER_400_3", "인증 코드가 올바르지 않습니다."),
+    USER_PASSWORD_SAME_AS_OLD(HttpStatus.BAD_REQUEST, "USER_400_4", "기존 비밀번호와 동일한 비밀번호로는 변경 불가합니다."),
+    EMAIL_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_404_1", "해당 이메일로 가입한 회원이 존재하지 않습니다."),
 
     USER_EMAIL_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "USER_401_1", "이메일 인증이 진행되지 않았습니다."),
     ;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/exception/code/UserErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/exception/code/UserErrorCode.java
@@ -13,6 +13,7 @@ public enum UserErrorCode implements BaseErrorCode {
     USER_EMAIL_NOT_VALID(HttpStatus.BAD_REQUEST, "USER_400_2", "해당 이메일로 메일 전송에 실패했습니다."),
     USER_EMAIL_AUTH_INVALID(HttpStatus.BAD_REQUEST, "USER_400_3", "인증 코드가 올바르지 않습니다."),
     NOT_PROVIDE_SOCIAL(HttpStatus.BAD_REQUEST, "USER_400_4", "지원하지 않는 소셜 로그인 방식입니다."),
+    USER_PASSWORD_SAME_AS_OLD(HttpStatus.BAD_REQUEST, "USER_400_5", "이전 비밀번호와 동일한 비밀번호로 바꿀 수 없습니다."),
 
     // 401
     USER_EMAIL_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "USER_401_1", "이메일 인증이 진행되지 않았습니다."),

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/exception/handler/UserHandler.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/exception/handler/UserHandler.java
@@ -1,10 +1,10 @@
-package com.whereyouad.WhereYouAd.domains.user.exception;
+package com.whereyouad.WhereYouAd.domains.user.exception.handler;
 
 import com.whereyouad.WhereYouAd.global.exception.AppException;
 import com.whereyouad.WhereYouAd.global.exception.BaseErrorCode;
 
-public class UserException extends AppException {
-    public UserException(BaseErrorCode errorCode) {
+public class UserHandler extends AppException {
+    public UserHandler(BaseErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/persistence/entity/User.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/persistence/entity/User.java
@@ -47,4 +47,9 @@ public class User extends BaseEntity {
     public void updateProfile(String name){
         this.name = name;
     }
+
+
+    public void resetPassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/persistence/entity/User.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/persistence/entity/User.java
@@ -42,4 +42,8 @@ public class User extends BaseEntity {
     @Column(nullable = false, name = "status")
     @ColumnDefault("'ACTIVE'")  //기본값 ACTIVE
     private UserStatus status;  //ACTIVE, SUSPENDED, DELETED
+
+    public void resetPassword(String newPassword) {
+        this.password = newPassword;
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/UserController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/UserController.java
@@ -1,6 +1,7 @@
 package com.whereyouad.WhereYouAd.domains.user.presentation;
 
 import com.whereyouad.WhereYouAd.domains.user.application.dto.request.EmailRequest;
+import com.whereyouad.WhereYouAd.domains.user.application.dto.request.PwdResetRequest;
 import com.whereyouad.WhereYouAd.domains.user.application.dto.response.EmailSentResponse;
 import com.whereyouad.WhereYouAd.domains.user.domain.service.EmailService;
 import com.whereyouad.WhereYouAd.domains.user.domain.service.UserService;
@@ -46,6 +47,24 @@ public class UserController implements UserControllerDocs {
 
         return ResponseEntity.ok(
                 DataResponse.from("이메일 인증이 성공적으로 완료되었습니다.")
+        );
+    }
+
+    @PostMapping("/pwd-reset/email")
+    public ResponseEntity<DataResponse<EmailSentResponse>> sendEmailForPwdReset(@RequestBody @Valid EmailRequest.Send request) {
+        EmailSentResponse emailSentResponse = emailService.sendEmailForPwd(request.email());
+
+        return ResponseEntity.ok(
+                DataResponse.created(emailSentResponse)
+        );
+    }
+
+    @PostMapping("/pwd-reset")
+    public ResponseEntity<DataResponse<String>> resetPassword(@RequestBody @Valid PwdResetRequest request) {
+        userService.passwordReset(request.email(), request.password());
+
+        return ResponseEntity.ok(
+                DataResponse.from("비밀번호 변경이 완료되었습니다.")
         );
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/UserController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/UserController.java
@@ -55,7 +55,7 @@ public class UserController implements UserControllerDocs {
         EmailSentResponse emailSentResponse = emailService.sendEmailForPwd(request.email());
 
         return ResponseEntity.ok(
-                DataResponse.created(emailSentResponse)
+                DataResponse.from(emailSentResponse)
         );
     }
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/UserController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/UserController.java
@@ -50,7 +50,7 @@ public class UserController implements UserControllerDocs {
         );
     }
 
-    @PostMapping("/pwd-reset/email")
+    @PostMapping("/password-reset/request")
     public ResponseEntity<DataResponse<EmailSentResponse>> sendEmailForPwdReset(@RequestBody @Valid EmailRequest.Send request) {
         EmailSentResponse emailSentResponse = emailService.sendEmailForPwd(request.email());
 
@@ -59,7 +59,7 @@ public class UserController implements UserControllerDocs {
         );
     }
 
-    @PostMapping("/pwd-reset")
+    @PostMapping("/password-reset/confirm")
     public ResponseEntity<DataResponse<String>> resetPassword(@RequestBody @Valid PwdResetRequest request) {
         userService.passwordReset(request.email(), request.password());
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/docs/UserControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/docs/UserControllerDocs.java
@@ -1,6 +1,7 @@
 package com.whereyouad.WhereYouAd.domains.user.presentation.docs;
 
 import com.whereyouad.WhereYouAd.domains.user.application.dto.request.EmailRequest;
+import com.whereyouad.WhereYouAd.domains.user.application.dto.request.PwdResetRequest;
 import com.whereyouad.WhereYouAd.domains.user.application.dto.request.SignUpRequest;
 import com.whereyouad.WhereYouAd.domains.user.application.dto.response.EmailSentResponse;
 import com.whereyouad.WhereYouAd.domains.user.application.dto.response.SignUpResponse;
@@ -19,7 +20,7 @@ public interface UserControllerDocs {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
-            @ApiResponse(responseCode = "400_2", description = "이메일 중복 회원 존재")
+            @ApiResponse(responseCode = "400_1", description = "이메일 중복 회원 존재")
     })
     public ResponseEntity<DataResponse<SignUpResponse>> signUp(@RequestBody @Valid SignUpRequest request);
 
@@ -30,7 +31,7 @@ public interface UserControllerDocs {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
-            @ApiResponse(responseCode = "400_3", description = "이메일 전송실패(이메일 오타 등)")
+            @ApiResponse(responseCode = "400_2", description = "이메일 전송실패(이메일 오타 등)")
     })
     public ResponseEntity<DataResponse<EmailSentResponse>> sendEmail(@RequestBody @Valid EmailRequest.Send request);
 
@@ -40,7 +41,30 @@ public interface UserControllerDocs {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
-            @ApiResponse(responseCode = "400_4", description = "실패(인증코드 불일치)")
+            @ApiResponse(responseCode = "400_3", description = "실패(인증코드 불일치)")
     })
     public ResponseEntity<DataResponse<String>> verifyEmail(@RequestBody @Valid EmailRequest.Verify request);
+
+    @Operation(
+            summary = "사용자 비밀번호 재설정을 위한 이메일 인증코드 전송 API",
+            description = "회원의 이메일을 입력받아 해당 이메일로 인증코드를 전송합니다(인증코드 검증은 기존 /email-verify 로 진행)"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400_2", description = "이메일 전송실패(이메일 오타 등)"),
+            @ApiResponse(responseCode = "404_1", description = "해당 이메일로 가입한 회원 존재하지 않음")
+    })
+    public ResponseEntity<DataResponse<EmailSentResponse>> sendEmailForPwdReset(@RequestBody @Valid EmailRequest.Send request);
+
+    @Operation(
+            summary = "사용자 비밀번호 재설정 API",
+            description = "회원의 이메일과 재설정할 비밀번호를 입력받아 비밀번호를 재설정(이전과 같은 비밀번호 일 경우 예외 발생)"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400_5", description = "이전 비밀번호와 동일 비밀번호로 변경 불가"),
+            @ApiResponse(responseCode = "401_1", description = "이메일 인증 진행되지 않음"),
+            @ApiResponse(responseCode = "404_1", description = "해당 이메일로 가입한 회원 존재하지 않음")
+    })
+    public ResponseEntity<DataResponse<String>> resetPassword(@RequestBody @Valid PwdResetRequest request);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/global/security/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/security/oauth2/service/CustomOAuth2UserService.java
@@ -1,6 +1,6 @@
 package com.whereyouad.WhereYouAd.global.security.oauth2.service;
 
-import com.whereyouad.WhereYouAd.domains.user.exception.UserException;
+import com.whereyouad.WhereYouAd.domains.user.exception.handler.UserHandler;
 import com.whereyouad.WhereYouAd.global.security.oauth2.dto.*;
 import com.whereyouad.WhereYouAd.domains.user.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.domains.user.exception.code.UserErrorCode;
@@ -50,7 +50,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         } else if (provider == Provider.KAKAO){
             oAuth2Response = new KaKaoResponse(oAuth2User.getAttributes());
         } else {
-            throw new UserException(UserErrorCode.NOT_PROVIDE_SOCIAL);
+            throw new UserHandler(UserErrorCode.NOT_PROVIDE_SOCIAL);
         }
 
         // 사용자 소셜 로그인 고유 id (제공자 + 소셜 발급 id) -> (중복 회원 가입 방지)
@@ -69,7 +69,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 user = userOptional.get();
                 // 기존 이메일에 해당하는 유저가 존재하지만 이메일 인증이 안된 경우 -> 연동 불가
                 if (!user.isEmailVerified()) {
-                    throw new UserException(UserErrorCode.USER_EMAIL_NOT_VERIFIED);
+                    throw new UserHandler(UserErrorCode.USER_EMAIL_NOT_VERIFIED);
                 }
             }
             // 신규 유저(기존 email X, 소셜 로그인 처음) -> DB에 저장

--- a/src/main/java/com/whereyouad/WhereYouAd/global/security/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/security/oauth2/service/CustomOAuth2UserService.java
@@ -1,8 +1,8 @@
 package com.whereyouad.WhereYouAd.global.security.oauth2.service;
 
+import com.whereyouad.WhereYouAd.domains.user.exception.UserException;
 import com.whereyouad.WhereYouAd.global.security.oauth2.dto.*;
 import com.whereyouad.WhereYouAd.domains.user.domain.constant.Provider;
-import com.whereyouad.WhereYouAd.domains.user.exception.UserSignUpException;
 import com.whereyouad.WhereYouAd.domains.user.exception.code.UserErrorCode;
 import com.whereyouad.WhereYouAd.domains.user.persistence.entity.AuthProviderAccount;
 import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
@@ -50,7 +50,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         } else if (provider == Provider.KAKAO){
             oAuth2Response = new KaKaoResponse(oAuth2User.getAttributes());
         } else {
-            throw new UserSignUpException(UserErrorCode.NOT_PROVIDE_SOCIAL);
+            throw new UserException(UserErrorCode.NOT_PROVIDE_SOCIAL);
         }
 
         // 사용자 소셜 로그인 고유 id (제공자 + 소셜 발급 id) -> (중복 회원 가입 방지)
@@ -69,7 +69,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 user = userOptional.get();
                 // 기존 이메일에 해당하는 유저가 존재하지만 이메일 인증이 안된 경우 -> 연동 불가
                 if (!user.isEmailVerified()) {
-                    throw new UserSignUpException(UserErrorCode.USER_EMAIL_NOT_VERIFIED);
+                    throw new UserException(UserErrorCode.USER_EMAIL_NOT_VERIFIED);
                 }
             }
             // 신규 유저(기존 email X, 소셜 로그인 처음) -> DB에 저장


### PR DESCRIPTION
## 📌 관련 이슈
- Close #13 

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

비밀번호를 재설정 하려는 계정에 대해 이메일 인증 진행 후 비밀번호 재설정하는 API 추가

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- 기존의 최초 회원가입 시 이메일 발송 로직을 템플릿화
- 비밀번호 재설정 시 이메일 인증 로직과 최초 회원가입 시의 이메일 인증 로직에서 검증 부분을 구분
- 이전 비밀번호와 같은 값으로 재설정 시도 시 예외 처리

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.

1. 최초 회원가입 (이메일 : test@example.com, 비밀번호: password)
<img width="954" height="629" alt="최초 회원가입" src="https://github.com/user-attachments/assets/1ccacfd0-2fcf-4284-a38b-424eff377ff9" />

2. 비밀번호 재설정을 위해 test@example.com 에 대해 인증 이메일 발송
<img width="945" height="623" alt="비번 재설정 이메일" src="https://github.com/user-attachments/assets/c252bb30-6b24-4073-aaca-693803f0deb3" />

3. 이메일 인증 진행 (이메일 인증은 기존 최초 회원가입 시 사용하던 /email-verify 로 진행)
<img width="947" height="586" alt="비번 재설정 이메일 인증완료" src="https://github.com/user-attachments/assets/48ea5780-a43a-4581-9205-853b28a2f349" />

4. 비밀번호 newPassword 로 재설정 완료 및 새로운 비밀번호로 정상 로그인 확인
<img width="949" height="605" alt="비번 재설정 완료" src="https://github.com/user-attachments/assets/c0db1dde-89f7-4826-a33f-106956004dba" />

<img width="941" height="620" alt="새로운 비번 로그인" src="https://github.com/user-attachments/assets/810636f9-4f25-4d80-984d-5b2ec0aa6483" />

===예외 처리===
1. 이메일 인증 없이 비밀번호 재설정 요청 API 에 접근한 경우 예외처리
1-1) redis 비어있는 상태 -> 진행된 이메일 인증 없음
<img width="371" height="94" alt="redis 비어있음" src="https://github.com/user-attachments/assets/5cf5d1af-88cc-448e-b440-805ad1d44420" />

1-2) 이메일 인증 없이 비밀번호 재설정 요청 시 예외처리
<img width="932" height="608" alt="인증 없이 비번 재설정 시도" src="https://github.com/user-attachments/assets/d5b8a03c-5b74-41c2-a4b5-1b36570590a5" />

2. 기존 비밀번호와 동일한 비밀번호로 재설정 시도 시 예외 처리
2-1) 이메일 test@example.com, 비밀번호 password 로 회원가입한 상태
<img width="954" height="629" alt="최초 회원가입" src="https://github.com/user-attachments/assets/3cc80c5b-464a-4690-a4f1-4cdc1bb05601" />

2-2) 동일한 "password" 로 비밀번호 재설정 시도 시 예외처리
<img width="948" height="633" alt="이전과 동일 비번으로 재설정 시도 오류" src="https://github.com/user-attachments/assets/664970a4-8d7c-45c2-99ac-ed33d333cb7f" />


## ✅ 체크리스트
- [✅] 브랜치 전략(GitHub Flow)을 준수했나요?
- [✅] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [✅] 테스트 통과 확인
- [✅] 서버 실행 확인
- [✅] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- 이전에 설정해뒀던 비밀번호와 동일한 비밀번호로 재설정 시도를 막는 로직을 넣어봤는데 어떤가요?
- 기존 최초 회원가입 시 이메일 전송하는 것과 비밀번호 재설정 시 이메일 전송하는 게 중복 부분이 많은 것 같아
  템플릿 느낌으로 메서드를 빼서 만들어봤는데 오류의 여지가 있을까요? (EmailService 내부 sendEmail(), sendEmailForPwd() 메서드)
- 이메일 인증코드를 받아 검증하는 API 는 기존의 최초 회원가입 시에 사용하던 /email-verify API 를 사용하도록 했는데 
  이대로 해도 괜찮을까요 아니면 따로 추가 API 를 만드는 게 나을까요?

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 이메일 인증 기반 비밀번호 재설정 흐름 추가(재설정 요청 및 확인)
  * 비밀번호 재설정 이메일 전송 전용 경로 추가

* **버그 수정 / 유효성 검사**
  * 새 비밀번호가 이전 비밀번호와 동일한 경우 차단

* **개선**
  * 이메일 인증 처리 및 에러 응답 정비
  * 인증 코드 유효시간 단축(3분)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->