### PR TITLE
Fix/#34 reissue API 500 오류 응답 수정

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/exception/code/AuthErrorCode.java
@@ -11,6 +11,7 @@ public enum AuthErrorCode implements BaseErrorCode {
     //토큰 관련
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_401_2", "토큰이 만료되었습니다."),
     INVALID_TOKEN_FORMAT(HttpStatus.UNAUTHORIZED, "AUTH_401_3", "잘못된 토큰 형식입니다."),
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_401_4", "쿠키에 refreshToken 값이 존재하지 않습니다."),
 
     // 로그인 실패 (비밀번호 틀림 or 계정 없음)
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_401_1", "아이디 또는 비밀번호가 일치하지 않습니다."),

--- a/src/main/java/com/whereyouad/WhereYouAd/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/exception/GlobalExceptionHandler.java
@@ -2,12 +2,14 @@ package com.whereyouad.WhereYouAd.global.exception;
 
 import com.whereyouad.WhereYouAd.domains.user.exception.code.AuthErrorCode;
 import com.whereyouad.WhereYouAd.global.response.ErrorResponse;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -64,6 +66,37 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
+                .body(errorResponse);
+    }
+
+    //reissue API 호출 시 쿠키 값이 아예 없는 경우(삭제된 경우) 예외처리
+    @ExceptionHandler(MissingRequestCookieException.class)
+    public ResponseEntity<ErrorResponse> handleMissingCookieException(MissingRequestCookieException e, HttpServletRequest request) {
+        log.error("reissue 요청에 쿠키 누락: {}", e.getMessage());
+
+        ErrorResponse errorResponse = ErrorResponse.of(
+                AuthErrorCode.TOKEN_NOT_FOUND,
+                request
+        );
+
+        return ResponseEntity
+                .status(AuthErrorCode.TOKEN_NOT_FOUND.getHttpStatus())
+                .body(errorResponse);
+
+    }
+
+    //reissue API 호출 시 만료된 refreshToken 값으로 접근 시도한 경우 예외 처리
+    @ExceptionHandler(ExpiredJwtException.class)
+    public ResponseEntity<ErrorResponse> handleExpiredJwtException(ExpiredJwtException e, HttpServletRequest request) {
+        log.warn("만료된 JWT refreshToken 입니다: {}", e.getMessage());
+
+        ErrorResponse errorResponse = ErrorResponse.of(
+                AuthErrorCode.TOKEN_EXPIRED, // 만료 전용 에러 코드 사용
+                request
+        );
+
+        return ResponseEntity
+                .status(AuthErrorCode.TOKEN_EXPIRED.getHttpStatus())
                 .body(errorResponse);
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
- Close #34 

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

reissue API 관련 오류 수정

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- reissue API 에 쿠키 값 누락된 상태로 요청 시 500 오류 현상 수정, 
- reissue API 에 만료된 refreshToken 값으로 요청시 "잘못된 토큰 형식" -> "토큰 만료" 로 수정

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.

===기존 오류 응답===
1. 쿠키 값 없이 reissue 요청 시 500 오류
<img width="835" height="682" alt="기존 쿠키 존재X" src="https://github.com/user-attachments/assets/ba8f5f41-a7db-4251-9ad1-c7fa2f3b4746" />

<img width="2107" height="1060" alt="기존 500오류" src="https://github.com/user-attachments/assets/d85df58d-db9d-4cb0-aad1-b285c623e891" />

2. 만료된 refreshToken 값으로 reissue 요청 시 오류 응답
<img width="2133" height="1053" alt="기존 refreshToken 만료시" src="https://github.com/user-attachments/assets/6920972e-ec74-46db-92e0-b0468047b0cc" />

===수정 이후 응답===
1. 쿠키 값 누락 시
<img width="2134" height="998" alt="수정 이후 no cookie" src="https://github.com/user-attachments/assets/f3362775-8d89-4bb7-a91e-82db3678b65d" />

2. refreshToken 만료된 상태에서 요청 시
<img width="2130" height="1056" alt="수정 이후 만료" src="https://github.com/user-attachments/assets/dba42f54-1a06-4080-91b6-e3aa4bca1ead" />


## ✅ 체크리스트
- [✅] 브랜치 전략(GitHub Flow)을 준수했나요?
- [✅] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [✅] 테스트 통과 확인
- [✅] 서버 실행 확인
- [✅] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- 디버깅 과정에서 refreshToken 이 만료된 상태로 요청 시 응답값도 자세하게 나타내는 게 나을 것 같아 추가 수정 진행했습니다!

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 만료된 토큰 및 누락된 새로고침 토큰에 대한 예외 처리 개선
  * 인증 오류 발생 시 명확한 오류 응답 제공
  * 토큰 관련 요청 실패에 대한 적절한 HTTP 상태 코드 반환

<!-- end of auto-generated comment: release notes by coderabbit.ai -->