### PR TITLE
:sparkles: feat: ClickLog 엔티티 코드 작성

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/persistence/entity/ClickLog.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/persistence/entity/ClickLog.java
@@ -1,0 +1,37 @@
+package com.whereyouad.WhereYouAd.domains.click.persistence.entity;
+
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdContent;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "click_log")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class ClickLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "click_log_id")
+    private Long id;
+
+    @Column(name = "ip_address", length = 45)
+    private String ipAddress;
+
+    @Column(name = "device", length = 512)
+    private String device;
+
+    @Column(name = "clicked_at", nullable = false)
+    private LocalDateTime clickedAt;
+
+    @Column(name = "is_suspect", nullable = false)
+    private Boolean isSuspect;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ad_content_id", nullable = false)
+    private AdContent adContent;
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/global/security/SecurityConfig.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/security/SecurityConfig.java
@@ -72,7 +72,11 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
-        config.setAllowedOrigins(Arrays.asList("http://localhost:5173")); //프론트 로컬 주소 허용
+        config.setAllowedOrigins(Arrays.asList(
+                "http://localhost:5173",           // 프론트 로컬 주소
+                "http://localhost:3000",           // 프론트 로컬 주소 (대안)
+                "http://52.79.171.160:8080"        // 배포 서버 주소 (Swagger UI 등)
+        ));
 
         config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
 


### PR DESCRIPTION
## 📌 관련 이슈
- Close #74

## 🚀 개요
ERD에 ClickLog(실시간 클릭수) 스키마를 작성하고, ClickLog 엔티티 코드를 작성하였습니다.

## 📄 작업 내용
- Erd Cloud에 ClickLog(실시간 클릭수) 스키마를 작성
- ClickLog 엔티티 코드 작성
- (기타) SecurityConfig에 배포 서버 CORS 설정 추가: CORS 허용에 추가 하지 않았어서 배포 서버 Swagger에서 로그인이 안 되고 있어 해당 설정을 추가함.
<img width="387" height="113" alt="image" src="https://github.com/user-attachments/assets/2a31a3ec-3d8e-42d4-bc7c-c29f0b1cf51a" />

## 📸 스크린샷 / 테스트 결과 (선택)
### ClickLog 스키마
<img width="603" height="195" alt="image" src="https://github.com/user-attachments/assets/b9a68b79-36b8-44ff-95bc-f4a1ea2509b8" />

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
이슈 작업 단위를 작게 나눠두어, PR을 바로 올렸습니다..!
현재 MetricFact의 clicks는 원래 광고 플랫폼에서 전달 받을 일정 기간동안의 클릭수인데, 추후 작업에서 이 clicks 값을 특정 기간동안 ClickLog를 집계한 값으로 반영할지 고민이네요.. 일단 이 방향으로 진행하고 광고 플랫폼 연동 시 API로 전달 받은 값을 가져오도록 할까요?

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항

* 플랫폼의 클릭 추적 기능을 지원하기 위한 백엔드 데이터 저장소 기반 시설을 추가했습니다
* 다양한 개발 및 배포 환경에서 애플리케이션이 원활하게 작동할 수 있도록 호환성 설정을 확대했습니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->