### PR TITLE
Feat/#27 조직 멤버 초대 및 수락 구현

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/request/OrgRequest.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/request/OrgRequest.java
@@ -22,4 +22,8 @@ public class OrgRequest {
             String logoUrl
     ) {}
 
+    public record Invite(
+            @NotBlank(message = "이메일은 필수입니다.")
+            String email
+    ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/request/OrgRequest.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/request/OrgRequest.java
@@ -1,5 +1,6 @@
 package com.whereyouad.WhereYouAd.domains.organization.application.dto.request;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public class OrgRequest {
@@ -24,6 +25,7 @@ public class OrgRequest {
 
     public record Invite(
             @NotBlank(message = "이메일은 필수입니다.")
+            @Email(message = "이메일 형식이 올바르지 않습니다.")
             String email
     ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/response/OrgResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/response/OrgResponse.java
@@ -27,4 +27,9 @@ public class OrgResponse {
             String message
     ) {}
 
+    public record OrgInvitationResponse(
+            Long orgId,
+            String message,
+            String email
+    ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/mapper/OrgMemberConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/mapper/OrgMemberConverter.java
@@ -5,14 +5,25 @@ import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMemb
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
 import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
 
+import java.time.LocalDateTime;
+
 public class OrgMemberConverter {
 
     public static OrgMember toOrgMemberADMIN(User user, Organization organization) {
         return OrgMember.builder()
                 .user(user)
                 .organization(organization)
-                .joinedAt(organization.getCreatedAt()) //생성한 사람의 조직 합류 시간은 조직 생성 시간과 동일
-                .role(OrgRole.ADMIN) //생성한 사람은 ADMIN
+                .joinedAt(organization.getCreatedAt()) // 생성한 사람의 조직 합류 시간은 조직 생성 시간과 동일
+                .role(OrgRole.ADMIN) // 생성한 사람은 ADMIN
+                .build();
+    }
+
+    public static OrgMember toOrgMemberMEMBER(User user, Organization organization) {
+        return OrgMember.builder()
+                .user(user)
+                .organization(organization)
+                .joinedAt(LocalDateTime.now()) // 조직 초대 완료 시점
+                .role(OrgRole.MEMBER) // 초대된 사람은 MEMBER (default)
                 .build();
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
@@ -19,5 +19,5 @@ public interface OrgService {
 
     OrgResponse.OrgInvitationResponse sendOrgInvitation(Long orgId, String email);
 
-    OrgResponse.OrgInvitationResponse acceptOrgInvitation(String token);
+    OrgResponse.OrgInvitationResponse acceptOrgInvitation(Long userId, String token);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
@@ -18,4 +18,6 @@ public interface OrgService {
     OrgResponse.Delete restoreOrganization(Long userId, Long orgId);
 
     OrgResponse.OrgInvitationResponse sendOrgInvitation(Long orgId, String email);
+
+    OrgResponse.OrgInvitationResponse acceptOrgInvitation(String token);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
@@ -17,7 +17,7 @@ public interface OrgService {
 
     OrgResponse.Delete restoreOrganization(Long userId, Long orgId);
 
-    OrgResponse.OrgInvitationResponse sendOrgInvitation(Long orgId, String email);
+    OrgResponse.OrgInvitationResponse sendOrgInvitation(Long userId, Long orgId, String email);
 
     OrgResponse.OrgInvitationResponse acceptOrgInvitation(Long userId, String token);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
@@ -16,4 +16,6 @@ public interface OrgService {
     void removeOrganizationSoft(Long userId, Long orgId);
 
     OrgResponse.Delete restoreOrganization(Long userId, Long orgId);
+
+    OrgResponse.OrgInvitationResponse sendOrgInvitation(Long orgId, String email);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -141,14 +141,24 @@ public class OrgServiceImpl implements OrgService {
 
     @Override
     // 조직 초대 이메일 보내기
-    public OrgResponse.OrgInvitationResponse sendOrgInvitation(Long orgId, String email) {
+    public OrgResponse.OrgInvitationResponse sendOrgInvitation(Long userId, Long orgId, String email) {
         Organization organization = orgRepository.findById(orgId)
                 .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
 
+        // 초대자와 조직 관계 검증 (초대자가 조직의 멤버인지 확인)
+        User sender = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(UserErrorCode.USER_NOT_FOUND));
+
+        if (!orgMemberRepository.existsByUserAndOrganization(sender, organization)) {
+            // 초대자가 조직 멤버가 아님 -> 권한 없음
+            throw new OrgHandler(OrgErrorCode.ORG_FORBIDDEN);
+        }
+
         // 초대 완료 여부 확인, 가입 여부에 상관 없이 이메일 발송
         userRepository.findUserByEmail(email).ifPresent(user -> {
-            if (orgMemberRepository.existsByUser(user))
-                new OrgHandler(OrgErrorCode.ORG_MEMBER_ALREADY_ACTIVE);
+            if (orgMemberRepository.existsByUserAndOrganization(user, organization)) {
+                throw new OrgHandler(OrgErrorCode.ORG_MEMBER_ALREADY_ACTIVE);
+            }
         });
 
         // Redis key = 임의의 UUID 토큰(조직 초대 이메일 내 링크를 구별)
@@ -191,7 +201,7 @@ public class OrgServiceImpl implements OrgService {
                 .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
 
         // 이미 멤버인지 중복 체크
-        if (orgMemberRepository.existsByUser(user))
+        if (orgMemberRepository.existsByUserAndOrganization(user, organization))
             throw new OrgHandler(OrgErrorCode.ORG_MEMBER_ALREADY_ACTIVE);
 
         orgMemberRepository.save(OrgMemberConverter.toOrgMemberADMIN(user, organization));

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -184,7 +184,7 @@ public class OrgServiceImpl implements OrgService {
 
         // 초대된 이메일과 현재 로그인한 사용자의 이메일이 일치하는지 확인
         if (!user.getEmail().equals(email)) {
-            throw new OrgHandler(OrgErrorCode.ORG_INVITATION_INVALID);
+            throw new OrgHandler(OrgErrorCode.ORG_INVITATION_FORBIDDEN_USER);
         }
 
         Organization organization = orgRepository.findById(Long.parseLong(valueForSplit[0]))

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -165,19 +165,33 @@ public class OrgServiceImpl implements OrgService {
     @Override
     // 조직 초대 수락 (이메일 내 링크 클릭 시)
     public OrgResponse.OrgInvitationResponse acceptOrgInvitation(String token) {
+        // 링크 만료 또는 유효하지 않을 시
+        if (token == null)
+            throw new OrgHandler(OrgErrorCode.ORG_INVITATION_INVALID);
+
         // Redis 내 UUID(key)에 대한 email(value) 비교
-        String email = redisUtil.getData(token).split(":")[1];
-        Organization organization = orgRepository.findById(Long.parseLong(redisUtil.getData(token).split(":")[0]))
+        String value = redisUtil.getData("INVITE:" + token);
+        if (value == null) {
+            throw new OrgHandler(OrgErrorCode.ORG_INVITATION_INVALID);
+        }
+
+        String email = value.split(":")[1];
+
+        Organization organization = orgRepository.findById(Long.parseLong(value.split(":")[0]))
                 .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
 
         User user = userRepository.findUserByEmail(email).orElseThrow(() ->
                 // 회원이 아닐 시
                 new UserHandler(UserErrorCode.USER_NOT_FOUND));
 
+        // 이미 멤버인지 중복 체크
+        if (orgMemberRepository.existsByUser(user))
+            throw new OrgHandler(OrgErrorCode.ORG_MEMBER_ALREADY_ACTIVE);
+
         orgMemberRepository.save(OrgMemberConverter.toOrgMemberADMIN(user, organization));
 
         // Redis 사용 토큰 삭제
-        redisUtil.deleteData(token);
+        redisUtil.deleteData("INVITE:" + token);
 
         return new OrgResponse.OrgInvitationResponse(organization.getId(), "조직 멤버 초대 이메일을 수락하였습니다.", email);
     }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -163,8 +163,17 @@ public class OrgServiceImpl implements OrgService{
     @Override
     // 조직 초대 수락 (이메일 내 링크 클릭 시)
     public OrgResponse.OrgInvitationResponse acceptOrgInvitation(String token) {
+        // Redis 내 UUID(key)에 대한 email(value) 비교
+        String email = redisUtil.getData(token).split(":")[1];
+        Organization organization = orgRepository.findById(Long.parseLong(redisUtil.getData(token).split(":")[0]))
+                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
 
-//        orgMemberRepository.save();
-        return null;
+        User user = userRepository.findUserByEmail(email).orElseThrow(() ->
+                // 회원이 아닐 시
+                new UserHandler(UserErrorCode.USER_NOT_FOUND));
+
+        orgMemberRepository.save(OrgMemberConverter.toOrgMemberADMIN(user, organization));
+
+        return new OrgResponse.OrgInvitationResponse(organization.getId(), "조직 멤버 초대 이메일을 수락하였습니다.", email);
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -16,11 +16,13 @@ import com.whereyouad.WhereYouAd.domains.user.exception.code.UserErrorCode;
 import com.whereyouad.WhereYouAd.domains.user.exception.handler.UserHandler;
 import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
 import com.whereyouad.WhereYouAd.domains.user.persistence.repository.UserRepository;
+import com.whereyouad.WhereYouAd.global.utils.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @Transactional
@@ -31,6 +33,7 @@ public class OrgServiceImpl implements OrgService{
     private final OrgMemberRepository orgMemberRepository;
     private final UserRepository userRepository;
 
+    private final RedisUtil redisUtil;
     private final EmailService emailService;
 
     //조직(워크스페이스) 생성 메서드
@@ -137,27 +140,31 @@ public class OrgServiceImpl implements OrgService{
     }
 
     @Override
+    // 조직 초대 이메일 보내기
     public OrgResponse.OrgInvitationResponse sendOrgInvitation(Long orgId, String email) {
         Organization organization = orgRepository.findById(orgId).orElseThrow(() ->
             new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
 
-        // 유저 회원 가입 유무
-        User user = userRepository.findUserByEmail(email).orElseThrow(() ->
-                new UserHandler(UserErrorCode.USER_NOT_FOUND));
-
-        // 회원 가입 미완료 (유저가 아닐 시)
-        if (user == null) {
-            emailService.sendEmailForOrgInvitation(email);
-        }
-
-        // 회원 가입 완료 (이미 존재하는 유저)
-        else {
-            // 이미 초대 완료
+        // 초대 완료 여부 확인, 가입 여부에 상관 없이 이메일 발송
+        userRepository.findUserByEmail(email).ifPresent( user -> {
             if (orgMemberRepository.existsByUser(user))
                 new OrgHandler(OrgErrorCode.ORG_MEMBER_ALREADY_ACTIVE);
+        });
 
-            else emailService.sendEmailForOrgInvitation(email);
-        }
+        // Redis key = 임의의 UUID 토큰(조직 초대 이메일 내 링크를 구별)
+        String token = UUID.randomUUID().toString();
+        // Redis value = 조직 아이디와 이메일의 조합
+        String value = orgId + ":" + email;
+        redisUtil.setDataExpire(token, value,3600*24);
+
         return new OrgResponse.OrgInvitationResponse(orgId, "조직 멤버 초대 이메일을 전송하였습니다.", email);
+    }
+
+    @Override
+    // 조직 초대 수락 (이메일 내 링크 클릭 시)
+    public OrgResponse.OrgInvitationResponse acceptOrgInvitation(String token) {
+
+//        orgMemberRepository.save();
+        return null;
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -204,7 +204,7 @@ public class OrgServiceImpl implements OrgService {
         if (orgMemberRepository.existsByUserAndOrganization(user, organization))
             throw new OrgHandler(OrgErrorCode.ORG_MEMBER_ALREADY_ACTIVE);
 
-        orgMemberRepository.save(OrgMemberConverter.toOrgMemberADMIN(user, organization));
+        orgMemberRepository.save(OrgMemberConverter.toOrgMemberMEMBER(user, organization));
 
         // Redis 사용 토큰 삭제
         redisUtil.deleteData("INVITE:" + token);

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -11,6 +11,7 @@ import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMemb
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgRepository;
+import com.whereyouad.WhereYouAd.domains.user.domain.service.EmailService;
 import com.whereyouad.WhereYouAd.domains.user.exception.code.UserErrorCode;
 import com.whereyouad.WhereYouAd.domains.user.exception.handler.UserHandler;
 import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
@@ -29,6 +30,8 @@ public class OrgServiceImpl implements OrgService{
     private final OrgRepository orgRepository;
     private final OrgMemberRepository orgMemberRepository;
     private final UserRepository userRepository;
+
+    private final EmailService emailService;
 
     //조직(워크스페이스) 생성 메서드
     public OrgResponse.Create createOrganization(Long userId, OrgRequest.Create request) {
@@ -131,5 +134,30 @@ public class OrgServiceImpl implements OrgService{
 
         //조직 status 만 DELETED 로 변경 후 종료
         organization.softDelete();
+    }
+
+    @Override
+    public OrgResponse.OrgInvitationResponse sendOrgInvitation(Long orgId, String email) {
+        Organization organization = orgRepository.findById(orgId).orElseThrow(() ->
+            new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
+
+        // 유저 회원 가입 유무
+        User user = userRepository.findUserByEmail(email).orElseThrow(() ->
+                new UserHandler(UserErrorCode.USER_NOT_FOUND));
+
+        // 회원 가입 미완료 (유저가 아닐 시)
+        if (user == null) {
+            emailService.sendEmailForOrgInvitation(email);
+        }
+
+        // 회원 가입 완료 (이미 존재하는 유저)
+        else {
+            // 이미 초대 완료
+            if (orgMemberRepository.existsByUser(user))
+                new OrgHandler(OrgErrorCode.ORG_MEMBER_ALREADY_ACTIVE);
+
+            else emailService.sendEmailForOrgInvitation(email);
+        }
+        return new OrgResponse.OrgInvitationResponse(orgId, "조직 멤버 초대 이메일을 전송하였습니다.", email);
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -27,7 +27,7 @@ import java.util.UUID;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class OrgServiceImpl implements OrgService{
+public class OrgServiceImpl implements OrgService {
 
     private final OrgRepository orgRepository;
     private final OrgMemberRepository orgMemberRepository;
@@ -36,27 +36,27 @@ public class OrgServiceImpl implements OrgService{
     private final RedisUtil redisUtil;
     private final EmailService emailService;
 
-    //조직(워크스페이스) 생성 메서드
+    // 조직(워크스페이스) 생성 메서드
     public OrgResponse.Create createOrganization(Long userId, OrgRequest.Create request) {
 
-        //유저 정보 추출
+        // 유저 정보 추출
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(UserErrorCode.USER_NOT_FOUND));
 
-        //만약 해당 User 가 이미 같은 name 을 가진 Organization 에 속해있으면 예외처리
-        //해당 User 의 OrgMember 를 모두 추출해서,
+        // 만약 해당 User 가 이미 같은 name 을 가진 Organization 에 속해있으면 예외처리
+        // 해당 User 의 OrgMember 를 모두 추출해서,
         List<OrgMember> orgMemberByUser = orgMemberRepository.findOrgMemberByUser(user);
         for (OrgMember orgMember : orgMemberByUser) {
-            //OrgMember 내부 Organization 의 name 이 생성하려는 request 의 name 과 같으면
+            // OrgMember 내부 Organization 의 name 이 생성하려는 request 의 name 과 같으면
             if (orgMember.getOrganization().getName().equals(request.name())) {
-                throw new OrgHandler(OrgErrorCode.ORG_NAME_DUPLICATE); //예외처리
+                throw new OrgHandler(OrgErrorCode.ORG_NAME_DUPLICATE); // 예외처리
             }
         }
 
-        //조직 생성
+        // 조직 생성
         Organization organization = OrgConverter.toOrganization(userId, request);
 
-        //OrgMember 생성
+        // OrgMember 생성
         OrgMember orgMember = OrgMemberConverter.toOrgMemberADMIN(user, organization);
 
         orgRepository.save(organization);
@@ -66,24 +66,24 @@ public class OrgServiceImpl implements OrgService{
     }
 
     public OrgResponse.Read getOrganization(Long userId) {
-        //TODO
+        // TODO
         return null;
     }
 
-    //조직 정보 수정 메서드
+    // 조직 정보 수정 메서드
     public OrgResponse.Update modifyOrganization(Long userId, Long orgId, OrgRequest.Update request) {
         Organization organization = orgRepository.findById(orgId)
                 .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
 
-        //만약 조직 정보 수정을 요청한 회원이 해당 조직을 생성한 회원이 아니라면,
+        // 만약 조직 정보 수정을 요청한 회원이 해당 조직을 생성한 회원이 아니라면,
         if (!organization.getOwnerUserId().equals(userId)) {
-            throw new OrgHandler(OrgErrorCode.ORG_FORBIDDEN); //예외처리
+            throw new OrgHandler(OrgErrorCode.ORG_FORBIDDEN); // 예외처리
         }
 
-        //조직 정보 수정
+        // 조직 정보 수정
         organization.modifyInfo(request);
 
-        //변환 된 필드값과 해당 조직의 Id, updatedAt 가 포함된 DTO 로 반환
+        // 변환 된 필드값과 해당 조직의 Id, updatedAt 가 포함된 DTO 로 반환
         return OrgConverter.toUpdatedResponse(organization);
     }
 
@@ -91,62 +91,62 @@ public class OrgServiceImpl implements OrgService{
         Organization organization = orgRepository.findById(orgId)
                 .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
 
-        //만약 조직 복구 요청한 회원이 해당 조직을 생성한 회원이 아니라면,
+        // 만약 조직 복구 요청한 회원이 해당 조직을 생성한 회원이 아니라면,
         if (!organization.getOwnerUserId().equals(userId)) {
-            throw new OrgHandler(OrgErrorCode.ORG_FORBIDDEN); //예외처리
+            throw new OrgHandler(OrgErrorCode.ORG_FORBIDDEN); // 예외처리
         }
 
-        //조직이 이미 활성화 상태라면,
+        // 조직이 이미 활성화 상태라면,
         if (organization.getStatus() == OrgStatus.ACTIVE) {
-            throw new OrgHandler(OrgErrorCode.ORG_ALREADY_ACTIVE); //예외처리
+            throw new OrgHandler(OrgErrorCode.ORG_ALREADY_ACTIVE); // 예외처리
         }
 
-        organization.restoreDelete(); //조직 Soft Delete 복구
+        organization.restoreDelete(); // 조직 Soft Delete 복구
 
         return OrgConverter.toRestoredResponse(organization);
     }
 
-    //조직 삭제 메서드 -> Hard Delete (DB 에서 완전히 제거)
+    // 조직 삭제 메서드 -> Hard Delete (DB 에서 완전히 제거)
     public void removeOrganization(Long userId, Long orgId) {
         Organization organization = orgRepository.findById(orgId)
                 .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
 
-        //만약 조직 삭제 요청한 회원이 해당 조직을 생성한 회원이 아니라면,
+        // 만약 조직 삭제 요청한 회원이 해당 조직을 생성한 회원이 아니라면,
         if (!organization.getOwnerUserId().equals(userId)) {
-            throw new OrgHandler(OrgErrorCode.ORG_FORBIDDEN); //예외처리
+            throw new OrgHandler(OrgErrorCode.ORG_FORBIDDEN); // 예외처리
         }
 
-        //해당 조직에 가입된 모든 회원들의 가입 정보 삭제
+        // 해당 조직에 가입된 모든 회원들의 가입 정보 삭제
         List<OrgMember> orgMembers = orgMemberRepository.findOrgMemberByOrg(organization);
 
         orgMemberRepository.deleteAll(orgMembers);
 
-        //조직 실제 삭제
+        // 조직 실제 삭제
         orgRepository.delete(organization);
     }
 
-    //조직 삭제 메서드 -> Soft Delete (status 만 DELETED 로 변경)
+    // 조직 삭제 메서드 -> Soft Delete (status 만 DELETED 로 변경)
     public void removeOrganizationSoft(Long userId, Long orgId) {
         Organization organization = orgRepository.findById(orgId)
                 .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
 
-        //만약 조직 삭제 요청한 회원이 해당 조직을 생성한 회원이 아니라면,
+        // 만약 조직 삭제 요청한 회원이 해당 조직을 생성한 회원이 아니라면,
         if (!organization.getOwnerUserId().equals(userId)) {
             throw new OrgHandler(OrgErrorCode.ORG_FORBIDDEN);
         }
 
-        //조직 status 만 DELETED 로 변경 후 종료
+        // 조직 status 만 DELETED 로 변경 후 종료
         organization.softDelete();
     }
 
     @Override
     // 조직 초대 이메일 보내기
     public OrgResponse.OrgInvitationResponse sendOrgInvitation(Long orgId, String email) {
-        Organization organization = orgRepository.findById(orgId).orElseThrow(() ->
-            new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
+        Organization organization = orgRepository.findById(orgId)
+                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
 
         // 초대 완료 여부 확인, 가입 여부에 상관 없이 이메일 발송
-        userRepository.findUserByEmail(email).ifPresent( user -> {
+        userRepository.findUserByEmail(email).ifPresent(user -> {
             if (orgMemberRepository.existsByUser(user))
                 new OrgHandler(OrgErrorCode.ORG_MEMBER_ALREADY_ACTIVE);
         });
@@ -155,7 +155,9 @@ public class OrgServiceImpl implements OrgService{
         String token = UUID.randomUUID().toString();
         // Redis value = 조직 아이디와 이메일의 조합
         String value = orgId + ":" + email;
-        redisUtil.setDataExpire(token, value,3600*24);
+        redisUtil.setDataExpire("INVITE:" + token, value, 3600 * 24L);
+
+        emailService.sendEmailForOrgInvitation(token, email, organization.getName());
 
         return new OrgResponse.OrgInvitationResponse(orgId, "조직 멤버 초대 이메일을 전송하였습니다.", email);
     }
@@ -164,7 +166,7 @@ public class OrgServiceImpl implements OrgService{
     // 조직 초대 수락 (이메일 내 링크 클릭 시)
     public OrgResponse.OrgInvitationResponse acceptOrgInvitation(String token) {
         // Redis 내 UUID(key)에 대한 email(value) 비교
-        String email = redisUtil.getData(token).split(":")[1];
+        String email = redisUtil.getData(token.split(":")[1]).split(":")[1];
         Organization organization = orgRepository.findById(Long.parseLong(redisUtil.getData(token).split(":")[0]))
                 .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -175,9 +175,10 @@ public class OrgServiceImpl implements OrgService {
             throw new OrgHandler(OrgErrorCode.ORG_INVITATION_INVALID);
         }
 
-        String email = value.split(":")[1];
+        String[] valueForSplit = value.split(":");
+        String email = valueForSplit[1];
 
-        Organization organization = orgRepository.findById(Long.parseLong(value.split(":")[0]))
+        Organization organization = orgRepository.findById(Long.parseLong(valueForSplit[0]))
                 .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
 
         User user = userRepository.findUserByEmail(email).orElseThrow(() ->

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -164,7 +164,7 @@ public class OrgServiceImpl implements OrgService {
 
     @Override
     // 조직 초대 수락 (이메일 내 링크 클릭 시)
-    public OrgResponse.OrgInvitationResponse acceptOrgInvitation(String token) {
+    public OrgResponse.OrgInvitationResponse acceptOrgInvitation(Long userId, String token) {
         // 링크 만료 또는 유효하지 않을 시
         if (token == null)
             throw new OrgHandler(OrgErrorCode.ORG_INVITATION_INVALID);
@@ -178,12 +178,17 @@ public class OrgServiceImpl implements OrgService {
         String[] valueForSplit = value.split(":");
         String email = valueForSplit[1];
 
+        // 로그인한 사용자 검증
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(UserErrorCode.USER_NOT_FOUND));
+
+        // 초대된 이메일과 현재 로그인한 사용자의 이메일이 일치하는지 확인
+        if (!user.getEmail().equals(email)) {
+            throw new OrgHandler(OrgErrorCode.ORG_INVITATION_INVALID);
+        }
+
         Organization organization = orgRepository.findById(Long.parseLong(valueForSplit[0]))
                 .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
-
-        User user = userRepository.findUserByEmail(email).orElseThrow(() ->
-                // 회원이 아닐 시
-                new UserHandler(UserErrorCode.USER_NOT_FOUND));
 
         // 이미 멤버인지 중복 체크
         if (orgMemberRepository.existsByUser(user))

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -166,7 +166,7 @@ public class OrgServiceImpl implements OrgService {
     // 조직 초대 수락 (이메일 내 링크 클릭 시)
     public OrgResponse.OrgInvitationResponse acceptOrgInvitation(String token) {
         // Redis 내 UUID(key)에 대한 email(value) 비교
-        String email = redisUtil.getData(token.split(":")[1]).split(":")[1];
+        String email = redisUtil.getData(token).split(":")[1];
         Organization organization = orgRepository.findById(Long.parseLong(redisUtil.getData(token).split(":")[0]))
                 .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
 
@@ -175,6 +175,9 @@ public class OrgServiceImpl implements OrgService {
                 new UserHandler(UserErrorCode.USER_NOT_FOUND));
 
         orgMemberRepository.save(OrgMemberConverter.toOrgMemberADMIN(user, organization));
+
+        // Redis 사용 토큰 삭제
+        redisUtil.deleteData(token);
 
         return new OrgResponse.OrgInvitationResponse(organization.getId(), "조직 멤버 초대 이메일을 수락하였습니다.", email);
     }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
@@ -21,7 +21,9 @@ public enum OrgErrorCode implements BaseErrorCode {
     ORG_ALREADY_ACTIVE(HttpStatus.CONFLICT, "ORG_409_1", "해당 조직은 이미 활성화 상태 입니다."),
 
     // 409
-    ORG_MEMBER_ALREADY_ACTIVE(HttpStatus.CONFLICT, "ORG_MEMBER_409_1", "이미 해당 조직에 초대되어있습니다.");
+    ORG_MEMBER_ALREADY_ACTIVE(HttpStatus.CONFLICT, "ORG_MEMBER_409_1", "이미 해당 조직에 초대되어있습니다."),
+
+    ORG_INVITATION_INVALID(HttpStatus.BAD_REQUEST, "ORG_INVITATION_400" , "조직 초대 토큰이 만료되었거나 유효하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
@@ -23,7 +23,12 @@ public enum OrgErrorCode implements BaseErrorCode {
     // 409
     ORG_MEMBER_ALREADY_ACTIVE(HttpStatus.CONFLICT, "ORG_MEMBER_409_1", "이미 해당 조직에 초대되어있습니다."),
 
-    ORG_INVITATION_INVALID(HttpStatus.BAD_REQUEST, "ORG_INVITATION_400" , "조직 초대 토큰이 만료되었거나 유효하지 않습니다.");
+    // 400
+    ORG_INVITATION_INVALID(HttpStatus.BAD_REQUEST, "ORG_INVITATION_400", "조직 초대 토큰이 만료되었거나 유효하지 않습니다."),
+
+    // 403
+    ORG_INVITATION_FORBIDDEN_USER(HttpStatus.FORBIDDEN, "ORG_INVITATION_403_1",
+            "초대된 이메일과 현재 로그인한 사용자의 이메일이 일치하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
@@ -18,8 +18,11 @@ public enum OrgErrorCode implements BaseErrorCode {
     ORG_NOT_FOUND(HttpStatus.NOT_FOUND, "ORG_404_1", "해당 id 의 조직이 존재하지 않습니다."),
 
     //409
-    ORG_ALREADY_ACTIVE(HttpStatus.CONFLICT, "ORG_409_1", "해당 조직은 이미 활성화 상태 입니다.")
-    ;
+    ORG_ALREADY_ACTIVE(HttpStatus.CONFLICT, "ORG_409_1", "해당 조직은 이미 활성화 상태 입니다."),
+
+    //409
+    ORG_MEMBER_ALREADY_ACTIVE(HttpStatus.CONFLICT, "ORG_MEMBER_409_1", "이미 해당 조직에 초대되어있습니다.");
+
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
@@ -8,19 +8,19 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum OrgErrorCode implements BaseErrorCode {
-    //400
+    // 400
     ORG_NAME_DUPLICATE(HttpStatus.BAD_REQUEST, "ORG_400_1", "사용자가 이미 속해있는 조직의 이름입니다."),
 
-    //403
+    // 403
     ORG_FORBIDDEN(HttpStatus.FORBIDDEN, "ORG_403_1", "해당 요청은 조직 생성자만 요청 가능합니다."),
 
-    //404
+    // 404
     ORG_NOT_FOUND(HttpStatus.NOT_FOUND, "ORG_404_1", "해당 id 의 조직이 존재하지 않습니다."),
 
-    //409
+    // 409
     ORG_ALREADY_ACTIVE(HttpStatus.CONFLICT, "ORG_409_1", "해당 조직은 이미 활성화 상태 입니다."),
 
-    //409
+    // 409
     ORG_MEMBER_ALREADY_ACTIVE(HttpStatus.CONFLICT, "ORG_MEMBER_409_1", "이미 해당 조직에 초대되어있습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
@@ -17,4 +17,6 @@ public interface OrgMemberRepository extends JpaRepository<OrgMember, Long> {
     //특정 Organization 에 속한 OrgMember 모두 추출하는 메서드
     @Query("select om from OrgMember om where om.organization = :organization")
     List<OrgMember> findOrgMemberByOrg(@Param(value = "organization") Organization organization);
+
+    Boolean existsByUser(User user);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
@@ -45,5 +45,5 @@ public interface OrgMemberRepository extends JpaRepository<OrgMember, Long> {
             @Param("status") UserStatus status
     );
 
-    Boolean existsByUser(User user);
+        Boolean existsByUserAndOrganization(User user, Organization organization);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
@@ -43,7 +43,6 @@ public class OrgController implements OrgControllerDocs {
         );
     }
 
-
     @PatchMapping("/{orgId}")
     public ResponseEntity<DataResponse<OrgResponse.Update>> modifyOrganization(
             @AuthenticationPrincipal(expression = "userId") Long userId,
@@ -115,7 +114,7 @@ public class OrgController implements OrgControllerDocs {
         return ResponseEntity.ok(DataResponse.from(orgInvitationResponse));
     }
 
-    @PostMapping("invitations/{token}")
+    @PostMapping("/invitations/{token}")
     public ResponseEntity<DataResponse<OrgResponse.OrgInvitationResponse>> acceptOrgInvitation(
             @AuthenticationPrincipal(expression = "userId") Long userId, @PathVariable String token) {
         OrgResponse.OrgInvitationResponse orgInvitationResponse = orgService.acceptOrgInvitation(userId, token);

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
@@ -88,8 +88,8 @@ public class OrgController implements OrgControllerDocs {
     }
 
     @PostMapping("/members/{orgId}/invitation")
-    public ResponseEntity<DataResponse<OrgResponse.OrgInvitationResponse>> sendOrgInvitation(@PathVariable Long orgId, @RequestBody String email) {
-        OrgResponse.OrgInvitationResponse orgInvitationResponse = orgService.sendOrgInvitation(orgId, email);
+    public ResponseEntity<DataResponse<OrgResponse.OrgInvitationResponse>> sendOrgInvitation(@PathVariable Long orgId, @RequestBody @Valid OrgRequest.Invite request) {
+        OrgResponse.OrgInvitationResponse orgInvitationResponse = orgService.sendOrgInvitation(orgId, request.email());
         return ResponseEntity.ok(DataResponse.from(orgInvitationResponse));
     }
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
@@ -92,4 +92,10 @@ public class OrgController implements OrgControllerDocs {
         OrgResponse.OrgInvitationResponse orgInvitationResponse = orgService.sendOrgInvitation(orgId, email);
         return ResponseEntity.ok(DataResponse.from(orgInvitationResponse));
     }
+
+    @GetMapping("invitations/{token}")
+    public ResponseEntity<DataResponse<OrgResponse.OrgInvitationResponse>> acceptOrgInvitation(@PathVariable String token) {
+        OrgResponse.OrgInvitationResponse orgInvitationResponse = orgService.acceptOrgInvitation(token);
+        return ResponseEntity.ok(DataResponse.from(orgInvitationResponse));
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
@@ -4,6 +4,7 @@ import com.whereyouad.WhereYouAd.domains.organization.application.dto.request.Or
 import com.whereyouad.WhereYouAd.domains.organization.application.dto.response.OrgResponse;
 import com.whereyouad.WhereYouAd.domains.organization.domain.service.OrgService;
 import com.whereyouad.WhereYouAd.domains.organization.presentation.docs.OrgControllerDocs;
+import com.whereyouad.WhereYouAd.domains.user.domain.service.EmailService;
 import com.whereyouad.WhereYouAd.global.response.DataResponse;
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.validation.Valid;
@@ -84,5 +85,11 @@ public class OrgController implements OrgControllerDocs {
         return ResponseEntity.ok(
                 DataResponse.from("조직이 정상적으로 삭제 처리 되었습니다.")
         );
+    }
+
+    @PostMapping("/members/{orgId}/invitation")
+    public ResponseEntity<DataResponse<OrgResponse.OrgInvitationResponse>> sendOrgInvitation(@PathVariable Long orgId, @RequestBody String email) {
+        OrgResponse.OrgInvitationResponse orgInvitationResponse = orgService.sendOrgInvitation(orgId, email);
+        return ResponseEntity.ok(DataResponse.from(orgInvitationResponse));
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
@@ -4,7 +4,7 @@ import com.whereyouad.WhereYouAd.domains.organization.application.dto.request.Or
 import com.whereyouad.WhereYouAd.domains.organization.application.dto.response.OrgResponse;
 import com.whereyouad.WhereYouAd.domains.organization.domain.service.OrgService;
 import com.whereyouad.WhereYouAd.domains.organization.presentation.docs.OrgControllerDocs;
-import com.whereyouad.WhereYouAd.domains.user.domain.service.EmailService;
+
 import com.whereyouad.WhereYouAd.global.response.DataResponse;
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.validation.Valid;
@@ -94,8 +94,8 @@ public class OrgController implements OrgControllerDocs {
     }
 
     @GetMapping("invitations/{token}")
-    public ResponseEntity<DataResponse<OrgResponse.OrgInvitationResponse>> acceptOrgInvitation(@PathVariable String token) {
-        OrgResponse.OrgInvitationResponse orgInvitationResponse = orgService.acceptOrgInvitation(token);
+    public ResponseEntity<DataResponse<OrgResponse.OrgInvitationResponse>> acceptOrgInvitation(@AuthenticationPrincipal(expression = "userId") Long userId, @PathVariable String token) {
+        OrgResponse.OrgInvitationResponse orgInvitationResponse = orgService.acceptOrgInvitation(userId, token);
         return ResponseEntity.ok(DataResponse.from(orgInvitationResponse));
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
@@ -107,13 +107,17 @@ public class OrgController implements OrgControllerDocs {
     }
 
     @PostMapping("/members/{orgId}/invitation")
-    public ResponseEntity<DataResponse<OrgResponse.OrgInvitationResponse>> sendOrgInvitation(@PathVariable Long orgId, @RequestBody @Valid OrgRequest.Invite request) {
-        OrgResponse.OrgInvitationResponse orgInvitationResponse = orgService.sendOrgInvitation(orgId, request.email());
+    public ResponseEntity<DataResponse<OrgResponse.OrgInvitationResponse>> sendOrgInvitation(
+            @AuthenticationPrincipal(expression = "userId") Long userId, @PathVariable Long orgId,
+            @RequestBody @Valid OrgRequest.Invite request) {
+        OrgResponse.OrgInvitationResponse orgInvitationResponse = orgService.sendOrgInvitation(userId, orgId,
+                request.email());
         return ResponseEntity.ok(DataResponse.from(orgInvitationResponse));
     }
 
-    @GetMapping("invitations/{token}")
-    public ResponseEntity<DataResponse<OrgResponse.OrgInvitationResponse>> acceptOrgInvitation(@AuthenticationPrincipal(expression = "userId") Long userId, @PathVariable String token) {
+    @PostMapping("invitations/{token}")
+    public ResponseEntity<DataResponse<OrgResponse.OrgInvitationResponse>> acceptOrgInvitation(
+            @AuthenticationPrincipal(expression = "userId") Long userId, @PathVariable String token) {
         OrgResponse.OrgInvitationResponse orgInvitationResponse = orgService.acceptOrgInvitation(userId, token);
         return ResponseEntity.ok(DataResponse.from(orgInvitationResponse));
     }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
@@ -69,4 +69,27 @@ public interface OrgControllerDocs {
             @PathVariable Long orgId,
             @RequestParam(defaultValue = "false") boolean isHard
     );
+
+    @Operation(summary = "조직 초대 이메일 발송 API", description = "조직 관리자가 이메일을 입력하여 새로운 멤버를 초대합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "404", description = "조직을 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 조직에 가입된 사용자")
+    })
+    public ResponseEntity<DataResponse<OrgResponse.OrgInvitationResponse>> sendOrgInvitation(
+            @PathVariable Long orgId,
+            @RequestBody @Valid OrgRequest.Invite request
+    );
+
+    @Operation(summary = "조직 초대 수락 API", description = "이메일로 받은 초대 토큰을 통해 조직 가입을 수락합니다. (로그인 필수, 본인 확인)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "유효하지 않거나 만료된 토큰"),
+            @ApiResponse(responseCode = "401", description = "로그인 필요"),
+            @ApiResponse(responseCode = "403", description = "초대된 이메일과 로그인한 사용자가 불일치")
+    })
+    public ResponseEntity<DataResponse<OrgResponse.OrgInvitationResponse>> acceptOrgInvitation(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable String token
+    );
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
@@ -100,6 +100,8 @@ public interface OrgControllerDocs {
     @Operation(summary = "조직 초대 이메일 발송 API", description = "조직 관리자가 이메일을 입력하여 새로운 멤버를 초대합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "401", description = "로그인 필요"),
+            @ApiResponse(responseCode = "403", description = "조직 멤버가 아닌 사용자의 요청"),
             @ApiResponse(responseCode = "404", description = "조직을 찾을 수 없음"),
             @ApiResponse(responseCode = "409", description = "이미 조직에 가입된 사용자")
     })

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
@@ -104,6 +104,7 @@ public interface OrgControllerDocs {
             @ApiResponse(responseCode = "409", description = "이미 조직에 가입된 사용자")
     })
     public ResponseEntity<DataResponse<OrgResponse.OrgInvitationResponse>> sendOrgInvitation(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
             @RequestBody @Valid OrgRequest.Invite request
     );

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/EmailService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/EmailService.java
@@ -1,5 +1,6 @@
 package com.whereyouad.WhereYouAd.domains.user.domain.service;
 
+import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgRepository;
 import com.whereyouad.WhereYouAd.domains.user.application.dto.response.EmailSentResponse;
 import com.whereyouad.WhereYouAd.domains.user.exception.handler.UserHandler;
 import com.whereyouad.WhereYouAd.domains.user.exception.code.UserErrorCode;
@@ -47,6 +48,10 @@ public class EmailService {
         } else { //만약 회원가입 되어있지 않다면
             throw new UserHandler(UserErrorCode.USER_NOT_FOUND); //예외발생
         }
+    }
+
+    // 조직 멤버 초대 이메일 발송
+    public void sendEmailForOrgInvitation(String email) {
     }
 
     //기존 이메일 발송 로직 템플릿 화

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/EmailService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/EmailService.java
@@ -25,14 +25,14 @@ public class EmailService {
     private final RedisUtil redisUtil;
     private final UserRepository userRepository;
 
-    //application.yml 적용 필요
+    // application.yml 적용 필요
     @Value("${spring.mail.username}")
     private String senderEmail;
 
-    //인증코드 이메일 발송 로직 (최초 회원가입 시)
+    // 인증코드 이메일 발송 로직 (최초 회원가입 시)
     public EmailSentResponse sendEmail(String toEmail) {
-        if (userRepository.existsByEmail(toEmail)) { //이미 해당 이메일로 생성한 계정이 있으면
-            throw new UserHandler(UserErrorCode.USER_EMAIL_DUPLICATE); //이메일 중복 예외(회원가입 시 사용했던 예외)
+        if (userRepository.existsByEmail(toEmail)) { // 이미 해당 이메일로 생성한 계정이 있으면
+            throw new UserHandler(UserErrorCode.USER_EMAIL_DUPLICATE); // 이메일 중복 예외(회원가입 시 사용했던 예외)
         }
 
         String type = "회원가입";
@@ -40,91 +40,103 @@ public class EmailService {
         return emailSendTemplate(toEmail, type);
     }
 
-    //비밀번호 재설정을 위한 인증코드 이메일 발송 로직 (이미 회원가입 된 상태에서 비밀번호 재설정)
+    // 비밀번호 재설정을 위한 인증코드 이메일 발송 로직 (이미 회원가입 된 상태에서 비밀번호 재설정)
     public EmailSentResponse sendEmailForPwd(String toEmail) {
-        if (userRepository.existsByEmail(toEmail)) { //이미 회원가입 되어있는 것이 확인되면
+        if (userRepository.existsByEmail(toEmail)) { // 이미 회원가입 되어있는 것이 확인되면
             String type = "비밀번호 재설정";
-            return emailSendTemplate(toEmail, type); //정상적으로 이메일 발송
-        } else { //만약 회원가입 되어있지 않다면
-            throw new UserHandler(UserErrorCode.USER_NOT_FOUND); //예외발생
+            return emailSendTemplate(toEmail, type); // 정상적으로 이메일 발송
+        } else { // 만약 회원가입 되어있지 않다면
+            throw new UserHandler(UserErrorCode.USER_NOT_FOUND); // 예외발생
         }
     }
 
     // 조직 멤버 초대 이메일 발송
-    public void sendEmailForOrgInvitation(String email) {
+    public void sendEmailForOrgInvitation(String toEmail) {
+        try {
+            // 이메일 전송
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setTo(toEmail);
+
+            message.setSubject("Where You Ad 조직에 초대 되었습니다.");
+            message.setText("http://localhost:3000/invitations/{token}");
+            message.setFrom(senderEmail);
+
+            emailSender.send(message);
+        } catch (MailException e) { // 예외 발생
+            throw new UserHandler(UserErrorCode.USER_EMAIL_NOT_VALID); // 통합 응답 처리 예외로 반환
+        }
     }
 
-    //기존 이메일 발송 로직 템플릿 화
+    // 기존 이메일 발송 로직 템플릿 화
     private EmailSentResponse emailSendTemplate(String toEmail, String type) {
 
-        //인증코드 재전송 로직 -> 이미 Redis 에 해당 이메일 인증코드가 있을시 삭제
+        // 인증코드 재전송 로직 -> 이미 Redis 에 해당 이메일 인증코드가 있을시 삭제
         String redisKey = "CODE:" + toEmail;
         if (redisUtil.getData(redisKey) != null) {
             redisUtil.deleteData(redisKey);
         }
 
-        String authCode = createCode(); //인증코드 생성
+        String authCode = createCode(); // 인증코드 생성
 
         if (isTestEmail(toEmail)) {
-            //테스트용 가짜 이메일은 서버 로그로만 인증코드를 보여주기
-            //실제 이메일 발송 X
-            //존재하지 않는 이메일 주소로 계속 이메일을 보내면 인증코드 전송용 이메일 계정이 스팸처리 될 가능성 존재하여 로그로 남기기
+            // 테스트용 가짜 이메일은 서버 로그로만 인증코드를 보여주기
+            // 실제 이메일 발송 X
+            // 존재하지 않는 이메일 주소로 계속 이메일을 보내면 인증코드 전송용 이메일 계정이 스팸처리 될 가능성 존재하여 로그로 남기기
             log.warn("{} 이메일 -> 테스트 or 개발용 가짜 이메일 입니다.", toEmail);
             log.warn("[TEST 모드] 실제 발송을 건너뜁니다.");
             log.warn("[TEST 모드] 수신자: {}", toEmail);
             log.warn("[TEST 모드] 인증코드: {}", authCode);
 
-        } else { //실제 존재하는 이메일이라면
+        } else { // 실제 존재하는 이메일이라면
 
             try {
-                //실제 인증 코드가 담긴 이메일 전송
+                // 실제 인증 코드가 담긴 이메일 전송
                 SimpleMailMessage message = new SimpleMailMessage();
                 message.setTo(toEmail);
-                //어떤 유형의 인증(최초 회원가입 or 비밀번호 재설정) 인지 구분하여 인증코드 발송
+                // 어떤 유형의 인증(최초 회원가입 or 비밀번호 재설정) 인지 구분하여 인증코드 발송
                 message.setSubject("whereyouad " + type + " 인증번호");
-                message.setText("[Where You Ad] " + type +  "\n 인증 번호는 [" + authCode + "] 입니다.");
+                message.setText("[Where You Ad] " + type + "\n 인증 번호는 [" + authCode + "] 입니다.");
                 message.setFrom(senderEmail);
 
-                emailSender.send(message); //만약 실제 존재하는 이메일인데 사용자가 오타를 냈다면
-            } catch (MailException e) { //예외 발생
-                throw new UserHandler(UserErrorCode.USER_EMAIL_NOT_VALID); //통합 응답 처리 예외로 반환
+                emailSender.send(message); // 만약 실제 존재하는 이메일인데 사용자가 오타를 냈다면
+            } catch (MailException e) { // 예외 발생
+                throw new UserHandler(UserErrorCode.USER_EMAIL_NOT_VALID); // 통합 응답 처리 예외로 반환
             }
-
         }
 
-        //Redis에 저장 (Key: "CODE:이메일", Value: "123456", 유효시간: 180초(3분))
-        //테스트 계정도 인증은 해야하니 Redis 에 코드가 저장 되어야 함.
-        //테스트 계정의 인증은 서버 로그를 통해 인증코드를 얻어 입력.
+        // Redis에 저장 (Key: "CODE:이메일", Value: "123456", 유효시간: 180초(3분))
+        // 테스트 계정도 인증은 해야하니 Redis 에 코드가 저장 되어야 함.
+        // 테스트 계정의 인증은 서버 로그를 통해 인증코드를 얻어 입력.
         redisUtil.setDataExpire("CODE:" + toEmail, authCode, 60 * 3L);
 
         return new EmailSentResponse("인증코드를 이메일로 전송했습니다.", toEmail, 180L);
     }
 
-    //인증코드 검증 메서드
+    // 인증코드 검증 메서드
     public void verifyEmailCode(String email, String inputCode) {
-        //해당 이메일 값으로 Redis 에서 조회
+        // 해당 이메일 값으로 Redis 에서 조회
         String key = "CODE:" + email;
         String savedCode = redisUtil.getData(key);
 
-        //만약 인증코드가 없거나 잘못 입력했다면,
+        // 만약 인증코드가 없거나 잘못 입력했다면,
         if (savedCode == null || !savedCode.equals(inputCode)) {
-            throw new UserHandler(UserErrorCode.USER_EMAIL_AUTH_INVALID); //예외 발생(BAD_REQUEST)
+            throw new UserHandler(UserErrorCode.USER_EMAIL_AUTH_INVALID); // 예외 발생(BAD_REQUEST)
         }
 
-        //정상적으로 인증코드를 입력했다면,
-        //기존 Redis 에 저장된 데이터를 지우고,
+        // 정상적으로 인증코드를 입력했다면,
+        // 기존 Redis 에 저장된 데이터를 지우고,
         redisUtil.deleteData(key);
-        //"해당 이메일이 정상적으로 인증되었다" 는 값을 다시 Redis 에 저장 -> 이후 회원가입(signup) 내부 로직에서 활용
-        redisUtil.setDataExpire("VERIFIED:" + email, "TRUE", 60 * 60L); //1시간 뒤 Expire
+        // "해당 이메일이 정상적으로 인증되었다" 는 값을 다시 Redis 에 저장 -> 이후 회원가입(signup) 내부 로직에서 활용
+        redisUtil.setDataExpire("VERIFIED:" + email, "TRUE", 60 * 60L); // 1시간 뒤 Expire
     }
 
-    //테스트용 이메일은, "test" 로 시작하거나, "example.com" 으로 끝나야 한다.
+    // 테스트용 이메일은, "test" 로 시작하거나, "example.com" 으로 끝나야 한다.
     private boolean isTestEmail(String email) {
         return email.startsWith("test") || email.endsWith("example.com");
     }
 
-    //무작위 인증코드 값 생성
+    // 무작위 인증코드 값 생성
     private String createCode() {
-        return String.valueOf((int)(Math.random() * (900000)) + 100000);
+        return String.valueOf((int) (Math.random() * (900000)) + 100000);
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/EmailService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/EmailService.java
@@ -1,6 +1,5 @@
 package com.whereyouad.WhereYouAd.domains.user.domain.service;
 
-import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgRepository;
 import com.whereyouad.WhereYouAd.domains.user.application.dto.response.EmailSentResponse;
 import com.whereyouad.WhereYouAd.domains.user.exception.handler.UserHandler;
 import com.whereyouad.WhereYouAd.domains.user.exception.code.UserErrorCode;
@@ -28,6 +27,9 @@ public class EmailService {
     // application.yml 적용 필요
     @Value("${spring.mail.username}")
     private String senderEmail;
+
+    @Value("${spring.application.base-url}")
+    private String baseUrl;
 
     // 인증코드 이메일 발송 로직 (최초 회원가입 시)
     public EmailSentResponse sendEmail(String toEmail) {
@@ -58,7 +60,7 @@ public class EmailService {
             message.setTo(toEmail);
 
             message.setSubject("[Where You Ad] 조직 " + orgName + "에 초대 되었습니다.");
-            message.setText("http://localhost:3000/invitations/"+ token);
+            message.setText(baseUrl + "/api/org/invitations/" + token);
             message.setFrom(senderEmail);
 
             emailSender.send(message);

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/EmailService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/EmailService.java
@@ -51,14 +51,14 @@ public class EmailService {
     }
 
     // 조직 멤버 초대 이메일 발송
-    public void sendEmailForOrgInvitation(String toEmail) {
+    public void sendEmailForOrgInvitation(String token, String toEmail, String orgName) {
         try {
             // 이메일 전송
             SimpleMailMessage message = new SimpleMailMessage();
             message.setTo(toEmail);
 
-            message.setSubject("Where You Ad 조직에 초대 되었습니다.");
-            message.setText("http://localhost:3000/invitations/{token}");
+            message.setSubject("[Where You Ad] 조직 " + orgName + "에 초대 되었습니다.");
+            message.setText("http://localhost:3000/invitations/"+ token);
             message.setFrom(senderEmail);
 
             emailSender.send(message);

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/AuthController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/AuthController.java
@@ -2,6 +2,7 @@ package com.whereyouad.WhereYouAd.domains.user.presentation;
 
 import com.whereyouad.WhereYouAd.domains.user.application.dto.request.LoginRequest;
 import com.whereyouad.WhereYouAd.domains.user.domain.service.AuthService;
+import com.whereyouad.WhereYouAd.domains.user.domain.service.EmailService;
 import com.whereyouad.WhereYouAd.domains.user.presentation.docs.AuthControllerDocs;
 import com.whereyouad.WhereYouAd.global.response.DataResponse;
 import com.whereyouad.WhereYouAd.global.security.jwt.dto.TokenResponse;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,8 +4,8 @@ server:
 spring:
   application:
     name: WhereYouAd
-  # 서버 기본 주소
-  base-url: ${BASE_URL:http://localhost:8080}
+    # 서버 기본 주소
+    base-url: ${BASE_URL:http://localhost:8080}
 
   # 1. 데이터베이스 설정
   datasource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,8 @@ server:
 spring:
   application:
     name: WhereYouAd
+  # 서버 기본 주소
+  base-url: ${BASE_URL:http://localhost:8080}
 
   # 1. 데이터베이스 설정
   datasource:


### PR DESCRIPTION
## 📌 관련 이슈
- Close #27

## 🚀 개요
조직 멤버가 다른 이를 이메일을 통해 조직으로 초대하고, 이메일을 받아 링크로 접속(초대 수락으로 간주)한 사람은 초대 되어 조직 멤버로 할당되도록 구현하였습니다.

## 📄 작업 내용
### 조직 초대 이메일 발송 API 
: 조직 멤버가 조직에 초대하고 싶은 자의 이메일을 입력하면, 해당 이메일로 초대 링크가 보내짐.
` POST /api/org/members/{orgId}/invitation `
``` JSON
// 요청 예시
{
  "email": "newuser@gmail.com"
}
```
``` JSON
// 응답 예시
{
  "status": "OK",
  "data": {
    "orgId": 1,
    "message": "조직 멤버 초대 이메일을 전송하였습니다.",
    "email": "newuser@gmail.com"
  }
}
```
> 실제 메일 내용
<img width="776" height="265" alt="image" src="https://github.com/user-attachments/assets/7eab45dc-c9a9-4de0-a994-1935cee59602" />

``` JAVA
// OrgServiceImpl 코드 일부
// Redis key = 임의의 UUID 토큰(조직 초대 이메일 내 링크를 구별)
        String token = UUID.randomUUID().toString();
          
// EmailService  코드 일부
        message.setText(baseUrl + "/api/org/invitations/" + token);

// application.yml 코드 일부
spring:
  application:
    name: WhereYouAd
    # 서버 기본 주소
    base-url: ${BASE_URL:http://localhost:8080}
```
- 조직 초대 로직은 OrgService, 이메일 발송 로직은 EmailService로 구분하여 책임 분리
- 접속 링크 뒤에 임의의 토큰을 부여하여, Redis에서 토큰(UUID)과 조직+초대 이메일을 각각 key:value로 하여 구분함.
- 배포 시에는 해당 접속 링크는 배포 서버용 .env의 BASE_URL에 따라 public IP로 바뀜 (로컬과 달리 실제 접속 가능)
- 회원가입 여부와 상관 없이, 회원이 아닌 자에게도 메일은 발송될 수 있음.

<br/>

### 조직 초대 수락 API

` POST /api/org/invitations/{token} `

<img width="334" height="204" alt="image" src="https://github.com/user-attachments/assets/1b2056d5-9bf8-4084-862e-c2c3ade240ea" />
<img width="334" height="138" alt="image" src="https://github.com/user-attachments/assets/c6bcc62d-31ae-4ccf-97df-2b327dd1a658" />

- 로그인 필수(`@AuthenticationPrincipal`) , 초대된 이메일과 로그인한 사용자가 일치해야함. 일치하지 않을 경우 `ORG_INVITATION_FORBIDDEN_USER 403` 에러 발생
- (참고) 이메일 링크 접속 시(= GET 요청 시), 프론트엔드는 먼저 로그인 여부를 확인
   - 비로그인 유저: 즉시 로그인/회원가입 페이지로 리다이렉트, 로그인 완료 후 다시 초대 수락 API를 호출하도록 처리
   - 로그인 유저: 즉시 API를 호출하여 초대 수락

## 📸 스크린샷 / 테스트 결과 (선택)
<img width="709" height="148" alt="image" src="https://github.com/user-attachments/assets/04851d90-1a59-4aca-89da-4bce823ba901" />
조직 멤버로 추가된 것을 확인할 수 있음.

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
- 초대 링크의 유효성을 관리하기 위해 Redis를 사용하고, 임의의 uuid를 링크에 넣는 식으로 구현했는데 괜찮을지 고민이네요..
- 일단 프론트 측에서 조직 초대를 수락하는 화면은 따로 없는 듯해서, 링크에 접속하면 수락으로 간주하긴 했는데 이런 화면이 생기면 수정될 필요가 있을 것 같습니다

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 조직 멤버 초대 기능 추가: 이메일로 초대 발송 및 초대 토큰 생성(유효기간 포함).
  * 초대 수락 기능 추가: 토큰으로 초대 수락 시 조직에 멤버로 가입됩니다.
  * 자동 초대 이메일 발송: 초대 링크가 포함된 이메일 전송 기능 추가.

* **버그 수정 / 개선**
  * 초대 흐름 관련 유효성 검증 및 오류응답 강화(이메일 형식, 토큰 만료/무효, 권한 불일치, 중복 초대 등).
  * 애플리케이션 기본 URL 설정 추가로 초대 링크 생성 안정성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->