### PR TITLE
Feat/#66 Soft Delete 된 조직 조회 API

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
@@ -11,6 +11,8 @@ public interface OrgService {
 
     OrgResponse.OrgDetail getOrganizationDetail(Long orgId);
 
+    OrgResponse.MyOrganizations getSoftDeletedOrgs(Long userId);
+
     OrgResponse.Update modifyOrganization(Long userId, Long orgId, OrgRequest.Update request);
 
     void removeOrganization(Long userId, Long orgId);

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -22,9 +22,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
+import java.util.*;
 
 @Service
 @Transactional
@@ -94,6 +92,26 @@ public class OrgServiceImpl implements OrgService {
 
         //DTO 로 변환
         return OrgConverter.toOrgDetail(organization);
+    }
+
+    public OrgResponse.MyOrganizations getSoftDeletedOrgs(Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(UserErrorCode.USER_NOT_FOUND));
+
+        //userId 일치하고, Organization 의 status 가 DELETED 인 OrgMember 만 조회
+        List<OrgMember> orgMembers = orgMemberRepository.findOrgMemberByUserIdSoftDeleted(userId);
+
+        //Soft Deleted 된 조직 없으면 빈 리스트 반환
+        if (orgMembers.isEmpty()) {
+            return OrgConverter.toMyOrganizations(Collections.emptyList());
+        }
+
+        //각각의 OrgMember 에서 SimpleInfo DTO 로 매핑
+        List<OrgResponse.SimpleInfo> infos = orgMembers.stream()
+                .map(OrgConverter::toOrgSimpleInfo)
+                .toList();
+
+        return OrgConverter.toMyOrganizations(infos);
     }
 
     // 조직 정보 수정 메서드

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
@@ -23,8 +23,8 @@ public interface OrgMemberRepository extends JpaRepository<OrgMember, Long> {
     @Query(value = "select om from OrgMember om join fetch om.organization o where om.user.id = :userId and o.status = 'ACTIVE'")
     List<OrgMember> findOrgMemberByUserId(@Param("userId") Long userId);
 
-    //userId 를 통해 OrgMember 추출 -> Organization 의 status 가 DELETED 인 경우에만 조회
-    @Query(value = "select om from OrgMember om join fetch om.organization o where om.user.id = :userId and o.status = 'DELETED'")
+    //userId 를 통해 OrgMember 추출 -> Organization 의 status 가 DELETED 이고, ownerUserId 가 userId 와 일치하는 경우에만 조회
+    @Query(value = "select om from OrgMember om join fetch om.organization o where om.user.id = :userId and o.status = 'DELETED' and om.organization.ownerUserId = :userId")
     List<OrgMember> findOrgMemberByUserIdSoftDeleted(@Param("userId") Long userId);
 
     //특정 Organization 에 속한 OrgMember 모두 추출하는 메서드

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
@@ -23,6 +23,10 @@ public interface OrgMemberRepository extends JpaRepository<OrgMember, Long> {
     @Query(value = "select om from OrgMember om join fetch om.organization o where om.user.id = :userId and o.status = 'ACTIVE'")
     List<OrgMember> findOrgMemberByUserId(@Param("userId") Long userId);
 
+    //userId 를 통해 OrgMember 추출 -> Organization 의 status 가 DELETED 인 경우에만 조회
+    @Query(value = "select om from OrgMember om join fetch om.organization o where om.user.id = :userId and o.status = 'DELETED'")
+    List<OrgMember> findOrgMemberByUserIdSoftDeleted(@Param("userId") Long userId);
+
     //특정 Organization 에 속한 OrgMember 모두 추출하는 메서드
     @Query("select om from OrgMember om where om.organization = :organization")
     List<OrgMember> findOrgMemberByOrg(@Param(value = "organization") Organization organization);

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
@@ -53,6 +53,18 @@ public class OrgController implements OrgControllerDocs {
         );
     }
 
+    @GetMapping("/deleted")
+    public ResponseEntity<DataResponse<OrgResponse.MyOrganizations>> getSoftDeletedOrganizations(
+            @AuthenticationPrincipal(expression = "userId") Long userId
+    )
+    {
+        OrgResponse.MyOrganizations response = orgService.getSoftDeletedOrgs(userId);
+
+        return ResponseEntity.ok(
+                DataResponse.from(response)
+        );
+    }
+
 
     @PatchMapping("/{orgId}")
     public ResponseEntity<DataResponse<OrgResponse.Update>> modifyOrganization(

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
@@ -45,6 +45,17 @@ public interface OrgControllerDocs {
     })
     public ResponseEntity<DataResponse<OrgResponse.OrgDetail>> getOrganizationDetail(@PathVariable Long orgId);
 
+    @Operation(
+            summary = "회원이 만든 조직 중 Soft Deleted 된 조직 목록 조회",
+            description = "해당 회원이 만든 조직 중 status 가 DELETED 인 조직만을 조회합니다. Soft Delete 된 조직 복구를 위해 사용 가능한 API 입니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "404_1", description = "회원 존재 X")
+    })
+    public ResponseEntity<DataResponse<OrgResponse.MyOrganizations>> getSoftDeletedOrganizations(
+            @AuthenticationPrincipal(expression = "userId") Long userId
+    );
 
     @Operation(
             summary = "조직 정보 수정 API",


### PR DESCRIPTION
## 📌 관련 이슈
- Close #66 

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

회원이 만든 조직들 중 status 가 DELETED 인(Soft Delete) 조직 조회 API 추가

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- 회원이 만든 조직들 중 status 가 DELETED 인(Soft Delete) 조직 조회 API 추가
- 회원이 만든 조직인 경우에만 (Organization 에서 ownerUserId 가 AccessToken 에서 추출한 userId 와 일치하는 경우에만) 조회 가능하도록 로직 구성

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.

DB 상태 : userId = 1 인 회원이 만든 조직 중 org_id = 2, org_id = 3 인 조직이 Soft Delete 된 상태
<img width="1316" height="306" alt="image" src="https://github.com/user-attachments/assets/7b04dfdc-8307-48df-bdfb-029f27c53015" />

회원 로그인하여 Soft Delete 된 조직 조회
<img width="1903" height="1306" alt="image" src="https://github.com/user-attachments/assets/d2da7bdf-f0b5-454b-8e36-77c61e874f74" />

userId = 1 인 회원은 org_id = 4 인 조직에 MEMBER 로 포함된 상태
<img width="653" height="247" alt="image" src="https://github.com/user-attachments/assets/f849c8fa-8a02-4d64-baed-a2bd02abb479" />

org_id = 4 인 조직을 DELETED 로 바꿔도 조직 생성자가 아니기 때문에 조회 되지 않음
<img width="1328" height="299" alt="image" src="https://github.com/user-attachments/assets/a96c4b14-dd8a-4fee-b9bb-ed8e03686649" />
<img width="1917" height="1322" alt="image" src="https://github.com/user-attachments/assets/42484c09-b177-4bd5-a4ff-473c64a209c1" />

## ✅ 체크리스트
- [✅] 브랜치 전략(GitHub Flow)을 준수했나요?
- [✅] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [✅] 테스트 통과 확인
- [✅] 서버 실행 확인
- [✅] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- 노션에 API 명세서 정리하다보니 Soft Delete 된 조직을 복구하기 위해 Soft Delete 된 조직 목록을 반환해주는 API 가 있어야 할 것 같아 추가했습니다.
- DTO는 기존 "내가 속한 조직 조회 API" 에서 쓰던 응답 DTO 를 활용했습니다.
- 이 이후에 Project 엔티티 생성 API 에 추가로 필요한 "조직 내 Project 에 연관되어 있지 않은 AdCampaign 엔티티를 Provider 별로 조회하는 API" 를 추가할 것 같습니다.

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

* 삭제된 조직 조회 기능 추가 - 사용자가 이전에 삭제한 자신의 조직 목록을 새로운 API를 통해 조회할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->