### PR TITLE
Feat/#26

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/request/OrgRequest.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/request/OrgRequest.java
@@ -16,7 +16,10 @@ public class OrgRequest {
     ) {}
 
     public record Update (
-        //TODO
+            @NotBlank(message = "조직 이름은 필수입니다.")
+            String name,
+            String description,
+            String logoUrl
     ) {}
 
     public record Delete (

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/response/OrgResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/response/OrgResponse.java
@@ -13,4 +13,12 @@ public class OrgResponse {
         //TODO
     ) {}
 
+    public record Update (
+            Long orgId,
+            String name,
+            String description,
+            String logoUrl,
+            LocalDateTime updatedAt
+    ) {}
+
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/mapper/OrgConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/mapper/OrgConverter.java
@@ -12,6 +12,14 @@ public class OrgConverter {
         return new OrgResponse.Create(organization.getId(), organization.getCreatedAt());
     }
 
+    public static OrgResponse.Update toUpdatedResponse(Organization organization) {
+        return new OrgResponse.Update(organization.getId(),
+                organization.getName(),
+                organization.getDescription(),
+                organization.getLogoUrl(),
+                organization.getUpdatedAt());
+    }
+
     //DTO -> Entity
     public static Organization toOrganization(Long userId, OrgRequest.Create request) {
         return Organization.builder()

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
@@ -9,7 +9,7 @@ public interface OrgService {
 
     OrgResponse.Read getOrganization(Long userId);
 
-    void modifyOrganization(Long userId, Long orgId, OrgRequest.Update request);
+    OrgResponse.Update modifyOrganization(Long userId, Long orgId, OrgRequest.Update request);
 
     void removeOrganization(Long userId, Long orgId);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -64,7 +64,16 @@ public class OrgServiceImpl implements OrgService{
     }
 
     public void modifyOrganization(Long userId, Long orgId, OrgRequest.Update request) {
-        //TODO
+        Organization organization = orgRepository.findById(orgId)
+                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
+
+        //만약 조직 정보 수정을 요청한 회원이 해당 조직을 생성한 회원이 아니라면,
+        if (!organization.getOwnerUserId().equals(userId)) {
+            throw new OrgHandler(OrgErrorCode.ORG_UPDATE_FORBIDDEN); //예외처리
+        }
+
+        //조직 정보 수정
+        organization.modifyInfo(request);
 
     }
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -63,7 +63,8 @@ public class OrgServiceImpl implements OrgService{
         return null;
     }
 
-    public void modifyOrganization(Long userId, Long orgId, OrgRequest.Update request) {
+    //조직 정보 수정 메서드
+    public OrgResponse.Update modifyOrganization(Long userId, Long orgId, OrgRequest.Update request) {
         Organization organization = orgRepository.findById(orgId)
                 .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
 
@@ -75,6 +76,8 @@ public class OrgServiceImpl implements OrgService{
         //조직 정보 수정
         organization.modifyInfo(request);
 
+        //변환 된 필드값과 해당 조직의 Id, updatedAt 가 포함된 DTO 로 반환
+        return OrgConverter.toUpdatedResponse(organization);
     }
 
     public void removeOrganization(Long userId, Long orgId) {

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
@@ -9,8 +9,14 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum OrgErrorCode implements BaseErrorCode {
     //400
-    ORG_NAME_DUPLICATE(HttpStatus.BAD_REQUEST, "ORG_400_1", "사용자가 이미 속해있는 조직의 이름입니다.");
+    ORG_NAME_DUPLICATE(HttpStatus.BAD_REQUEST, "ORG_400_1", "사용자가 이미 속해있는 조직의 이름입니다."),
 
+    //403
+    ORG_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "ORG_403_1", "조직 정보 변경은 해당 조직을 생성한 회원만 가능합니다."),
+
+    //404
+    ORG_NOT_FOUND(HttpStatus.NOT_FOUND, "ORG_404_1", "해당 id 의 조직이 존재하지 않습니다."),
+    ;
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/entity/Organization.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/entity/Organization.java
@@ -1,5 +1,6 @@
 package com.whereyouad.WhereYouAd.domains.organization.persistence.entity;
 
+import com.whereyouad.WhereYouAd.domains.organization.application.dto.request.OrgRequest;
 import com.whereyouad.WhereYouAd.domains.organization.domain.constant.OrgStatus;
 import com.whereyouad.WhereYouAd.global.common.BaseEntity;
 import jakarta.persistence.*;
@@ -35,4 +36,10 @@ public class Organization extends BaseEntity {
     @Column(nullable = false, name = "status")
     @ColumnDefault("'ACTIVE'") //기본값 ACTIVE
     private OrgStatus status; //ACTIVE, SUSPENDED, DELETED
+
+    public void modifyInfo(OrgRequest.Update request) {
+        this.name = request.name();
+        this.description = request.description();
+        this.logoUrl = request.logoUrl();
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
@@ -43,14 +43,16 @@ public class OrgController implements OrgControllerDocs {
 
 
     @PatchMapping("/{orgId}")
-    public ResponseEntity<Void> modifyOrganization(
+    public ResponseEntity<DataResponse<OrgResponse.Update>> modifyOrganization(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
             @RequestBody @Valid OrgRequest.Update request
     )
     {
-        orgService.modifyOrganization(userId, orgId, request);
-        return ResponseEntity.noContent().build();
+        OrgResponse.Update response = orgService.modifyOrganization(userId, orgId, request);
+        return ResponseEntity.ok(
+                DataResponse.from(response)
+        );
     }
 
     @Hidden

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
@@ -41,12 +41,12 @@ public class OrgController implements OrgControllerDocs {
         );
     }
 
-    @Hidden
+
     @PatchMapping("/{orgId}")
     public ResponseEntity<Void> modifyOrganization(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
-            @RequestBody OrgRequest.Update request
+            @RequestBody @Valid OrgRequest.Update request
     )
     {
         orgService.modifyOrganization(userId, orgId, request);

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 public interface OrgControllerDocs {
@@ -22,4 +23,19 @@ public interface OrgControllerDocs {
     })
     public ResponseEntity<DataResponse<OrgResponse.Create>> createOrganization(@AuthenticationPrincipal(expression = "userId") Long userId,
                                                                                @RequestBody @Valid OrgRequest.Create request);
+
+    @Operation(
+            summary = "조직 정보 수정 API",
+            description = "새로운 조직 이름, 설명, 로고 이미지 URL 을 받아 저장(해당 조직을 생성한 회원만 정보 변경 가능)"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "성공(응답X)"),
+            @ApiResponse(responseCode = "403_1", description = "허가되지 않은 회원의 요청(조직 생성 회원 X)"),
+            @ApiResponse(responseCode = "404_1", description = "해당 id 조직 존재 X")
+    })
+    public ResponseEntity<Void> modifyOrganization(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId,
+            @RequestBody @Valid OrgRequest.Update request
+    );
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
@@ -29,11 +29,11 @@ public interface OrgControllerDocs {
             description = "새로운 조직 이름, 설명, 로고 이미지 URL 을 받아 저장(해당 조직을 생성한 회원만 정보 변경 가능)"
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "성공(응답X)"),
+            @ApiResponse(responseCode = "200", description = "성공(변경된 필드 값들과 조직Id, 변경 시각 반환)"),
             @ApiResponse(responseCode = "403_1", description = "허가되지 않은 회원의 요청(조직 생성 회원 X)"),
             @ApiResponse(responseCode = "404_1", description = "해당 id 조직 존재 X")
     })
-    public ResponseEntity<Void> modifyOrganization(
+    public ResponseEntity<DataResponse<OrgResponse.Update>> modifyOrganization(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
             @RequestBody @Valid OrgRequest.Update request


### PR DESCRIPTION
## 📌 관련 이슈
- Close #26 

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

조직 정보 수정 API 추가

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- 조직 정보 수정 API 추가
- 조직 정보 수정 관련 오류 코드 추가
- 조직 정보 수정 관련 DTO 추가

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.

===이름 test 인 유저(id = 1) 가 생성한 org1 조직의 이름, 설명, 로고 이미지 URL 변경하기===
1. 변경 전 users 테이블 & organization 테이블
<img width="1333" height="714" alt="image" src="https://github.com/user-attachments/assets/6ca679c3-898c-4f7a-8eff-0a14a43a89cd" />

<img width="1327" height="765" alt="image" src="https://github.com/user-attachments/assets/c385c4d1-25aa-48fe-86b2-e10e3076b254" />

2. 조직 생성자만 정보 수정 가능하므로, id = 1 인 test 유저로 로그인 하여 토큰 획득
<img width="1894" height="1215" alt="image" src="https://github.com/user-attachments/assets/fd5db132-c784-413e-b945-f45aff8fd347" />

3. 조직 정보 새롭게 변경
<img width="1916" height="1023" alt="image" src="https://github.com/user-attachments/assets/b1dea260-46b9-4023-aef8-5090dbd1a616" />

DB organization 테이블 변경 내역 확인 가능
<img width="1318" height="740" alt="image" src="https://github.com/user-attachments/assets/037cbdef-ed4a-4944-a4d6-49cf1b3e4f8c" />

===예외 처리===
1. 조직 생성자(ADMIN) 가 아닌 회원으로 조직 정보 변경 요청 시

1-1. id = 2 인 test2 사용자로 로그인, 토큰 획득
<img width="1918" height="1195" alt="image" src="https://github.com/user-attachments/assets/4fff2f5f-ab41-48f8-ae7e-c62f17ec6660" />

1-2. test2 사용자의 AccessToken 으로 org1 조직 정보 변경 요청 시 예외처리 (403 Forbidden)
<img width="1920" height="1150" alt="image" src="https://github.com/user-attachments/assets/29343184-10db-4120-a862-72075ae3e3c8" />

2. 잘못된 조직 id 로 접근한 경우 -> DB 내 존재하지 않는 orgId = 6 에 대해 정보 수정 요청시 예외 (404 Not Found)
<img width="1905" height="1184" alt="image" src="https://github.com/user-attachments/assets/6f9a43e2-e3a1-4593-b102-505ea2782ea8" />

3. 정보 수정 요청 시 필수 값인 조직 이름이 공백으로 넘어오는 경우 -> @Valid 검사 예외 처리 (400 Bad Request)
<img width="1899" height="1218" alt="image" src="https://github.com/user-attachments/assets/ac3f3eed-4dc4-4586-a4b4-240e2afaf0be" />

## ✅ 체크리스트
- [✅] 브랜치 전략(GitHub Flow)을 준수했나요?
- [✅] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [✅] 테스트 통과 확인
- [✅] 서버 실행 확인
- [✅] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- 조직 조회 API 의 경우 한 회원의 모든 조직 리스트 / 각 조직의 세부 내용 조회 / 조직에 속한 회원들 조회 등 여러가지 관점이 있을 것 같아 비교적 작업이 빠르게 끝날 것 같은 수정, 삭제 API 부터 진행하려 합니다.
- 제가 기존에 알기로는 CRUD 에서 Update 와 Delete 는 요청이 성공적으로 처리되었을 때 204 noContent() 로 응답값을 따로 반환하지 않는 걸로 알고 있었는데 조사를 해보니 최근에는 Update 의 경우 200 OK 로 처리해서 Body 에 변경된 내용과 해당 조직 id, updatedAt 를 함께 반환하는 것도 권장된다고 하더라구요. 어떤 방법이 나을까요?
- 정보 수정 Request DTO 에서 조직 이름에만 @NotBlank 를 적용하고 나머지 필드에는 적용하지 않았는데, 나머지 필드에도 적용하는게 좋을까요?

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 조직 정보 수정 기능 추가 — 이름, 설명, 로고 URL을 업데이트할 수 있습니다.
  * 수정 결과를 반환하도록 변경되어 업데이트된 정보와 수정 시각을 확인할 수 있습니다.
  * 조직 소유자만 수정 가능하도록 권한 검증을 추가했습니다.

* **문서**
  * 조직 수정 API 문서화 및 요청 유효성 검사(이름 필수) 명세가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->