### PR TITLE
Feat/#62 캠페인 및 광고 상태 중단 및 재개 구현

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/AdvertisementCommandService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/AdvertisementCommandService.java
@@ -1,0 +1,9 @@
+package com.whereyouad.WhereYouAd.domains.advertisement.domain.service;
+
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
+
+public interface AdvertisementCommandService {
+    void updateProjectStatus(Long userId, Long orgId, Long projectId, Status status);
+
+    void updateAdContentStatus(Long userId, Long orgId, Long projectId, Long adContentId, Status status);
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/AdvertisementCommandServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/AdvertisementCommandServiceImpl.java
@@ -1,0 +1,87 @@
+package com.whereyouad.WhereYouAd.domains.advertisement.domain.service;
+
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
+import com.whereyouad.WhereYouAd.domains.advertisement.exception.AdvertisementHandler;
+import com.whereyouad.WhereYouAd.domains.advertisement.exception.code.AdvertisementErrorCode;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdContent;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdCampaignRepository;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdContentRepository;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdGroupRepository;
+import com.whereyouad.WhereYouAd.domains.organization.domain.constant.OrgStatus;
+import com.whereyouad.WhereYouAd.domains.organization.exception.code.OrgErrorCode;
+import com.whereyouad.WhereYouAd.domains.organization.exception.handler.OrgHandler;
+import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMember;
+import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
+import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
+import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgRepository;
+import com.whereyouad.WhereYouAd.domains.project.exception.ProjectHandler;
+import com.whereyouad.WhereYouAd.domains.project.exception.code.ProjectErrorCode;
+import com.whereyouad.WhereYouAd.domains.project.persistence.entity.Project;
+import com.whereyouad.WhereYouAd.domains.project.persistence.repository.ProjectRepository;
+import com.whereyouad.WhereYouAd.domains.user.exception.code.UserErrorCode;
+import com.whereyouad.WhereYouAd.domains.user.exception.handler.UserHandler;
+import com.whereyouad.WhereYouAd.domains.user.persistence.repository.UserRepository;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class AdvertisementCommandServiceImpl implements AdvertisementCommandService {
+
+    private final UserRepository userRepository;
+    private final OrgRepository orgRepository;
+    private final OrgMemberRepository orgMemberRepository;
+    private final ProjectRepository projectRepository;
+    private final AdCampaignRepository adCampaignRepository;
+    private final AdGroupRepository adGroupRepository;
+    private final AdContentRepository adContentRepository;
+
+    private void validateUserAndOrg(Long userId, Long orgId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(UserErrorCode.USER_NOT_FOUND));
+
+        Organization organization = orgRepository.findById(orgId)
+                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
+
+        if (organization.getStatus() == OrgStatus.DELETED) {
+            throw new OrgHandler(OrgErrorCode.ORG_SOFT_DELETED);
+        }
+
+        Optional<OrgMember> orgMember = orgMemberRepository.findByUserIdAndOrgId(userId, orgId);
+        if (orgMember.isEmpty()) {
+            throw new OrgHandler(OrgErrorCode.ORG_MEMBER_NOT_FOUND);
+        }
+    }
+
+    @Override
+    public void updateProjectStatus(Long userId, Long orgId, Long projectId, Status status) {
+        validateUserAndOrg(userId, orgId);
+
+        // 프로젝트 검증 및 권한 확인
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ProjectHandler(ProjectErrorCode.PROJECT_NOT_FOUND));
+
+        if (!project.getOrganization().getId().equals(orgId)) {
+            throw new ProjectHandler(ProjectErrorCode.ACCESS_FORBIDDEN);
+        }
+
+        adCampaignRepository.updateStatusByProjectId(projectId, status);
+        adGroupRepository.updateStatusByProjectId(projectId, status);
+        adContentRepository.updateStatusByProjectId(projectId, status);
+    }
+
+    @Override
+    public void updateAdContentStatus(Long userId, Long orgId, Long projectId, Long adContentId, Status status) {
+        validateUserAndOrg(userId, orgId);
+
+        AdContent adContent = adContentRepository.findByIdWithValidation(adContentId, projectId, orgId)
+                .orElseThrow(() -> new AdvertisementHandler(AdvertisementErrorCode.ADCONTENT_NOT_FOUND));
+
+        adContent.updateStatus(status);
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdContent.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdContent.java
@@ -35,11 +35,8 @@ public class AdContent extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ad_group_id")
     private AdGroup adGroup;
-    // @Enumerated(EnumType.STRING)
-    // @Column(name = "provider", nullable = false)
-    // private Provider provider;
 
-    // private LocalDateTime startDate;
-    //
-    // private LocalDateTime endDate;
+    public void updateStatus(Status status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdCampaignRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdCampaignRepository.java
@@ -6,6 +6,7 @@ import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdCamp
 import com.whereyouad.WhereYouAd.domains.dashboard.application.dto.response.DashboardResponse;
 import com.whereyouad.WhereYouAd.domains.project.application.dto.ProjectQueryDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -45,4 +46,11 @@ public interface AdCampaignRepository extends JpaRepository<AdCampaign, Long> {
             "FROM AdCampaign c WHERE c.project.id IN :projectIds")
     List<ProjectQueryDto.CampaignSummary> findCampaignSummariesByProjectIds(@Param("projectIds") List<Long> projectIds);
 
+    @Modifying
+    @Query("UPDATE AdCampaign a SET a.status = :status WHERE a.project.id = :projectId")
+    void updateStatusByProjectId(@Param("projectId") Long projectId, @Param("status") Status status);
+
+    @Modifying
+    @Query("UPDATE AdCampaign a SET a.status = :status WHERE a.project.organization.id = :orgId")
+    void updateStatusByOrganizationId(@Param("orgId") Long orgId, @Param("status") Status status);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdContentRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdContentRepository.java
@@ -2,33 +2,43 @@ package com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository;
 
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdContent;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface AdContentRepository extends JpaRepository<AdContent, Long> {
 
-    @Query("SELECT ac FROM AdContent ac " +
-            "JOIN FETCH ac.adGroup ag " +
-            "JOIN ag.adCampaign c " +
-            "JOIN c.project p " +
-            "JOIN p.organization o " +
-            "WHERE ac.id = :adContentId " +
-            "AND p.id = :projectId " +
-            "AND o.id = :orgId")
-    Optional<AdContent> findByIdWithValidation(
-            @Param("adContentId") Long adContentId,
-            @Param("projectId") Long projectId,
-            @Param("orgId") Long orgId);
+        @Query("SELECT ac FROM AdContent ac " +
+                        "JOIN FETCH ac.adGroup ag " +
+                        "JOIN ag.adCampaign c " +
+                        "JOIN c.project p " +
+                        "JOIN p.organization o " +
+                        "WHERE ac.id = :adContentId " +
+                        "AND p.id = :projectId " +
+                        "AND o.id = :orgId")
+        Optional<AdContent> findByIdWithValidation(
+                        @Param("adContentId") Long adContentId,
+                        @Param("projectId") Long projectId,
+                        @Param("orgId") Long orgId);
 
-    @Query("SELECT ac FROM AdContent ac " +
-            "JOIN FETCH ac.adGroup ag " +
-            "JOIN ag.adCampaign c " +
-            "JOIN c.project p " +
-            "JOIN p.organization o " +
-            "WHERE p.id = :projectId " +
-            "AND o.id = :orgId")
-    List<AdContent> findAllByIdWithValidation(@Param("projectId") Long projectId, @Param("orgId") Long orgId);
+        @Query("SELECT ac FROM AdContent ac " +
+                        "JOIN FETCH ac.adGroup ag " +
+                        "JOIN ag.adCampaign c " +
+                        "JOIN c.project p " +
+                        "JOIN p.organization o " +
+                        "WHERE p.id = :projectId " +
+                        "AND o.id = :orgId")
+        List<AdContent> findAllByIdWithValidation(@Param("projectId") Long projectId, @Param("orgId") Long orgId);
+
+        @Modifying
+        @Query("UPDATE AdContent a SET a.status = :status WHERE a.adGroup.adCampaign.project.id = :projectId")
+        void updateStatusByProjectId(@Param("projectId") Long projectId, @Param("status") Status status);
+
+        @Modifying
+        @Query("UPDATE AdContent a SET a.status = :status WHERE a.adGroup.adCampaign.project.organization.id = :orgId")
+        void updateStatusByOrganizationId(@Param("orgId") Long orgId, @Param("status") Status status);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdGroupRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdGroupRepository.java
@@ -1,7 +1,19 @@
 package com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository;
 
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdGroup;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AdGroupRepository extends JpaRepository<AdGroup, Long> {
+
+    @Modifying
+    @Query("UPDATE AdGroup a SET a.status = :status WHERE a.adCampaign.project.id = :projectId")
+    void updateStatusByProjectId(@Param("projectId") Long projectId, @Param("status") Status status);
+
+    @Modifying
+    @Query("UPDATE AdGroup a SET a.status = :status WHERE a.adCampaign.project.organization.id = :orgId")
+    void updateStatusByOrganizationId(@Param("orgId") Long orgId, @Param("status") Status status);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/AdvertisementController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/AdvertisementController.java
@@ -2,6 +2,8 @@ package com.whereyouad.WhereYouAd.domains.advertisement.presentation;
 
 import com.whereyouad.WhereYouAd.domains.advertisement.application.dto.response.AdvertisementResponse;
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.service.AdvertisementQueryService;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.service.AdvertisementCommandService;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
 import com.whereyouad.WhereYouAd.domains.advertisement.presentation.docs.AdvertisementControllerDocs;
 import com.whereyouad.WhereYouAd.global.response.DataResponse;
 import lombok.AccessLevel;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class AdvertisementController implements AdvertisementControllerDocs {
 
     private final AdvertisementQueryService advertisementQueryService;
+    private final AdvertisementCommandService advertisementCommandService;
 
     // AdContent - 개별 광고 상세 조회
     @GetMapping("/{orgId}/projects/{projectId}/ad-contents/{adContentId}")
@@ -42,7 +45,29 @@ public class AdvertisementController implements AdvertisementControllerDocs {
     public ResponseEntity<DataResponse<AdvertisementResponse.AdGroupInfoResponse>> readAdGroup(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId, @PathVariable Long projectId, @PathVariable Long adContentId) {
-        AdvertisementResponse.AdGroupInfoResponse adGroupInfoResponse = advertisementQueryService.readAdGroup(userId, orgId, projectId, adContentId);
+        AdvertisementResponse.AdGroupInfoResponse adGroupInfoResponse = advertisementQueryService.readAdGroup(userId,
+                orgId, projectId, adContentId);
         return ResponseEntity.ok(DataResponse.from(adGroupInfoResponse));
     }
+
+    // Project - 단일 프로젝트(캠페인) 전체 중단/재개
+    @PatchMapping("/{orgId}/projects/{projectId}/status")
+    public ResponseEntity<DataResponse<Void>> updateProjectStatus(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId, @PathVariable Long projectId,
+            @RequestParam Status status) {
+        advertisementCommandService.updateProjectStatus(userId, orgId, projectId, status);
+        return ResponseEntity.ok(DataResponse.ok());
+    }
+
+    // AdContent - 개별 광고 중단/재개
+    @PatchMapping("/{orgId}/projects/{projectId}/ad-contents/{adContentId}/status")
+    public ResponseEntity<DataResponse<Void>> updateAdContentStatus(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId, @PathVariable Long projectId, @PathVariable Long adContentId,
+            @RequestParam Status status) {
+        advertisementCommandService.updateAdContentStatus(userId, orgId, projectId, adContentId, status);
+        return ResponseEntity.ok(DataResponse.ok());
+    }
+
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/AdvertisementControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/AdvertisementControllerDocs.java
@@ -1,6 +1,7 @@
 package com.whereyouad.WhereYouAd.domains.advertisement.presentation.docs;
 
 import com.whereyouad.WhereYouAd.domains.advertisement.application.dto.response.AdvertisementResponse;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
 import com.whereyouad.WhereYouAd.global.response.DataResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 public interface AdvertisementControllerDocs {
 
@@ -38,4 +40,24 @@ public interface AdvertisementControllerDocs {
                         @AuthenticationPrincipal(expression = "userId") Long userId,
                         @PathVariable Long orgId, @PathVariable Long projectId, @PathVariable Long adContentId);
 
+        @Operation(summary = "단일 프로젝트(캠페인) 전체 중단/재개", description = "특정 프로젝트에 속한 모든 광고(AdCampaign, AdGroup, AdContent)의 상태를 일괄적으로 중단(PAUSED) 시키거나 재개(ON_GOING)합니다.")
+        @ApiResponses({
+                        @ApiResponse(responseCode = "200", description = "성공"),
+                        @ApiResponse(responseCode = "403", description = "AD_403_1: 해당 프로젝트에 대한 접근 권한이 없습니다."),
+                        @ApiResponse(responseCode = "404", description = "ORG_404_2: 해당 멤버가 조직에 존재하지 않습니다.<br>AD_404_1: 해당 프로젝트가 존재하지 않음")
+        })
+        ResponseEntity<DataResponse<Void>> updateProjectStatus(
+                        @AuthenticationPrincipal(expression = "userId") Long userId,
+                        @PathVariable Long orgId, @PathVariable Long projectId,
+                        @RequestParam Status status);
+
+        @Operation(summary = "개별 광고 중단/재개", description = "특정 개별 광고 콘텐츠(AdContent)의 상태를 중단(PAUSED) 시키거나 재개(ON_GOING)합니다.")
+        @ApiResponses({
+                        @ApiResponse(responseCode = "200", description = "성공"),
+                        @ApiResponse(responseCode = "404", description = "ORG_404_2: 해당 멤버가 조직에 존재하지 않습니다.<br>AD_404_3: 해당 광고가 존재하지 않음")
+        })
+        ResponseEntity<DataResponse<Void>> updateAdContentStatus(
+                        @AuthenticationPrincipal(expression = "userId") Long userId,
+                        @PathVariable Long orgId, @PathVariable Long projectId, @PathVariable Long adContentId,
+                        @RequestParam Status status);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectService.java
@@ -2,10 +2,13 @@ package com.whereyouad.WhereYouAd.domains.project.domain.service;
 
 import com.whereyouad.WhereYouAd.domains.project.application.dto.request.ProjectRequest;
 import com.whereyouad.WhereYouAd.domains.project.application.dto.response.ProjectResponse;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
 
 public interface ProjectService {
 
     ProjectResponse.CreatedResponse createProject(Long userId, Long orgId, ProjectRequest.CreateRequest request);
 
     ProjectResponse.ProjectListResponse getProjects(Long userId, Long orgId);
+
+    void updateAllProjectsStatus(Long userId, Long orgId, Status status);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
@@ -5,7 +5,10 @@ import com.whereyouad.WhereYouAd.domains.advertisement.exception.AdvertisementHa
 import com.whereyouad.WhereYouAd.domains.advertisement.exception.code.AdvertisementErrorCode;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdCampaign;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdCampaignRepository;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdGroupRepository;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdContentRepository;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.MetricFactRepository;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
 import com.whereyouad.WhereYouAd.domains.organization.domain.constant.OrgStatus;
 import com.whereyouad.WhereYouAd.domains.organization.exception.code.OrgErrorCode;
 import com.whereyouad.WhereYouAd.domains.organization.exception.handler.OrgHandler;
@@ -35,11 +38,13 @@ import java.util.stream.Collectors;
 @Service
 @Transactional
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-public class ProjectServiceImpl implements ProjectService{
+public class ProjectServiceImpl implements ProjectService {
 
     private final ProjectRepository projectRepository;
     private final UserRepository userRepository;
     private final AdCampaignRepository adCampaignRepository;
+    private final AdGroupRepository adGroupRepository;
+    private final AdContentRepository adContentRepository;
     private final OrgRepository orgRepository;
     private final OrgMemberRepository orgMemberRepository;
     private final MetricFactRepository metricFactRepository;
@@ -199,5 +204,27 @@ public class ProjectServiceImpl implements ProjectService{
                 .multiply(BigDecimal.valueOf(100))
                 .divide(BigDecimal.valueOf(totalBudget), 1, RoundingMode.DOWN)
                 .doubleValue();
+    }
+
+    @Override
+    public void updateAllProjectsStatus(Long userId, Long orgId, Status status) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(UserErrorCode.USER_NOT_FOUND));
+
+        Organization organization = orgRepository.findById(orgId)
+                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
+
+        if (organization.getStatus() == OrgStatus.DELETED) {
+            throw new OrgHandler(OrgErrorCode.ORG_SOFT_DELETED);
+        }
+
+        Optional<OrgMember> orgMember = orgMemberRepository.findByUserIdAndOrgId(userId, orgId);
+        if (orgMember.isEmpty()) {
+            throw new OrgHandler(OrgErrorCode.ORG_MEMBER_NOT_FOUND);
+        }
+
+        adCampaignRepository.updateStatusByOrganizationId(orgId, status);
+        adGroupRepository.updateStatusByOrganizationId(orgId, status);
+        adContentRepository.updateStatusByOrganizationId(orgId, status);
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/presentation/ProjectController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/presentation/ProjectController.java
@@ -4,6 +4,7 @@ import com.whereyouad.WhereYouAd.domains.project.application.dto.request.Project
 import com.whereyouad.WhereYouAd.domains.project.application.dto.response.ProjectResponse;
 import com.whereyouad.WhereYouAd.domains.project.domain.service.ProjectService;
 import com.whereyouad.WhereYouAd.domains.project.presentation.docs.ProjectControllerDocs;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
 import com.whereyouad.WhereYouAd.global.response.DataResponse;
 import jakarta.validation.Valid;
 import lombok.AccessLevel;
@@ -41,9 +42,17 @@ public class ProjectController implements ProjectControllerDocs {
     {
         ProjectResponse.ProjectListResponse response = projectService.getProjects(userId, orgId);
 
-        return ResponseEntity.ok(
-                DataResponse.from(response)
-        );
-    }
+                return ResponseEntity.ok(
+                                DataResponse.from(response));
+        }
+
+        @PatchMapping("/{orgId}/status")
+        public ResponseEntity<DataResponse<Void>> updateAllProjectsStatus(
+                        @AuthenticationPrincipal(expression = "userId") Long userId,
+                        @PathVariable Long orgId,
+                        @RequestParam Status status) {
+                projectService.updateAllProjectsStatus(userId, orgId, status);
+                return ResponseEntity.ok(DataResponse.ok());
+        }
 
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/presentation/docs/ProjectControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/presentation/docs/ProjectControllerDocs.java
@@ -2,6 +2,7 @@ package com.whereyouad.WhereYouAd.domains.project.presentation.docs;
 
 import com.whereyouad.WhereYouAd.domains.project.application.dto.request.ProjectRequest;
 import com.whereyouad.WhereYouAd.domains.project.application.dto.response.ProjectResponse;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
 import com.whereyouad.WhereYouAd.global.response.DataResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -11,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 public interface ProjectControllerDocs {
 
@@ -49,4 +51,17 @@ public interface ProjectControllerDocs {
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId
     );
+
+    @Operation(summary = "전체 프로젝트 중단/재개 API", description = "특정 조직에 속한 모든 프로젝트 및 그 하위의 모든 광고 그룹과 콘텐츠 상태를 일괄 중단(PAUSED) 하거나 재개(ON_GOING) 합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "404_1", description = "회원 찾을 수 없음"),
+            @ApiResponse(responseCode = "404_1", description = "조직 찾을 수 없음"),
+            @ApiResponse(responseCode = "404_2", description = "해당 조직에 회원이 속하지 않음"),
+            @ApiResponse(responseCode = "410_1", description = "조직 Soft Deleted")
+    })
+    public ResponseEntity<DataResponse<Void>> updateAllProjectsStatus(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId,
+            @RequestParam Status status);
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #62

## 🚀 개요
피그마 화면에 따라, 전체 캠페인, 특정 캠페인, 특정 광고의 상태를 중단하거나 재개할 수 있도록 수정하는 API를 구현하였습니다.
<img width="500" height="878" alt="image" src="https://github.com/user-attachments/assets/9dfb628d-e874-4572-8f5b-69c8fb837af4" />
<img width="500" height="1318" alt="image" src="https://github.com/user-attachments/assets/a44b8d25-7585-4ece-b351-fd7b3f2c7203" />

## 📄 작업 내용
### 특정 AdContent 상태 변경
<img width="800" height="858" alt="image" src="https://github.com/user-attachments/assets/f0d6828e-d382-41be-ac94-6a663e219535" />
<img width="800" height="474" alt="image" src="https://github.com/user-attachments/assets/c748a5bd-7b41-4ceb-a29c-0ee99ba375e1" />

### 특정 Project 상태 변경
관련 캠페인, 그룹, 광고의 상태가 모두 변경됩니다.
<img width="800" height="772" alt="image" src="https://github.com/user-attachments/assets/7c66791e-46f0-48b2-8837-78e145f4e249" />
<img width="800" height="1408" alt="image" src="https://github.com/user-attachments/assets/5d044c42-9419-4824-930d-15b99cfb8a00" />

### 모든 Project 상태 변경
조직 내 모든 프로젝트의 상태가 모두 변경됩니다.
<img width="800" height="610" alt="image" src="https://github.com/user-attachments/assets/3484e114-b4f1-4101-bbcd-59e713486bd5" />
<img width="800" height="965" alt="image" src="https://github.com/user-attachments/assets/f10e75ee-94e6-4224-a268-89e530d5c422" />


## 📸 스크린샷 / 테스트 결과 (선택)
status 쿼리 파라미터에 ON_GOING을 선택하면 다시 광고가 재개됩니다.
<img width="1409" height="338" alt="image" src="https://github.com/user-attachments/assets/80d9d428-dff5-4037-8c6d-ecf3816eb086" />

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
현재는 프로젝트 상태 변경 API에서, 프로젝트(캠페인 세트)를 중단 시키면 연관된 캠페인, 그룹, 광고 모두 쿼리를 통해 일괄적으로 status가 변경되는 식입니다.
하지만 추후 광고 플랫폼 연동 시에는 캠페인 중단 API를 사용하기에 직접 전부 일일이 중단 시키지 않고(하위 DB를 강제로 덮어쓰지 않고) 최상위 뎁스인 Project에 status를 두어 관리하도록 구조를 고도화하려는데 어떻게 생각하시나요..? 실제 API도 모든 걸 일일이 중단시키는 게 아니라 캠페인 또는 개별 광고 중단 API를 한번만 호출하기도 하고, 조금 복잡하지만 (ex. 하위 계층(그룹, 광고)의 상태는 ON_GOING이더라도 화면에는 PAUSED로 보이게끔 쿼리를 짜기) 나중에 다시 Project를 재개하여도 개별 광고가 원래 가지고 있던 상태를 잃어버리지 않아 고객 입장에서 더 좋다고 하네요..!

> 💬 리뷰어 가이드 (P-Rules) 
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 광고 콘텐츠 상태 관리 기능 추가 - 개별 광고 콘텐츠의 상태를 선택적으로 업데이트할 수 있습니다.
* 프로젝트 내 광고 일괄 관리 기능 추가 - 특정 프로젝트에 포함된 모든 광고의 상태를 한 번에 변경할 수 있습니다.
* 조직 전체 프로젝트 상태 관리 기능 추가 - 조직에 속한 모든 프로젝트의 상태를 중앙에서 통합으로 관리하고 업데이트할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->