### PR TITLE
Feat/#63 - Project 조회 API

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdCampaignRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdCampaignRepository.java
@@ -4,6 +4,7 @@ import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdCampaign;
 import com.whereyouad.WhereYouAd.domains.dashboard.application.dto.response.DashboardResponse;
+import com.whereyouad.WhereYouAd.domains.project.application.dto.ProjectQueryDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -39,4 +40,9 @@ public interface AdCampaignRepository extends JpaRepository<AdCampaign, Long> {
     @Query("SELECT SUM(c.budget) FROM AdCampaign c JOIN c.project p JOIN p.organization o JOIN OrgMember om ON om.organization = o WHERE om.user.id = :userId AND o.id = :orgId AND c.provider = :provider AND c.status = 'ON_GOING'")
     Long sumBudgetsByUserIdAndOrgIdAndProvider(@Param("userId") Long userId, @Param("orgId") Long orgId,
             @Param("provider") Provider provider);
+
+    @Query("SELECT new com.whereyouad.WhereYouAd.domains.project.application.dto.ProjectQueryDto$CampaignSummary(c.project.id, c.provider, c.budget) " +
+            "FROM AdCampaign c WHERE c.project.id IN :projectIds")
+    List<ProjectQueryDto.CampaignSummary> findCampaignSummariesByProjectIds(@Param("projectIds") List<Long> projectIds);
+
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/MetricFactRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/MetricFactRepository.java
@@ -6,6 +6,7 @@ import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.projection.MetricSumProjection;
 import com.whereyouad.WhereYouAd.domains.organization.domain.constant.OrgStatus;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.projection.RoasProjection;
+import com.whereyouad.WhereYouAd.domains.project.application.dto.ProjectQueryDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -104,4 +105,9 @@ public interface MetricFactRepository extends JpaRepository<MetricFact, Long> {
       @Param("orgId") Long orgId,
       @Param("start") LocalDateTime start,
       @Param("end") LocalDateTime end);
+
+    // 프로젝트 ID 목록으로 지출(spend) 총합 일괄 조회
+    @Query("SELECT new com.whereyouad.WhereYouAd.domains.project.application.dto.ProjectQueryDto$SpendSummary(m.project.id, SUM(m.spend)) " +
+            "FROM MetricFact m WHERE m.project.id IN :projectIds GROUP BY m.project.id")
+    List<ProjectQueryDto.SpendSummary> findSpendSummariesByProjectIds(@Param("projectIds") List<Long> projectIds);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/application/dto/ProjectQueryDto.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/application/dto/ProjectQueryDto.java
@@ -1,0 +1,19 @@
+package com.whereyouad.WhereYouAd.domains.project.application.dto;
+
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
+
+import java.math.BigDecimal;
+
+public class ProjectQueryDto {
+
+    public record CampaignSummary(
+            Long projectId,
+            Provider provider,
+            Long budget
+    ){}
+
+    public record SpendSummary(
+            Long projectId,
+            BigDecimal totalSpend
+    ){}
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/application/dto/response/ProjectResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/application/dto/response/ProjectResponse.java
@@ -1,9 +1,25 @@
 package com.whereyouad.WhereYouAd.domains.project.application.dto.response;
 
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
+
+import java.util.List;
+
 public class ProjectResponse {
 
     public record CreatedResponse(
             Long projectId,
             String message
     ){}
+
+    public record ProjectListResponse(
+            List<SimpleProjectResponse> projects
+    ) {}
+
+    public record SimpleProjectResponse(
+            Long projectId,
+            String name,
+            String description,
+            List<Provider> providers,
+            Double budgetUsageRate
+    ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/application/mapper/ProjectConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/application/mapper/ProjectConverter.java
@@ -1,12 +1,25 @@
 package com.whereyouad.WhereYouAd.domains.project.application.mapper;
 
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.domains.project.application.dto.response.ProjectResponse;
 import com.whereyouad.WhereYouAd.domains.project.persistence.entity.Project;
+
+import java.util.List;
 
 public class ProjectConverter {
 
     //Entity -> DTO
     public static ProjectResponse.CreatedResponse toCreatedResponse(Project project) {
         return new ProjectResponse.CreatedResponse(project.getId(), "캠페인 그룹 생성이 완료되었습니다.");
+    }
+
+    public static ProjectResponse.SimpleProjectResponse toSimpleProjectResponse(Project project, List<Provider> providers, Double budgetUsageRate)
+    {
+        return new ProjectResponse.SimpleProjectResponse(
+                project.getId(), project.getName(), project.getDescription(), providers, budgetUsageRate);
+    }
+
+    public static ProjectResponse.ProjectListResponse toProjectListResponse(List<ProjectResponse.SimpleProjectResponse> projects) {
+        return new ProjectResponse.ProjectListResponse(projects);
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectService.java
@@ -6,4 +6,6 @@ import com.whereyouad.WhereYouAd.domains.project.application.dto.response.Projec
 public interface ProjectService {
 
     ProjectResponse.CreatedResponse createProject(Long userId, Long orgId, ProjectRequest.CreateRequest request);
+
+    ProjectResponse.ProjectListResponse getProjects(Long userId, Long orgId);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
@@ -1,9 +1,11 @@
 package com.whereyouad.WhereYouAd.domains.project.domain.service;
 
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.domains.advertisement.exception.AdvertisementHandler;
 import com.whereyouad.WhereYouAd.domains.advertisement.exception.code.AdvertisementErrorCode;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdCampaign;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdCampaignRepository;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.MetricFactRepository;
 import com.whereyouad.WhereYouAd.domains.organization.domain.constant.OrgStatus;
 import com.whereyouad.WhereYouAd.domains.organization.exception.code.OrgErrorCode;
 import com.whereyouad.WhereYouAd.domains.organization.exception.handler.OrgHandler;
@@ -11,6 +13,7 @@ import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMemb
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgRepository;
+import com.whereyouad.WhereYouAd.domains.project.application.dto.ProjectQueryDto;
 import com.whereyouad.WhereYouAd.domains.project.application.dto.request.ProjectRequest;
 import com.whereyouad.WhereYouAd.domains.project.application.dto.response.ProjectResponse;
 import com.whereyouad.WhereYouAd.domains.project.application.mapper.ProjectConverter;
@@ -24,9 +27,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -38,6 +42,7 @@ public class ProjectServiceImpl implements ProjectService{
     private final AdCampaignRepository adCampaignRepository;
     private final OrgRepository orgRepository;
     private final OrgMemberRepository orgMemberRepository;
+    private final MetricFactRepository metricFactRepository;
 
     @Override
     public ProjectResponse.CreatedResponse createProject(Long userId, Long orgId,ProjectRequest.CreateRequest request) {
@@ -95,5 +100,99 @@ public class ProjectServiceImpl implements ProjectService{
         }
 
         return ProjectConverter.toCreatedResponse(project);
+    }
+
+    //조직 내 모든 Project 조회 로직
+    public ProjectResponse.ProjectListResponse getProjects(Long userId, Long orgId) {
+
+        //회원 Not Found 예외처리
+        userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(UserErrorCode.USER_NOT_FOUND));
+
+        //조직 Not Found 예외처리
+        Organization organization = orgRepository.findById(orgId)
+                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
+
+        //조직 Soft Delete 상태시 예외
+        if (organization.getStatus() == OrgStatus.DELETED) {
+            throw new OrgHandler(OrgErrorCode.ORG_SOFT_DELETED);
+        }
+
+        Optional<OrgMember> orgMember = orgMemberRepository.findByUserIdAndOrgId(userId, orgId);
+
+        //조직에 속하지 않은 회원의 요청일 시 예외
+        if (orgMember.isEmpty()) {
+            throw new OrgHandler(OrgErrorCode.ORG_MEMBER_NOT_FOUND);
+        }
+
+        // 조직 내 모든 Project 조회
+        List<Project> projects = projectRepository.findByOrganizationId(orgId);
+
+        //조직 내 Project 존재하지 않을 시 빈 리스트로 응답값 반환
+        if (projects.isEmpty()) {
+            return ProjectConverter.toProjectListResponse(Collections.emptyList());
+        }
+
+        // Project ID 리스트 추출
+        List<Long> projectIds = projects.stream()
+                .map(Project::getId)
+                .toList();
+
+        // 캠페인 요약 정보 (Provider, Budget) 조회 및 Map으로 그룹화
+        List<ProjectQueryDto.CampaignSummary> campaignSummaries =
+                adCampaignRepository.findCampaignSummariesByProjectIds(projectIds);
+
+        // projectId -> 해당 프로젝트의 모든 캠페인 요약 정보 리스트
+        Map<Long, List<ProjectQueryDto.CampaignSummary>> campaignMap = campaignSummaries.stream()
+                .collect(Collectors.groupingBy(ProjectQueryDto.CampaignSummary::projectId));
+
+        // 지출 요약 정보 (총 Spend) 조회 및 Map으로 매핑
+        List<ProjectQueryDto.SpendSummary> spendSummaries =
+                metricFactRepository.findSpendSummariesByProjectIds(projectIds);
+
+        // projectId -> 총 지출액(totalSpend)
+        Map<Long, BigDecimal> spendMap = spendSummaries.stream()
+                .collect(Collectors.toMap(
+                        ProjectQueryDto.SpendSummary::projectId,
+                        ProjectQueryDto.SpendSummary::totalSpend
+                ));
+
+        // 최종 응답 DTO 조합
+        List<ProjectResponse.SimpleProjectResponse> responseList = projects.stream().map(project -> {
+            Long projectId = project.getId();
+            List<ProjectQueryDto.CampaignSummary> projectCampaigns = campaignMap.getOrDefault(projectId, Collections.emptyList());
+
+            // Provider 추출 (Set을 사용하여 중복 플랫폼 제거 후 List 변환)
+            List<Provider> distinctProviders = projectCampaigns.stream()
+                    .map(ProjectQueryDto.CampaignSummary::provider)
+                    .distinct() // 중복된 KAKAO, NAVER 등이 있다면 하나만 남김
+                    .toList();
+
+            // 예산 소진 현황 계산
+            // 총 예산 (캠페인 budget의 합)
+            long totalBudget = projectCampaigns.stream()
+                    .mapToLong(summary -> summary.budget() != null ? summary.budget() : 0L)
+                    .sum();
+
+            // 총 지출 (MetricFact spend의 합)
+            BigDecimal totalSpend = spendMap.getOrDefault(projectId, BigDecimal.ZERO);
+
+            // 소진율 계산 (비용 / 예산 * 100)
+            double budgetUsageRate = 0.0;
+            if (totalBudget > 0 && totalSpend != null) {
+                budgetUsageRate = totalSpend
+                        .divide(BigDecimal.valueOf(totalBudget), 4, RoundingMode.HALF_UP) // 소수점 계산
+                        .multiply(BigDecimal.valueOf(100))
+                        .doubleValue();
+
+                // 소수점 첫째 자리까지 반올림
+                budgetUsageRate = Math.round(budgetUsageRate * 10.0) / 10.0;
+            }
+
+            return ProjectConverter.toSimpleProjectResponse(project, distinctProviders, budgetUsageRate);
+
+        }).toList();
+
+        return ProjectConverter.toProjectListResponse(responseList);
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
@@ -162,38 +162,42 @@ public class ProjectServiceImpl implements ProjectService{
             Long projectId = project.getId();
             List<ProjectQueryDto.CampaignSummary> projectCampaigns = campaignMap.getOrDefault(projectId, Collections.emptyList());
 
-            // Provider 추출 (Set을 사용하여 중복 플랫폼 제거 후 List 변환)
+            // Provider 추출
             List<Provider> distinctProviders = projectCampaigns.stream()
                     .map(ProjectQueryDto.CampaignSummary::provider)
-                    .distinct() // 중복된 KAKAO, NAVER 등이 있다면 하나만 남김
+                    .distinct()
                     .sorted(Comparator.comparing(Provider::name))
                     .toList();
-
-            // 예산 소진 현황 계산
-            // 총 예산 (캠페인 budget의 합)
-            long totalBudget = projectCampaigns.stream()
-                    .mapToLong(summary -> summary.budget() != null ? summary.budget() : 0L)
-                    .sum();
 
             // 총 지출 (MetricFact spend의 합)
             BigDecimal totalSpend = spendMap.getOrDefault(projectId, BigDecimal.ZERO);
 
-            // 소진율 계산 (비용 / 예산 * 100)
-            double budgetUsageRate = 0.0;
-            if (totalBudget > 0 && totalSpend != null) {
-                budgetUsageRate = totalSpend
-                        .divide(BigDecimal.valueOf(totalBudget), 4, RoundingMode.HALF_UP) // 소수점 계산
-                        .multiply(BigDecimal.valueOf(100))
-                        .doubleValue();
-
-                // 소수점 첫째 자리까지 반올림
-                budgetUsageRate = Math.round(budgetUsageRate * 10.0) / 10.0;
-            }
+            // 예산 소진 현황 계산 메서드 호출
+            double budgetUsageRate = calculateBudgetUsageRate(projectCampaigns, totalSpend);
 
             return ProjectConverter.toSimpleProjectResponse(project, distinctProviders, budgetUsageRate);
 
         }).toList();
 
         return ProjectConverter.toProjectListResponse(responseList);
+    }
+
+    //예산 소진 현황 계산 메서드
+    private double calculateBudgetUsageRate(List<ProjectQueryDto.CampaignSummary> projectCampaigns, BigDecimal totalSpend) {
+        // 총 예산 (캠페인 budget의 합)
+        long totalBudget = projectCampaigns.stream()
+                .mapToLong(summary -> summary.budget() != null ? summary.budget() : 0L)
+                .sum();
+
+        // 예산이 없거나 지출이 없으면 0.0 반환
+        if (totalBudget <= 0 || totalSpend == null) {
+            return 0.0;
+        }
+
+        // 소진율 계산 (비용 / 예산 * 100), 소수점 첫째 자리 이후로는 버림 처리
+        return totalSpend
+                .multiply(BigDecimal.valueOf(100))
+                .divide(BigDecimal.valueOf(totalBudget), 1, RoundingMode.DOWN)
+                .doubleValue();
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
@@ -166,6 +166,7 @@ public class ProjectServiceImpl implements ProjectService{
             List<Provider> distinctProviders = projectCampaigns.stream()
                     .map(ProjectQueryDto.CampaignSummary::provider)
                     .distinct() // 중복된 KAKAO, NAVER 등이 있다면 하나만 남김
+                    .sorted(Comparator.comparing(Provider::name))
                     .toList();
 
             // 예산 소진 현황 계산

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/presentation/ProjectController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/presentation/ProjectController.java
@@ -33,4 +33,17 @@ public class ProjectController implements ProjectControllerDocs {
         );
     }
 
+    @GetMapping("/{orgId}")
+    public ResponseEntity<DataResponse<ProjectResponse.ProjectListResponse>> getProjects(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId
+    )
+    {
+        ProjectResponse.ProjectListResponse response = projectService.getProjects(userId, orgId);
+
+        return ResponseEntity.ok(
+                DataResponse.from(response)
+        );
+    }
+
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/presentation/docs/ProjectControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/presentation/docs/ProjectControllerDocs.java
@@ -39,7 +39,7 @@ public interface ProjectControllerDocs {
                     "반환 값에는 각 캠페인 그룹의 Id(projectId),  이름, 설명, 해당 캠페인 그룹에서 진행하는 광고 플랫폼들(providers), 예산 소진 현황(budgetUsageRate) 입니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "성공"),
+            @ApiResponse(responseCode = "200", description = "성공"),
             @ApiResponse(responseCode = "404_1", description = "회원 찾을 수 없음"),
             @ApiResponse(responseCode = "404_1", description = "조직 찾을 수 없음"),
             @ApiResponse(responseCode = "404_2", description = "해당 조직에 회원이 속하지 않음"),

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/presentation/docs/ProjectControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/presentation/docs/ProjectControllerDocs.java
@@ -32,4 +32,21 @@ public interface ProjectControllerDocs {
             @PathVariable Long orgId,
             @Valid @RequestBody ProjectRequest.CreateRequest request
     );
+
+    @Operation(
+            summary = "캠페인 그룹 정보 조회 API",
+            description = "캠페인 그룹을 조회하려는 조직 Id 를 받아 해당 조직에 속한 모든 캠페인 그룹 정보를 조회 합니다. \n\n" +
+                    "반환 값에는 각 캠페인 그룹의 Id(projectId),  이름, 설명, 해당 캠페인 그룹에서 진행하는 광고 플랫폼들(providers), 예산 소진 현황(budgetUsageRate) 입니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "성공"),
+            @ApiResponse(responseCode = "404_1", description = "회원 찾을 수 없음"),
+            @ApiResponse(responseCode = "404_1", description = "조직 찾을 수 없음"),
+            @ApiResponse(responseCode = "404_2", description = "해당 조직에 회원이 속하지 않음"),
+            @ApiResponse(responseCode = "410_1", description = "조직 Soft Deleted")
+    })
+    public ResponseEntity<DataResponse<ProjectResponse.ProjectListResponse>> getProjects(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId
+    );
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #63 

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

특정 Organization 내부 모든 Project 조회 API 추가

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- 특정 Organization 내부 모든 Project 정보 조회 로직 추가
- 각 Project 내부 AdCampaign 의 서로 다른 Provider 값 추출 로직 추가
- 각 Project 내부 광고의 예산 소진 현황 퍼센티지로 계산 로직 추가

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.

Mock Data SQL 을 사용하여 DB 에 값을 넣은 상태,
user_id = 1 인 회원으로 로그인 하여 org_id = 1 인 조직의 모든 Project 조회
<img width="1924" height="1367" alt="image" src="https://github.com/user-attachments/assets/6ef0f51a-6ae8-4a89-9e84-832930dc0c8c" />
(기존 Mock data SQL 은 예산 소진 현황이 300% 대로 과도하게 높게 나오는 부분이 있어, MetricFact 쪽 SQL 을 일부 수정해서 소진율이 100 아래로 나오도록 조정했습니다.)

==예외 처리==
1. org_id 에 해당하는 조직 없을 경우 오류
<img width="1913" height="1087" alt="image" src="https://github.com/user-attachments/assets/f6a7a7db-5f2c-4210-b2a6-1fd25a5fc432" />

2. 해당 조직에 회원이 속하지 않을 경우 오류
<img width="1886" height="1071" alt="image" src="https://github.com/user-attachments/assets/88955bf0-b078-44db-889e-28d288eb2bff" />

3. 조직이 Soft Delete 된 경우 오류
<img width="1894" height="1090" alt="image" src="https://github.com/user-attachments/assets/9794c341-7680-4c6c-977b-9b632a9d039d" />


## ✅ 체크리스트
- [✅] 브랜치 전략(GitHub Flow)을 준수했나요?
- [✅] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [✅] 테스트 통과 확인
- [✅] 서버 실행 확인
- [✅] API 동작 확인
- 
---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- 커밋 메세지를 "Organization 내부 Project 조회" 라고 해야하는데 실수로 "Project 내부 AdCampaign 조회" 로 했습니다. 죄송합니다ㅠㅠ
- 해당 Project 들을 조회하는 것에도 Cursor 를 써서 무한 스크롤을 구현하는게 좋을까요?
- 각각의 Project 마다 진행하는 광고의 서로다른 Provider 를 추출하는 로직과, 예산 소진 현황을 계산하는 로직이 진행할 때 좀 헷갈렸어서 이 부분들 로직이 맞는지 봐주시면 좋을 것 같습니다!

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 조직별 프로젝트 목록 조회 API(/api/project/{orgId})가 추가되었습니다.
  * 각 프로젝트에 대해 캠페인 제공자 목록, 집계된 지출 합계 및 프로젝트별 예산 사용률이 함께 제공됩니다.
  * 프로젝트 응답 형식에 간단한 프로젝트 요약 목록이 도입되었습니다.

* **문서**
  * 새 프로젝트 조회 API에 대한 OpenAPI 설명과 응답/에러 문서가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->