### PR TITLE
Feat/#29 조직 삭제 API 추가

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/request/OrgRequest.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/request/OrgRequest.java
@@ -22,7 +22,4 @@ public class OrgRequest {
             String logoUrl
     ) {}
 
-    public record Delete (
-        //TODO
-    ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/response/OrgResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/response/OrgResponse.java
@@ -21,4 +21,10 @@ public class OrgResponse {
             LocalDateTime updatedAt
     ) {}
 
+    //Soft Delete 복구 시 응답값
+    public record Delete (
+            Long orgId,
+            String message
+    ) {}
+
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/mapper/OrgConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/mapper/OrgConverter.java
@@ -20,6 +20,11 @@ public class OrgConverter {
                 organization.getUpdatedAt());
     }
 
+    public static OrgResponse.Delete toRestoredResponse(Organization organization) {
+        return new OrgResponse.Delete(organization.getId(),
+                "해당 조직이 활성화 되었습니다");
+    }
+
     //DTO -> Entity
     public static Organization toOrganization(Long userId, OrgRequest.Create request) {
         return Organization.builder()

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
@@ -14,4 +14,6 @@ public interface OrgService {
     void removeOrganization(Long userId, Long orgId);
 
     void removeOrganizationSoft(Long userId, Long orgId);
+
+    OrgResponse.Delete restoreOrganization(Long userId, Long orgId);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
@@ -12,4 +12,6 @@ public interface OrgService {
     OrgResponse.Update modifyOrganization(Long userId, Long orgId, OrgRequest.Update request);
 
     void removeOrganization(Long userId, Long orgId);
+
+    void removeOrganizationSoft(Long userId, Long orgId);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -70,7 +70,7 @@ public class OrgServiceImpl implements OrgService{
 
         //만약 조직 정보 수정을 요청한 회원이 해당 조직을 생성한 회원이 아니라면,
         if (!organization.getOwnerUserId().equals(userId)) {
-            throw new OrgHandler(OrgErrorCode.ORG_UPDATE_FORBIDDEN); //예외처리
+            throw new OrgHandler(OrgErrorCode.ORG_FORBIDDEN); //예외처리
         }
 
         //조직 정보 수정
@@ -80,8 +80,36 @@ public class OrgServiceImpl implements OrgService{
         return OrgConverter.toUpdatedResponse(organization);
     }
 
+    //조직 삭제 메서드 -> Hard Delete (DB 에서 완전히 제거)
     public void removeOrganization(Long userId, Long orgId) {
-        //TODO
+        Organization organization = orgRepository.findById(orgId)
+                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
 
+        //만약 조직 삭제 요청한 회원이 해당 조직을 생성한 회원이 아니라면,
+        if (!organization.getOwnerUserId().equals(userId)) {
+            throw new OrgHandler(OrgErrorCode.ORG_FORBIDDEN); //예외처리
+        }
+
+        //해당 조직에 가입된 모든 회원들의 가입 정보 삭제
+        List<OrgMember> orgMembers = orgMemberRepository.findOrgMemberByOrg(organization);
+
+        orgMemberRepository.deleteAll(orgMembers);
+
+        //조직 실제 삭제
+        orgRepository.delete(organization);
+    }
+
+    //조직 삭제 메서드 -> Soft Delete (status 만 DELETED 로 변경)
+    public void removeOrganizationSoft(Long userId, Long orgId) {
+        Organization organization = orgRepository.findById(orgId)
+                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
+
+        //만약 조직 삭제 요청한 회원이 해당 조직을 생성한 회원이 아니라면,
+        if (!organization.getOwnerUserId().equals(userId)) {
+            throw new OrgHandler(OrgErrorCode.ORG_FORBIDDEN);
+        }
+
+        //조직 status 만 DELETED 로 변경 후 종료
+        organization.softDelete();
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -4,6 +4,7 @@ import com.whereyouad.WhereYouAd.domains.organization.application.dto.request.Or
 import com.whereyouad.WhereYouAd.domains.organization.application.dto.response.OrgResponse;
 import com.whereyouad.WhereYouAd.domains.organization.application.mapper.OrgConverter;
 import com.whereyouad.WhereYouAd.domains.organization.application.mapper.OrgMemberConverter;
+import com.whereyouad.WhereYouAd.domains.organization.domain.constant.OrgStatus;
 import com.whereyouad.WhereYouAd.domains.organization.exception.code.OrgErrorCode;
 import com.whereyouad.WhereYouAd.domains.organization.exception.handler.OrgHandler;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMember;
@@ -78,6 +79,25 @@ public class OrgServiceImpl implements OrgService{
 
         //변환 된 필드값과 해당 조직의 Id, updatedAt 가 포함된 DTO 로 반환
         return OrgConverter.toUpdatedResponse(organization);
+    }
+
+    public OrgResponse.Delete restoreOrganization(Long userId, Long orgId) {
+        Organization organization = orgRepository.findById(orgId)
+                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
+
+        //만약 조직 복구 요청한 회원이 해당 조직을 생성한 회원이 아니라면,
+        if (!organization.getOwnerUserId().equals(userId)) {
+            throw new OrgHandler(OrgErrorCode.ORG_FORBIDDEN); //예외처리
+        }
+
+        //조직이 이미 활성화 상태라면,
+        if (organization.getStatus() == OrgStatus.ACTIVE) {
+            throw new OrgHandler(OrgErrorCode.ORG_ALREADY_ACTIVE); //예외처리
+        }
+
+        organization.restoreDelete(); //조직 Soft Delete 복구
+
+        return OrgConverter.toRestoredResponse(organization);
     }
 
     //조직 삭제 메서드 -> Hard Delete (DB 에서 완전히 제거)

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
@@ -16,6 +16,9 @@ public enum OrgErrorCode implements BaseErrorCode {
 
     //404
     ORG_NOT_FOUND(HttpStatus.NOT_FOUND, "ORG_404_1", "해당 id 의 조직이 존재하지 않습니다."),
+
+    //409
+    ORG_ALREADY_ACTIVE(HttpStatus.CONFLICT, "ORG_409_1", "해당 조직은 이미 활성화 상태 입니다.")
     ;
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
@@ -12,7 +12,7 @@ public enum OrgErrorCode implements BaseErrorCode {
     ORG_NAME_DUPLICATE(HttpStatus.BAD_REQUEST, "ORG_400_1", "사용자가 이미 속해있는 조직의 이름입니다."),
 
     //403
-    ORG_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "ORG_403_1", "조직 정보 변경은 해당 조직을 생성한 회원만 가능합니다."),
+    ORG_FORBIDDEN(HttpStatus.FORBIDDEN, "ORG_403_1", "해당 요청은 조직 생성자만 요청 가능합니다."),
 
     //404
     ORG_NOT_FOUND(HttpStatus.NOT_FOUND, "ORG_404_1", "해당 id 의 조직이 존재하지 않습니다."),

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/entity/Organization.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/entity/Organization.java
@@ -46,4 +46,8 @@ public class Organization extends BaseEntity {
     public void softDelete() {
         this.status = OrgStatus.DELETED;
     }
+
+    public void restoreDelete() {
+        this.status = OrgStatus.ACTIVE;
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/entity/Organization.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/entity/Organization.java
@@ -35,11 +35,15 @@ public class Organization extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, name = "status")
     @ColumnDefault("'ACTIVE'") //기본값 ACTIVE
-    private OrgStatus status; //ACTIVE, SUSPENDED, DELETED
+    private OrgStatus status; //ACTIVE, DELETED
 
     public void modifyInfo(OrgRequest.Update request) {
         this.name = request.name();
         this.description = request.description();
         this.logoUrl = request.logoUrl();
+    }
+
+    public void softDelete() {
+        this.status = OrgStatus.DELETED;
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
@@ -1,8 +1,11 @@
 package com.whereyouad.WhereYouAd.domains.organization.persistence.repository;
 
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMember;
+import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
 import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -10,4 +13,8 @@ public interface OrgMemberRepository extends JpaRepository<OrgMember, Long> {
 
     //User 가 가진 OrgMember 모두 추출하는 메서드
     List<OrgMember> findOrgMemberByUser(User user);
+
+    //특정 Organization 에 속한 OrgMember 모두 추출하는 메서드
+    @Query("select om from OrgMember om where om.organization = :organization")
+    List<OrgMember> findOrgMemberByOrg(@Param(value = "organization") Organization organization);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
@@ -69,7 +69,7 @@ public class OrgController implements OrgControllerDocs {
     }
 
     @DeleteMapping("/{orgId}")
-    public ResponseEntity<Void> removeOrganization(
+    public ResponseEntity<DataResponse<String>> removeOrganization(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
             @RequestParam(defaultValue = "false") boolean isHard
@@ -81,6 +81,8 @@ public class OrgController implements OrgControllerDocs {
             orgService.removeOrganizationSoft(userId, orgId); //Soft Delete
         }
 
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok(
+                DataResponse.from("조직이 정상적으로 삭제 처리 되었습니다.")
+        );
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
@@ -55,14 +55,19 @@ public class OrgController implements OrgControllerDocs {
         );
     }
 
-    @Hidden
     @DeleteMapping("/{orgId}")
     public ResponseEntity<Void> removeOrganization(
             @AuthenticationPrincipal(expression = "userId") Long userId,
-            @PathVariable Long orgId
+            @PathVariable Long orgId,
+            @RequestParam(defaultValue = "false") boolean isHard
     )
     {
-        orgService.removeOrganization(userId, orgId);
+        if (isHard) { //true 로 하여 Hard Delete 시
+            orgService.removeOrganization(userId, orgId); //Hard Delete
+        } else { //기본값(false) 이면
+            orgService.removeOrganizationSoft(userId, orgId); //Soft Delete
+        }
+
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
@@ -55,6 +55,19 @@ public class OrgController implements OrgControllerDocs {
         );
     }
 
+    @PatchMapping("/{orgId}/restore")
+    public ResponseEntity<DataResponse<OrgResponse.Delete>> restoreOrganization(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId
+    )
+    {
+        OrgResponse.Delete response = orgService.restoreOrganization(userId, orgId);
+
+        return ResponseEntity.ok(
+                DataResponse.from(response)
+        );
+    }
+
     @DeleteMapping("/{orgId}")
     public ResponseEntity<Void> removeOrganization(
             @AuthenticationPrincipal(expression = "userId") Long userId,

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
@@ -60,11 +60,11 @@ public interface OrgControllerDocs {
                     "param 인 isHard = true 이면 Hard Delete (DB에서 삭제), isHard = false 이면 Soft Delete (status 만 DELETED 로 변경)"
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "성공(반환X)"),
+            @ApiResponse(responseCode = "200", description = "성공"),
             @ApiResponse(responseCode = "403_1", description = "허가되지 않은 회원의 요청(조직 생성 회원 X)"),
             @ApiResponse(responseCode = "404_1", description = "해당 id 조직 존재 X")
     })
-    public ResponseEntity<Void> removeOrganization(
+    public ResponseEntity<DataResponse<String>> removeOrganization(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
             @RequestParam(defaultValue = "false") boolean isHard

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
@@ -9,10 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 public interface OrgControllerDocs {
     @Operation(
@@ -39,6 +36,22 @@ public interface OrgControllerDocs {
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
             @RequestBody @Valid OrgRequest.Update request
+    );
+
+    @Operation(
+            summary = "조직 복구 API",
+            description = "Soft Delete 로 임시삭제한 조직을 다시 활성화 합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "403_1", description = "허가되지 않은 회원의 요청(조직 생성 회원 X)"),
+            @ApiResponse(responseCode = "404_1", description = "해당 id 조직 존재 X"),
+            @ApiResponse(responseCode = "409_1", description = "이미 활성화 상태인 조직")
+    })
+    @PatchMapping("/{orgId}/restore")
+    public ResponseEntity<DataResponse<OrgResponse.Delete>> restoreOrganization(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId
     );
 
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
@@ -48,7 +48,6 @@ public interface OrgControllerDocs {
             @ApiResponse(responseCode = "404_1", description = "해당 id 조직 존재 X"),
             @ApiResponse(responseCode = "409_1", description = "이미 활성화 상태인 조직")
     })
-    @PatchMapping("/{orgId}/restore")
     public ResponseEntity<DataResponse<OrgResponse.Delete>> restoreOrganization(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId
@@ -65,7 +64,6 @@ public interface OrgControllerDocs {
             @ApiResponse(responseCode = "403_1", description = "허가되지 않은 회원의 요청(조직 생성 회원 X)"),
             @ApiResponse(responseCode = "404_1", description = "해당 id 조직 존재 X")
     })
-    @DeleteMapping("/{orgId}")
     public ResponseEntity<Void> removeOrganization(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
@@ -9,8 +9,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 public interface OrgControllerDocs {
     @Operation(
@@ -37,5 +39,23 @@ public interface OrgControllerDocs {
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
             @RequestBody @Valid OrgRequest.Update request
+    );
+
+
+    @Operation(
+            summary = "조직 삭제 API",
+            description = "조직 Id 를 PathVariable 로 받아 해당 조직 삭제(해당 조직을 생성한 회원만 삭제 가능) \n\n" +
+                    "param 인 isHard = true 이면 Hard Delete (DB에서 삭제), isHard = false 이면 Soft Delete (status 만 DELETED 로 변경)"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "성공(반환X)"),
+            @ApiResponse(responseCode = "403_1", description = "허가되지 않은 회원의 요청(조직 생성 회원 X)"),
+            @ApiResponse(responseCode = "404_1", description = "해당 id 조직 존재 X")
+    })
+    @DeleteMapping("/{orgId}")
+    public ResponseEntity<Void> removeOrganization(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId,
+            @RequestParam(defaultValue = "false") boolean isHard
     );
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #29 

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

조직 삭제 API (Soft & Hard) 추가, Soft Delete 복구 API (PATCH) 추가

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- 조직 삭제 API 추가 (하나의 API 에서 내부적으로 Soft / Hard Delete 구분)
- 삭제 로직 내부에 요청한 회원이 ADMIN 인지 확인하는 로직 포함
- Soft Delete 복구 API 추가

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.

1. DB 에서 org_id = 4 인 조직 Soft & Hard Delete 진행

1-1. 해당 조직의 생성자인 id = 2 인 사용자로 로그인, 토큰 획득
<img width="1901" height="1253" alt="image" src="https://github.com/user-attachments/assets/ff3c10e6-c7b1-4c2f-9122-81da0ce29738" />

1-2 . 해당 토큰으로 조직 Soft delete 요청, DB 정상 반영(status => DELETED)
<img width="1913" height="1110" alt="image" src="https://github.com/user-attachments/assets/335ac0c2-0943-438d-a21d-97f3e1ef07be" />

<img width="1322" height="783" alt="image" src="https://github.com/user-attachments/assets/9350fa63-ee21-436b-a856-7d898de9edf4" />


1-3. Soft Delete 조직 복구, DB 정상 반영(status => ACTIVE)
<img width="1918" height="1250" alt="image" src="https://github.com/user-attachments/assets/68f3f2fe-cbab-45c5-81a1-717201060228" />

<img width="1323" height="785" alt="image" src="https://github.com/user-attachments/assets/d1aa91a7-8d98-4433-89c2-a3e484f26835" />

1-4. org_id = 4 조직에 대해 Hard Delete 요청, DB 정상 반영
<img width="1906" height="1215" alt="image" src="https://github.com/user-attachments/assets/8671c3cf-a332-4eeb-993c-487ff8517943" />

<img width="1336" height="788" alt="image" src="https://github.com/user-attachments/assets/415e23e7-5a68-49bc-8174-12819db7e9fc" />

===예외 처리===
1. id = 1 인 회원이 id = 2 인 회원이 만든 조직에 삭제 요청 보낼 시 오류 처리 (403 Forbidden)
<img width="1332" height="794" alt="image" src="https://github.com/user-attachments/assets/8e0d811e-2ad8-4fd3-bca9-aabb14bfa1d0" />

<img width="1910" height="1187" alt="image" src="https://github.com/user-attachments/assets/9b355d32-7544-40c7-b476-0be6251ba0ab" />

2. 잘못된 org_id 로 접근 시 오류 (404 Not Found)
<img width="1923" height="1173" alt="image" src="https://github.com/user-attachments/assets/a5911b7e-b733-43ef-b13c-07950a3758af" />

3. 이미 상태가 ACTIVE 인 조직에 대해 Soft Delete 복구 API 요청 시 오류 (409 Conflict)
<img width="1914" height="1213" alt="image" src="https://github.com/user-attachments/assets/b2308eca-41a2-44f0-b3a5-5090d8559122" />


## ✅ 체크리스트
- [✅] 브랜치 전략(GitHub Flow)을 준수했나요?
- [✅] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [✅] 테스트 통과 확인
- [✅] 서버 실행 확인
- [✅] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- 피그마에서는 조직 삭제를 기본적으로 Hard Delete 로 다루는것으로 보이긴 하는데, 저희 Organization 에서 status 필드가 있어서 Soft Delete 와 Hard Delete 를 @RequestParam 으로 구분해서 접근하도록 해봤는데 어떤가요?
- 이전에 조직 정보 수정 API 에서 "조직 생성자가 아닌 회원이 수정 API 접근 시 오류" 처리하던 코드를 수정 뿐만이 아닌 삭제에서도 사용할 수 있도록 수정해봤는데 괜찮을까요?

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 조직 소프트 삭제(비활성화), 복구 기능 추가
  * 삭제 시 선택 가능한 완전 삭제(하드 삭제) 옵션 추가
  * 삭제/복구 결과를 반환하는 응답 페이로드 추가 (복구 시 식별자 및 메시지 포함)

* **버그 수정**
  * 조직 권한 검사 메시지 및 권한 검증 동작 개선
  * 이미 활성화된 조직에 대한 충돌 처리 추가

* **문서**
  * API 문서에 복구 및 삭제(하드/소프트) 엔드포인트와 응답 내용 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->