### PR TITLE
:bug: fix: CORS 오류 해결을 위한 SecurityConfig 수정

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/global/security/SecurityConfig.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/security/SecurityConfig.java
@@ -15,6 +15,12 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.Collections;
 
 @Configuration
 @RequiredArgsConstructor
@@ -30,6 +36,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource())) //CORS 추가
                 .csrf(csrf -> csrf.disable()) //CSRF 보호 비활성화
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS) //세션 관리 정책을 STATELESS -> JWT 사용하므로
@@ -58,5 +65,24 @@ public class SecurityConfig {
     @Bean  //회원 비밀번호 BCrypt 암호화를 위한 Bean 등록
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean //CORS 설정
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowedOrigins(Arrays.asList("http://localhost:5173")); //프론트 로컬 주소 허용
+
+        config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+
+        // 허용할 헤더
+        config.setAllowedHeaders(Collections.singletonList("*"));
+
+        // 인증 정보(쿠키, Authorization 헤더 등)를 포함한 요청 허용
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config); // 모든 경로에 대해 위 설정 적용
+        return source;
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #21 

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

프론트 API 연동 시 CORS 오류 해결을 위한 SecurityConfig 추가

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- SecurityConfig 내부 CORS 설정 추가 (프론트 로컬 주소 -> http://localhost:5173 허용) 

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.

## ✅ 체크리스트
- [✅] 브랜치 전략(GitHub Flow)을 준수했나요?
- [✅] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [✅] 테스트 통과 확인
- [✅] 서버 실행 확인
- [✅] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- 프론트 분들 API 연동 작업 하려면 빠르게 반영해주는게 좋을 것 같아서 오류 있는거 아니면 바로 머지하겠습니다!

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 크로스 오리진 요청(CORS) 지원이 활성화되었습니다. GET, POST, PUT, DELETE, PATCH 및 OPTIONS 등 다양한 HTTP 메서드를 지원하며, 모든 헤더를 허용하고 인증 정보를 포함한 요청도 처리할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->