### PR TITLE
Feat/#68 Organization 내부 Project 연동되지 않은 AdCampaign 조회 API 

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/application/dto/response/AdvertisementResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/application/dto/response/AdvertisementResponse.java
@@ -24,4 +24,14 @@ public class AdvertisementResponse {
             String targetInfo,
             Status status
     ) {}
+
+    public record AdCampaignListResponse(
+            List<AdCampaignSimpleResponse> adCampaigns
+    ) {}
+
+    public record AdCampaignSimpleResponse(
+            Long adCampaignId,
+            String name,
+            String description
+    ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/application/mapper/AdvertisementConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/application/mapper/AdvertisementConverter.java
@@ -1,6 +1,7 @@
 package com.whereyouad.WhereYouAd.domains.advertisement.application.mapper;
 
 import com.whereyouad.WhereYouAd.domains.advertisement.application.dto.response.AdvertisementResponse;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdCampaign;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdContent;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdGroup;
 
@@ -23,5 +24,14 @@ public class AdvertisementConverter {
     public static AdvertisementResponse.AdGroupInfoResponse toAdGroupInfo(AdGroup adGroup) {
         return new AdvertisementResponse.AdGroupInfoResponse(
                 adGroup.getId(), adGroup.getName(), adGroup.getTargetingInfo(), adGroup.getStatus());
+    }
+
+    public static AdvertisementResponse.AdCampaignSimpleResponse toAdCampaignSimple(AdCampaign adCampaign) {
+        return new AdvertisementResponse.AdCampaignSimpleResponse(
+                adCampaign.getId(), adCampaign.getName(), adCampaign.getDescription());
+    }
+
+    public static AdvertisementResponse.AdCampaignListResponse toAdCampaignList(List<AdvertisementResponse.AdCampaignSimpleResponse> simpleResponses) {
+        return new AdvertisementResponse.AdCampaignListResponse(simpleResponses);
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/AdvertisementQueryService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/AdvertisementQueryService.java
@@ -10,4 +10,6 @@ public interface AdvertisementQueryService {
     AdvertisementResponse.AdContentInfosResponse readAdContents(Long userId, Long orgId, Long projectId);
 
     AdvertisementResponse.AdGroupInfoResponse readAdGroup(Long userId, Long orgId, Long projectId, Long adContentId);
+
+    AdvertisementResponse.AdCampaignListResponse readAdCampaigns(Long userId, Long orgId, String providerType);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/AdvertisementQueryServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/AdvertisementQueryServiceImpl.java
@@ -2,10 +2,13 @@ package com.whereyouad.WhereYouAd.domains.advertisement.domain.service;
 
 import com.whereyouad.WhereYouAd.domains.advertisement.application.dto.response.AdvertisementResponse;
 import com.whereyouad.WhereYouAd.domains.advertisement.application.mapper.AdvertisementConverter;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.domains.advertisement.exception.AdvertisementHandler;
 import com.whereyouad.WhereYouAd.domains.advertisement.exception.code.AdvertisementErrorCode;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdCampaign;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdContent;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdGroup;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdCampaignRepository;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdContentRepository;
 import com.whereyouad.WhereYouAd.domains.organization.exception.code.OrgErrorCode;
 import com.whereyouad.WhereYouAd.domains.organization.exception.handler.OrgHandler;
@@ -15,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -24,6 +28,7 @@ public class AdvertisementQueryServiceImpl implements AdvertisementQueryService 
 
     private final AdContentRepository adContentRepository;
     private final OrgMemberRepository orgMemberRepository;
+    private final AdCampaignRepository adCampaignRepository;
 
     @Override
     public AdvertisementResponse.AdContentInfoResponse readAdContent(Long userId, Long orgId, Long projectId,
@@ -69,5 +74,32 @@ public class AdvertisementQueryServiceImpl implements AdvertisementQueryService 
         AdGroup adGroup = adContent.getAdGroup();
 
         return AdvertisementConverter.toAdGroupInfo(adGroup);
+    }
+
+    //Project 엔티티 생성을 위해, 기존에 Project 와 연관되지 않은 AdCampaign 을 Provider 값과 orgId 기반 조회하는 메서드
+    //API 연동시, AdCampaign 내부 organization 필드와 함께 리팩티렁 필요
+    @Override
+    public AdvertisementResponse.AdCampaignListResponse readAdCampaigns(Long userId, Long orgId, String providerType) {
+        if (!orgMemberRepository.existsByUserIdAndOrganizationId(userId, orgId)) {
+            throw new OrgHandler(OrgErrorCode.ORG_MEMBER_NOT_FOUND);
+        }
+
+        Provider provider;
+        try { //providerType 에 잘못된 값이 입력되지 않았는지 검증
+            provider = Provider.valueOf(providerType.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new AdvertisementHandler(AdvertisementErrorCode.INVALID_PROVIDER_VALUE);
+        }
+
+        //orgId, Provider 가 일치하고, project 가 null 인 AdCampaign 리스트 추출
+        List<AdCampaign> adCampaigns = adCampaignRepository.findByOrgIdAndProviderWithNullProject(orgId, provider);
+
+        //각각의 AdCampaign 엔티티를 AdCampaignSimpleResponse DTO 로 변환
+        List<AdvertisementResponse.AdCampaignSimpleResponse> simpleResponses = adCampaigns.stream()
+                .map(AdvertisementConverter::toAdCampaignSimple)
+                .toList();
+
+        //최종 응답값으로 변환
+        return AdvertisementConverter.toAdCampaignList(simpleResponses);
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/AdvertisementQueryServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/AdvertisementQueryServiceImpl.java
@@ -13,6 +13,7 @@ import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.Ad
 import com.whereyouad.WhereYouAd.domains.organization.exception.code.OrgErrorCode;
 import com.whereyouad.WhereYouAd.domains.organization.exception.handler.OrgHandler;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
+import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgRepository;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,6 +29,7 @@ public class AdvertisementQueryServiceImpl implements AdvertisementQueryService 
     private final AdContentRepository adContentRepository;
     private final OrgMemberRepository orgMemberRepository;
     private final AdCampaignRepository adCampaignRepository;
+    private final OrgRepository orgRepository;
 
     @Override
     public AdvertisementResponse.AdContentInfoResponse readAdContent(Long userId, Long orgId, Long projectId,
@@ -79,6 +81,11 @@ public class AdvertisementQueryServiceImpl implements AdvertisementQueryService 
     //API 연동시, AdCampaign 내부 organization 필드와 함께 리팩티렁 필요
     @Override
     public AdvertisementResponse.AdCampaignListResponse readAdCampaigns(Long userId, Long orgId, String providerType) {
+        //조직 존재 검증
+        orgRepository.findById(orgId)
+                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
+
+        //조직에 회원이 속하는지 검증
         if (!orgMemberRepository.existsByUserIdAndOrganizationId(userId, orgId)) {
             throw new OrgHandler(OrgErrorCode.ORG_MEMBER_NOT_FOUND);
         }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/AdvertisementQueryServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/AdvertisementQueryServiceImpl.java
@@ -18,7 +18,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/exception/code/AdvertisementErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/exception/code/AdvertisementErrorCode.java
@@ -11,6 +11,7 @@ public enum AdvertisementErrorCode implements BaseErrorCode {
 
     // 400
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "AD_400_1", "날짜 입력이 잘못되었습니다."),
+    INVALID_PROVIDER_VALUE(HttpStatus.BAD_REQUEST, "AD_400_2", "providerType 입력이 잘못되었습니다."),
 
     //404
     ADCAMPAIGN_NOT_FOUND(HttpStatus.NOT_FOUND, "AD_404_1", "해당 캠페인이 존재하지 않습니다."),

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdCampaign.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdCampaign.java
@@ -3,6 +3,7 @@ package com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity;
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Goal;
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
+import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
 import com.whereyouad.WhereYouAd.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -58,6 +59,12 @@ public class AdCampaign extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_id")
     private Project project;
+
+    //Organization 의존성
+    //API 연동 시 리팩터링 필요
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "org_id")
+    private Organization organization;
 
     public void relateProject(Project project) {
         this.project = project;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdCampaignRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdCampaignRepository.java
@@ -53,4 +53,8 @@ public interface AdCampaignRepository extends JpaRepository<AdCampaign, Long> {
     @Modifying
     @Query("UPDATE AdCampaign a SET a.status = :status WHERE a.project.organization.id = :orgId")
     void updateStatusByOrganizationId(@Param("orgId") Long orgId, @Param("status") Status status);
+
+    //provider 값과 orgId 값이 일치하고, project 가 null 인 AdCampaign 엔티티 리스트로 추출
+    @Query("SELECT adc FROM AdCampaign adc WHERE adc.provider = :provider AND adc.project IS null AND adc.organization.id = :orgId")
+    List<AdCampaign> findByOrgIdAndProviderWithNullProject(@Param("orgId") Long orgId, @Param("provider") Provider provider);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/AdvertisementController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/AdvertisementController.java
@@ -70,4 +70,19 @@ public class AdvertisementController implements AdvertisementControllerDocs {
         return ResponseEntity.ok(DataResponse.ok());
     }
 
+
+    @GetMapping("/{orgId}/campaigns")
+    public ResponseEntity<DataResponse<AdvertisementResponse.AdCampaignListResponse>> readAdCampaigns(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId,
+            @RequestParam(required = true) String providerType
+    )
+    {
+        AdvertisementResponse.AdCampaignListResponse response = advertisementQueryService.readAdCampaigns(userId, orgId, providerType);
+
+        return ResponseEntity.ok(
+                DataResponse.from(response)
+        );
+    }
+
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/AdvertisementControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/AdvertisementControllerDocs.java
@@ -60,4 +60,21 @@ public interface AdvertisementControllerDocs {
                         @AuthenticationPrincipal(expression = "userId") Long userId,
                         @PathVariable Long orgId, @PathVariable Long projectId, @PathVariable Long adContentId,
                         @RequestParam Status status);
+
+
+        @Operation(
+                summary = "각 플랫폼별 광고 캠페인 조회 API",
+                description = "각 플랫폼별로 우리 서비스 내에서 캠페인 그룹으로 묶이지 않은 캠페인을 조회합니다.\n\n" +
+                        "/api/project/create/{orgId} 캠페인 그룹 정보 설정 API 에서 각 플랫폼별 캠페인을 선택하기 위해 사용되는 API 입니다."
+        )
+        @ApiResponses({
+                @ApiResponse(responseCode = "200", description = "성공"),
+                @ApiResponse(responseCode = "404", description = "ORG_404_2: 해당 멤버가 조직에 존재하지 않습니다."),
+                @ApiResponse(responseCode = "400", description = "AD_400_2: providerType 입력이 잘못되었습니다.")
+        })
+        public ResponseEntity<DataResponse<AdvertisementResponse.AdCampaignListResponse>> readAdCampaigns(
+                @AuthenticationPrincipal(expression = "userId") Long userId,
+                @PathVariable Long orgId,
+                @RequestParam(required = true) String providerType
+        );
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/AdvertisementControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/AdvertisementControllerDocs.java
@@ -70,7 +70,8 @@ public interface AdvertisementControllerDocs {
         @ApiResponses({
                 @ApiResponse(responseCode = "200", description = "성공"),
                 @ApiResponse(responseCode = "404", description = "ORG_404_2: 해당 멤버가 조직에 존재하지 않습니다."),
-                @ApiResponse(responseCode = "400", description = "AD_400_2: providerType 입력이 잘못되었습니다.")
+                @ApiResponse(responseCode = "400", description = "AD_400_2: providerType 입력이 잘못되었습니다."),
+                @ApiResponse(responseCode = "404", description = "ORG_404_1: 해당 id 의 조직이 존재하지 않습니다.")
         })
         public ResponseEntity<DataResponse<AdvertisementResponse.AdCampaignListResponse>> readAdCampaigns(
                 @AuthenticationPrincipal(expression = "userId") Long userId,


### PR DESCRIPTION
## 📌 관련 이슈
- Close #68 

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

Project 엔티티 추가 API 호출 시 필요한 provider 별 AdCampaign 조회를 위해, 
Organization 내부 Project 연동되지 않은 AdCampaign 조회 API 추가

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- Organization - AdCampaign 간 1:N 연관관계 추가(AdCampaign 에 ManyToOne 매핑)
- orgId, providerType 을 입력받아 해당하는 AdCampaign 중 project 가 null 인 엔티티 추출 로직 개발

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.

최초 DB 상태 (project 연관되어있지 않고, org_id = 1 로 연관된 AdCampaign 을 provider 별로 3개씩 추가해놓은 상태)
<img width="1330" height="330" alt="image" src="https://github.com/user-attachments/assets/026b1c76-d64e-4240-aeab-ee01fe1d52ca" />

user_id = 1 회원으로 로그인하여 org_id = 1 인 조직 내부 각각의 providerType 값으로 AdCampaign 조회 응답
<img width="1899" height="1013" alt="image" src="https://github.com/user-attachments/assets/72ec4c01-44b5-4d4b-a063-546791c4d58b" />

<img width="1900" height="984" alt="image" src="https://github.com/user-attachments/assets/37e096d7-ad7c-42db-853a-1481fd00897a" />

<img width="1916" height="931" alt="image" src="https://github.com/user-attachments/assets/232cffcf-4506-4f90-9fb3-9af6602d6653" />

===예외처리===
회원이 조직에 속하지 않을 경우 오류
<img width="1892" height="598" alt="image" src="https://github.com/user-attachments/assets/cd263b0f-0f6b-4352-8149-c76875f0fb6e" />

org_id 에 해당하는 조직 존재하지 않을 시 오류
<img width="1893" height="529" alt="image" src="https://github.com/user-attachments/assets/ca2f856f-8de8-4540-89a2-0e83c8696321" />


## ✅ 체크리스트
- [✅] 브랜치 전략(GitHub Flow)을 준수했나요?
- [✅] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [✅] 테스트 통과 확인
- [✅] 서버 실행 확인
- [✅] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- AdCampaign 에 Organization 을 ManyToOne 으로 의존성 추가해서 진행했습니다. 일단 기존에 AdCampaign 자체를 생성하거나 조회하는 API 가 따로 없었던 것 같아 오류는 안나는 것 같은데 혹시라도 다른 API 로직 등에 AdCampaign 엔티티 변경으로 오류 발생할 곳이 있다면 알려주시면 그 부분도 리팩터링 진행해보겠습니다.

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 광고 캠페인을 제공자 유형별로 조회할 수 있는 새로운 API 엔드포인트 추가
  * 조직 단위의 광고 캠페인 목록을 구조화된 형식으로 반환
  * 제공자 유형 입력값 검증 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->