### PR TITLE
Feat/#25 맴버 조회 API 구현

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/response/OrgResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/response/OrgResponse.java
@@ -29,6 +29,11 @@ public class OrgResponse {
             List<OrgMemberDTO> members
     ) {}
 
+    // 조직 멤버 전체 수 조회 응답
+    public record OrgMemberCountDTO(
+            int totalCount
+    ) {}
+
     public record OrgMemberDTO(
             String name,
             String email,

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/response/OrgResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/response/OrgResponse.java
@@ -1,6 +1,7 @@
 package com.whereyouad.WhereYouAd.domains.organization.application.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class OrgResponse {
 
@@ -21,4 +22,17 @@ public class OrgResponse {
             LocalDateTime updatedAt
     ) {}
 
+    // 조직 멤버 조회 응답 (무한 스크롤 - Slice 기반)
+    public record OrgMemberSliceDTO(
+            boolean hasNext,
+            String nextCursor,
+            List<OrgMemberDTO> members
+    ) {}
+
+    public record OrgMemberDTO(
+            String name,
+            String email,
+            String profileImageUrl,
+            String role
+    ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/mapper/OrgConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/mapper/OrgConverter.java
@@ -3,7 +3,10 @@ package com.whereyouad.WhereYouAd.domains.organization.application.mapper;
 import com.whereyouad.WhereYouAd.domains.organization.application.dto.request.OrgRequest;
 import com.whereyouad.WhereYouAd.domains.organization.application.dto.response.OrgResponse;
 import com.whereyouad.WhereYouAd.domains.organization.domain.constant.OrgStatus;
+import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMember;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
+
+import java.util.List;
 
 public class OrgConverter {
 
@@ -29,5 +32,27 @@ public class OrgConverter {
                 .ownerUserId(userId)
                 .status(OrgStatus.ACTIVE)
                 .build();
+    }
+
+    // 조직 멤버 Slice DTO 변환 (무한 스크롤)
+    public static OrgResponse.OrgMemberSliceDTO toOrgMemberSliceDTO(
+            boolean hasNext,
+            String nextCursor,
+            List<OrgMember> orgMembers
+    ) {
+        List<OrgResponse.OrgMemberDTO> memberDTOs = orgMembers.stream()
+                .map(m -> new OrgResponse.OrgMemberDTO(
+                        m.getUser().getName(),
+                        m.getUser().getEmail(),
+                        m.getUser().getProfileImageUrl(),
+                        m.getRole().name()
+                ))
+                .toList();
+
+        return new OrgResponse.OrgMemberSliceDTO(
+                hasNext,
+                nextCursor,
+                memberDTOs
+        );
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgQueryService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgQueryService.java
@@ -1,0 +1,12 @@
+package com.whereyouad.WhereYouAd.domains.organization.domain.service;
+
+import com.whereyouad.WhereYouAd.domains.organization.application.dto.response.OrgResponse;
+
+public interface OrgQueryService {
+
+    // 조직에 속한 맴버 조회 (무한 스크롤 - Slice 기반)
+    OrgResponse.OrgMemberSliceDTO getOrgMembers(Long orgId, String cursor, Integer size);
+
+    // 조직의 전체 멤버 수 조회
+    OrgResponse.OrgMemberCountDTO getOrgMembersCount(Long orgId);
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgQueryServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgQueryServiceImpl.java
@@ -1,0 +1,71 @@
+package com.whereyouad.WhereYouAd.domains.organization.domain.service;
+
+import com.whereyouad.WhereYouAd.domains.organization.application.dto.response.OrgResponse;
+import com.whereyouad.WhereYouAd.domains.organization.application.mapper.OrgConverter;
+import com.whereyouad.WhereYouAd.domains.organization.exception.code.OrgErrorCode;
+import com.whereyouad.WhereYouAd.domains.organization.exception.handler.OrgHandler;
+import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMember;
+import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
+import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
+import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgRepository;
+import com.whereyouad.WhereYouAd.global.utils.cursor.CursorUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OrgQueryServiceImpl implements OrgQueryService{
+
+    private final OrgRepository orgRepository;
+    private final OrgMemberRepository orgMemberRepository;
+
+    // 조직 멤버 조회 (커서 기반 무한 스크롤 - Slice + CursorUtil)
+    @Override
+    public OrgResponse.OrgMemberSliceDTO getOrgMembers(Long orgId, String encodedCursor, Integer size) {
+
+        // 조직 존재 여부 확인
+        Organization organization = orgRepository.findById(orgId)
+                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
+
+        // 페이지 크기 기본값 설정 (기본 20개)
+        int pageSize = (size != null && size > 0) ? size : 20;
+
+        // 커서 디코딩 (null이면 첫 페이지)
+        Long cursor = null;
+        if (encodedCursor != null && !encodedCursor.isBlank()) {
+            cursor = CursorUtil.decodeToId(encodedCursor);
+        }
+
+        // Slice 조회 (자동으로 hasNext 계산)
+        Slice<OrgMember> slice = orgMemberRepository.findByOrganizationIdWithCursor(
+                orgId,
+                cursor,
+                PageRequest.of(0, pageSize));
+
+        // nextCursor 인코딩 (다음 페이지가 있으면)
+        String nextCursor = null;
+        if (slice.hasNext() && !slice.getContent().isEmpty()) {
+            Long lastId = slice.getContent().get(slice.getContent().size() - 1).getId();
+            nextCursor = CursorUtil.encode(lastId);
+        }
+
+        return OrgConverter.toOrgMemberSliceDTO(slice.hasNext(), nextCursor, slice.getContent());
+    }
+
+    // 조직 전체 멤버 수 조회
+    @Override
+    public OrgResponse.OrgMemberCountDTO getOrgMembersCount(Long orgId) {
+        // 조직 존재 여부 확인
+        Organization organization = orgRepository.findById(orgId)
+                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
+
+        // 전체 멤버 수 조회
+        int totalCount = orgMemberRepository.countByOrganizationId(orgId);
+
+        return new OrgResponse.OrgMemberCountDTO(totalCount);
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgQueryServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgQueryServiceImpl.java
@@ -8,6 +8,7 @@ import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMemb
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgRepository;
+import com.whereyouad.WhereYouAd.domains.user.domain.constant.UserStatus;
 import com.whereyouad.WhereYouAd.global.utils.cursor.CursorUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -43,6 +44,7 @@ public class OrgQueryServiceImpl implements OrgQueryService{
         // Slice 조회 (자동으로 hasNext 계산)
         Slice<OrgMember> slice = orgMemberRepository.findByOrganizationIdWithCursor(
                 orgId,
+                UserStatus.ACTIVE,
                 cursor,
                 PageRequest.of(0, pageSize));
 
@@ -64,7 +66,7 @@ public class OrgQueryServiceImpl implements OrgQueryService{
                 .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
 
         // 전체 멤버 수 조회
-        int totalCount = orgMemberRepository.countByOrganizationId(orgId);
+        int totalCount = orgMemberRepository.countByOrganizationIdAndUserStatus(orgId, UserStatus.ACTIVE);
 
         return new OrgResponse.OrgMemberCountDTO(totalCount);
     }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
@@ -2,6 +2,7 @@ package com.whereyouad.WhereYouAd.domains.organization.persistence.repository;
 
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMember;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
+import com.whereyouad.WhereYouAd.domains.user.domain.constant.UserStatus;
 import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -22,16 +23,25 @@ public interface OrgMemberRepository extends JpaRepository<OrgMember, Long> {
 
     // 조직 멤버 조회 (무한 스크롤 - Slice 반환)
     @Query("SELECT m FROM OrgMember m " +
-            "JOIN FETCH m.user " +
+            "JOIN FETCH m.user u " +
             "WHERE m.organization.id = :orgId " +
+            "AND u.status = :status " +
             "AND (:cursor IS NULL OR m.id > :cursor) " +
             "ORDER BY m.id ASC")
     Slice<OrgMember> findByOrganizationIdWithCursor(
             @Param("orgId") Long orgId,
+            @Param("status") UserStatus status,
             @Param("cursor") Long cursor,
             Pageable pageable
     );
 
     // 조직의 전체 멤버 수 조회
-    int countByOrganizationId(Long orgId);
+    @Query("SELECT COUNT(m) FROM OrgMember m " +
+            "JOIN m.user u " +
+            "WHERE m.organization.id = :orgId " +
+            "AND u.status = :status")
+    int countByOrganizationIdAndUserStatus(
+            @Param("orgId") Long orgId,
+            @Param("status") UserStatus status
+    );
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
@@ -27,4 +27,6 @@ public interface OrgMemberRepository extends JpaRepository<OrgMember, Long> {
             Pageable pageable
     );
 
+    // 조직의 전체 멤버 수 조회
+    int countByOrganizationId(Long orgId);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
@@ -2,7 +2,11 @@ package com.whereyouad.WhereYouAd.domains.organization.persistence.repository;
 
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMember;
 import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -10,4 +14,17 @@ public interface OrgMemberRepository extends JpaRepository<OrgMember, Long> {
 
     //User 가 가진 OrgMember 모두 추출하는 메서드
     List<OrgMember> findOrgMemberByUser(User user);
+
+    // 조직 멤버 조회 (무한 스크롤 - Slice 반환)
+    @Query("SELECT m FROM OrgMember m " +
+            "JOIN FETCH m.user " +
+            "WHERE m.organization.id = :orgId " +
+            "AND (:cursor IS NULL OR m.id > :cursor) " +
+            "ORDER BY m.id ASC")
+    Slice<OrgMember> findByOrganizationIdWithCursor(
+            @Param("orgId") Long orgId,
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
+
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
@@ -2,6 +2,7 @@ package com.whereyouad.WhereYouAd.domains.organization.presentation;
 
 import com.whereyouad.WhereYouAd.domains.organization.application.dto.request.OrgRequest;
 import com.whereyouad.WhereYouAd.domains.organization.application.dto.response.OrgResponse;
+import com.whereyouad.WhereYouAd.domains.organization.domain.service.OrgQueryService;
 import com.whereyouad.WhereYouAd.domains.organization.domain.service.OrgService;
 import com.whereyouad.WhereYouAd.domains.organization.presentation.docs.OrgControllerDocs;
 import com.whereyouad.WhereYouAd.global.response.DataResponse;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class OrgController implements OrgControllerDocs {
 
     private final OrgService orgService;
+    private final OrgQueryService orgQueryService;
 
     @PostMapping("/create")
     public ResponseEntity<DataResponse<OrgResponse.Create>> createOrganization(
@@ -65,4 +67,15 @@ public class OrgController implements OrgControllerDocs {
         orgService.removeOrganization(userId, orgId);
         return ResponseEntity.noContent().build();
     }
+
+    @GetMapping("/members/{orgId}")
+    public ResponseEntity<DataResponse<OrgResponse.OrgMemberSliceDTO>> getOrgMembers(
+            @PathVariable Long orgId,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(required = false, defaultValue = "10") Integer size
+    ) {
+        OrgResponse.OrgMemberSliceDTO response = orgQueryService.getOrgMembers(orgId, cursor, size);
+        return ResponseEntity.ok(DataResponse.from(response));
+    }
+
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
@@ -78,4 +78,11 @@ public class OrgController implements OrgControllerDocs {
         return ResponseEntity.ok(DataResponse.from(response));
     }
 
+    @GetMapping("/members/{orgId}/count")
+    public ResponseEntity<DataResponse<OrgResponse.OrgMemberCountDTO>> getOrgMembersCount(
+            @PathVariable Long orgId
+    ) {
+        OrgResponse.OrgMemberCountDTO response = orgQueryService.getOrgMembersCount(orgId);
+        return ResponseEntity.ok(DataResponse.from(response));
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 public interface OrgControllerDocs {
     @Operation(
@@ -37,5 +38,32 @@ public interface OrgControllerDocs {
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
             @RequestBody @Valid OrgRequest.Update request
+    );
+
+    @Operation(
+            summary = "조직 멤버 조회 API (무한 스크롤 - Slice 기반)",
+            description = "조직에 속한 멤버를 조회합니다. cursor와 size 파라미터를 통해 무한 스크롤을 지원합니다. cursor는 Base64로 인코딩된 문자열입니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공 (hasNext: 다음 페이지 존재 여부, nextCursor: 다음 페이지 커서, members: 멤버 리스트)"),
+            @ApiResponse(responseCode = "404_1", description = "해당 id 조직 존재 X"),
+            @ApiResponse(responseCode = "400", description = "잘못된 커서 형식")
+    })
+    ResponseEntity<DataResponse<OrgResponse.OrgMemberSliceDTO>> getOrgMembers(
+            @PathVariable Long orgId,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(required = false) Integer size
+    );
+
+    @Operation(
+            summary = "조직 전체 멤버 수 조회 API",
+            description = "조직의 전체 멤버 수를 조회합니다. 무한 스크롤 초기 로딩 시 1회만 호출하는 것을 권장합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공 (totalCount: 전체 멤버 수)"),
+            @ApiResponse(responseCode = "404_1", description = "해당 id 조직 존재 X")
+    })
+    ResponseEntity<DataResponse<OrgResponse.OrgMemberCountDTO>> getOrgMembersCount(
+            @PathVariable Long orgId
     );
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/global/utils/cursor/CursorUtil.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/utils/cursor/CursorUtil.java
@@ -1,0 +1,96 @@
+package com.whereyouad.WhereYouAd.global.utils.cursor;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.whereyouad.WhereYouAd.global.utils.cursor.dto.CursorData;
+import com.whereyouad.WhereYouAd.global.utils.cursor.exception.CursorException;
+import com.whereyouad.WhereYouAd.global.utils.cursor.exception.code.CursorErrorCode;
+import lombok.extern.slf4j.Slf4j;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/*
+CursorData 객체 생성
+JSON 직렬화 (예: {"id":12345})
+Base64 인코딩 (예: eyJpZCI6MTIzNDV9)
+
+디코딩은 위 과정의 역순으로 진행
+ */
+@Slf4j
+public class CursorUtil {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    // 유틸리티 클래스이므로 인스턴스화 방지
+    private CursorUtil() {
+        throw new UnsupportedOperationException("Utility class cannot be instantiated");
+    }
+
+
+    // ID를 Base64 인코딩된 커서 문자열로 변환
+    public static String encode(Long id) {
+
+        // 커서 아이디가 없거나 양수가 아닌 경우
+        if (id == null || id <= 0) {
+            throw new CursorException(CursorErrorCode.ID_NOT_POSITIVE_NUMBER);
+        }
+
+        try {
+            CursorData cursorData = new CursorData(id);
+
+            // 1. JSON 직렬화
+            String json = objectMapper.writeValueAsString(cursorData);
+
+            // 2. Base64 인코딩 (URL-safe, padding 제거)
+            String encoded = Base64.getUrlEncoder()
+                    .withoutPadding()
+                    .encodeToString(json.getBytes(StandardCharsets.UTF_8));
+
+            return encoded;
+
+        } catch (JsonProcessingException e) {
+            // 커서 인코딩에 실패한 경우
+            log.error("Failed to encode cursor for ID: {}", id, e);
+            throw new CursorException(CursorErrorCode.ENCODE_ERROR);
+        }
+    }
+
+
+    // 인코딩된 커서 문자열을 CursorData 객체로 디코딩
+    public static CursorData decode(String encodedCursor) {
+
+        // 커서 값이 없는 경우
+        if (encodedCursor == null || encodedCursor.isBlank()) {
+            throw new CursorException(CursorErrorCode.EMPTY_CURSOR);
+        }
+
+        try {
+            // 1. Base64 디코딩
+            byte[] decodedBytes = Base64.getUrlDecoder()
+                    .decode(encodedCursor.getBytes(StandardCharsets.UTF_8));
+            String json = new String(decodedBytes, StandardCharsets.UTF_8);
+
+            // 2. JSON 역직렬화
+            CursorData cursorData = objectMapper.readValue(json, CursorData.class);
+
+            return cursorData;
+
+        } catch (IllegalArgumentException | JsonProcessingException e) {
+            // Base64 형식이 아니거나 JSON 파싱에 실패한 경우
+            log.error("Invalid cursor format: {}", encodedCursor, e);
+            throw new CursorException(CursorErrorCode.INVALID_CURSOR_FORMAT);
+
+        } catch (Exception e) {
+            // 그 외 디코딩에 실패한 경우
+            log.error("Unexpected error while decoding cursor: {}", encodedCursor, e);
+            throw new CursorException(CursorErrorCode.DECODE_ERROR);
+        }
+    }
+
+
+    // 인코딩된 커서 문자열에서 ID 값을 반환
+    public static Long decodeToId(String encodedCursor) {
+        return decode(encodedCursor).id();
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/global/utils/cursor/dto/CursorData.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/utils/cursor/dto/CursorData.java
@@ -1,0 +1,13 @@
+package com.whereyouad.WhereYouAd.global.utils.cursor.dto;
+
+import com.whereyouad.WhereYouAd.global.utils.cursor.exception.CursorException;
+import com.whereyouad.WhereYouAd.global.utils.cursor.exception.code.CursorErrorCode;
+
+public record CursorData(
+        Long id) {
+    public CursorData {
+        if (id == null || id <= 0) {
+            throw new CursorException(CursorErrorCode.ID_NOT_POSITIVE_NUMBER);
+        }
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/global/utils/cursor/exception/CursorException.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/utils/cursor/exception/CursorException.java
@@ -1,0 +1,10 @@
+package com.whereyouad.WhereYouAd.global.utils.cursor.exception;
+
+import com.whereyouad.WhereYouAd.global.exception.AppException;
+import com.whereyouad.WhereYouAd.global.exception.BaseErrorCode;
+
+public class CursorException extends AppException {
+    public CursorException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/global/utils/cursor/exception/code/CursorErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/utils/cursor/exception/code/CursorErrorCode.java
@@ -1,0 +1,25 @@
+package com.whereyouad.WhereYouAd.global.utils.cursor.exception.code;
+
+import com.whereyouad.WhereYouAd.global.exception.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CursorErrorCode implements BaseErrorCode {
+
+    // 400
+    ID_NOT_POSITIVE_NUMBER(HttpStatus.BAD_REQUEST, "CURSOR_400_1", "ID값은 양수입니다."),
+    EMPTY_CURSOR(HttpStatus.BAD_REQUEST, "CURSOR_400_2", "커서 값이 비어있습니다."),
+    INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST, "CURSOR_400_3", "잘못된 커서 형식입니다."),
+
+    // 500
+    ENCODE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CURSOR_500_1", "커서 인코딩 중 오류가 발생했습니다."),
+    DECODE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CURSOR_500_2", "커서 디코딩 중 오류가 발생했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Close #25 

## 🚀 개요
> 조직에 속한 맴버 조회하기


## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- 무한 스크롤 방식을 위한 커서 유틸 클래스 제작
- 맴버 조회 API 구현, 맴버 총 인원수 API 제작
- status가 ACTIVE인 회원만 조회하도록 수정

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.
- 전체 API 사진
<img width="1618" height="133" alt="image" src="https://github.com/user-attachments/assets/41067867-99ac-41e0-8be1-1ce6403c1a6b" />

- 맴버 조회 API
<img width="1612" height="666" alt="image" src="https://github.com/user-attachments/assets/e65832b1-19cc-44ac-8d02-d78d5d172dbf" />

<img width="1616" height="586" alt="image" src="https://github.com/user-attachments/assets/e79ca8b0-f1d1-4151-8f2a-e35b8910cdf9" />

- 조직 인원 수 전체 조회
<img width="1624" height="990" alt="image" src="https://github.com/user-attachments/assets/5904659a-ac38-4aff-b451-739a12038922" />

- 조직에 속해있지만 상태가 DELETED인 user_id가 10인 맴버는 조회X
<img width="876" height="267" alt="image" src="https://github.com/user-attachments/assets/0e8f4f02-fa4c-4ee9-a95f-47404ef1bfd4" />


## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- 무한 스크롤 방식에 맴버 전체 인원 수가 들어가면 성능에 좋지 않을 것 같아서 메서드를 분리해서 작성했습니다.
- Global에 CursorUtil 클래스 작성했습니다.
- 조회하는 로직은 따로 QueryService로 분리했는데 번거롭다 싶으면 리팩터링 하겠습니다!

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 조직 구성원 목록 조회 API 추가: 무한 스크롤 방식의 커서 기반 페이지네이션 지원
  * 조직 구성원 총 개수 조회 API 추가
  * 구성원 정보에 이름, 이메일, 프로필 이미지, 역할 정보 포함

<!-- end of auto-generated comment: release notes by coderabbit.ai -->