### PR TITLE
Feat/#76 Project 개별 조회 구현 및 관련 수정

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/application/dto/response/AdvertisementResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/application/dto/response/AdvertisementResponse.java
@@ -10,6 +10,7 @@ public class AdvertisementResponse {
             Long id,
             String trackingUrl,
             String landingUrl,
+            String description,
             Status status,
             String targetInfo
     ) {}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/application/mapper/AdvertisementConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/application/mapper/AdvertisementConverter.java
@@ -12,7 +12,7 @@ public class AdvertisementConverter {
     public static AdvertisementResponse.AdContentInfoResponse toAdContentInfo(AdContent adContent,
             AdvertisementResponse.AdGroupInfoResponse adGroupInfoResponse) {
         return new AdvertisementResponse.AdContentInfoResponse(
-                adContent.getId(), adContent.getTrackingUrl(), adContent.getLandingUrl(), adContent.getStatus(), adGroupInfoResponse.targetInfo());
+                adContent.getId(), adContent.getTrackingUrl(), adContent.getLandingUrl(), adContent.getDescription(), adContent.getStatus(), adGroupInfoResponse.targetInfo());
     }
 
     public static AdvertisementResponse.AdContentInfosResponse toAdContentsInfo(List<AdContent> adContents) {

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdContent.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdContent.java
@@ -27,6 +27,9 @@ public class AdContent extends BaseEntity {
 
     private String type;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    @ColumnDefault("'ON_GOING'")
     private Status status;
 
     private String cta;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdContent.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdContent.java
@@ -23,11 +23,10 @@ public class AdContent extends BaseEntity {
 
     private String landingUrl;
 
+    private String description;
+
     private String type;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
-    @ColumnDefault("'ON_GOING'")
     private Status status;
 
     private String cta;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdCampaignRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdCampaignRepository.java
@@ -46,6 +46,10 @@ public interface AdCampaignRepository extends JpaRepository<AdCampaign, Long> {
             "FROM AdCampaign c WHERE c.project.id IN :projectIds")
     List<ProjectQueryDto.CampaignSummary> findCampaignSummariesByProjectIds(@Param("projectIds") List<Long> projectIds);
 
+    @Query("SELECT new com.whereyouad.WhereYouAd.domains.project.application.dto.ProjectQueryDto$CampaignSummary(c.project.id, c.provider, c.budget) " +
+            "FROM AdCampaign c WHERE c.project.id = :projectIds")
+    List<ProjectQueryDto.CampaignSummary> findCampaignSummariesByProjectId(@Param("projectId") Long projectId);
+
     @Modifying
     @Query("UPDATE AdCampaign a SET a.status = :status WHERE a.project.id = :projectId")
     void updateStatusByProjectId(@Param("projectId") Long projectId, @Param("status") Status status);

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdCampaignRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdCampaignRepository.java
@@ -47,7 +47,7 @@ public interface AdCampaignRepository extends JpaRepository<AdCampaign, Long> {
     List<ProjectQueryDto.CampaignSummary> findCampaignSummariesByProjectIds(@Param("projectIds") List<Long> projectIds);
 
     @Query("SELECT new com.whereyouad.WhereYouAd.domains.project.application.dto.ProjectQueryDto$CampaignSummary(c.project.id, c.provider, c.budget) " +
-            "FROM AdCampaign c WHERE c.project.id = :projectIds")
+            "FROM AdCampaign c WHERE c.project.id = :projectId")
     List<ProjectQueryDto.CampaignSummary> findCampaignSummariesByProjectId(@Param("projectId") Long projectId);
 
     @Modifying

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/MetricFactRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/MetricFactRepository.java
@@ -137,4 +137,9 @@ public interface MetricFactRepository extends JpaRepository<MetricFact, Long> {
             @Param("end") LocalDateTime end,
             @Param("orgId") Long orgId
     );
+
+    // 프로젝트 ID로 지출(spend) 총합  조회
+    @Query("SELECT new com.whereyouad.WhereYouAd.domains.project.application.dto.ProjectQueryDto$SpendSummary(m.project.id, SUM(m.spend)) " +
+            "FROM MetricFact m WHERE m.project.id = :projectId GROUP BY m.project.id")
+    ProjectQueryDto.SpendSummary findSpendSummaryByProjectId(Long projectId);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/MetricFactRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/MetricFactRepository.java
@@ -137,9 +137,4 @@ public interface MetricFactRepository extends JpaRepository<MetricFact, Long> {
             @Param("end") LocalDateTime end,
             @Param("orgId") Long orgId
     );
-
-    // 프로젝트 ID로 지출(spend) 총합  조회
-    @Query("SELECT new com.whereyouad.WhereYouAd.domains.project.application.dto.ProjectQueryDto$SpendSummary(m.project.id, SUM(m.spend)) " +
-            "FROM MetricFact m WHERE m.project.id = :projectId GROUP BY m.project.id")
-    ProjectQueryDto.SpendSummary findSpendSummaryByProjectId(Long projectId);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/application/dto/response/ProjectResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/application/dto/response/ProjectResponse.java
@@ -1,6 +1,7 @@
 package com.whereyouad.WhereYouAd.domains.project.application.dto.response;
 
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -19,6 +20,7 @@ public class ProjectResponse {
     public record SimpleProjectResponse(
             Long projectId,
             String name,
+            Status status,
             String description,
             List<Provider> providers,
             Double budgetUsageRate
@@ -27,6 +29,7 @@ public class ProjectResponse {
     public record ProjectInfoResponse (
         Long projectId,
         String name,
+        Status status,
         String description,
         Long budget,
         LocalDate createdAt,

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/application/dto/response/ProjectResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/application/dto/response/ProjectResponse.java
@@ -2,6 +2,7 @@ package com.whereyouad.WhereYouAd.domains.project.application.dto.response;
 
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public class ProjectResponse {
@@ -21,5 +22,14 @@ public class ProjectResponse {
             String description,
             List<Provider> providers,
             Double budgetUsageRate
+    ) {}
+
+    public record ProjectInfoResponse (
+        Long projectId,
+        String name,
+        String description,
+        Long budget,
+        LocalDate createdAt,
+        List<Provider> providers
     ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/application/mapper/ProjectConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/application/mapper/ProjectConverter.java
@@ -16,7 +16,7 @@ public class ProjectConverter {
     public static ProjectResponse.SimpleProjectResponse toSimpleProjectResponse(Project project, List<Provider> providers, Double budgetUsageRate)
     {
         return new ProjectResponse.SimpleProjectResponse(
-                project.getId(), project.getName(), project.getDescription(), providers, budgetUsageRate);
+                project.getId(), project.getName(), project.getStatus(), project.getDescription(), providers, budgetUsageRate);
     }
 
     public static ProjectResponse.ProjectListResponse toProjectListResponse(List<ProjectResponse.SimpleProjectResponse> projects) {
@@ -25,6 +25,6 @@ public class ProjectConverter {
 
     public static ProjectResponse.ProjectInfoResponse toProjectInfoResponse(Project project, List<Provider> providers, Long budget) {
         return new ProjectResponse.ProjectInfoResponse(
-                project.getId(), project.getName(), project.getDescription(), budget, project.getCreatedAt().toLocalDate(), providers);
+                project.getId(), project.getName(), project.getStatus(), project.getDescription(), budget, project.getCreatedAt().toLocalDate(), providers);
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/application/mapper/ProjectConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/application/mapper/ProjectConverter.java
@@ -22,4 +22,9 @@ public class ProjectConverter {
     public static ProjectResponse.ProjectListResponse toProjectListResponse(List<ProjectResponse.SimpleProjectResponse> projects) {
         return new ProjectResponse.ProjectListResponse(projects);
     }
+
+    public static ProjectResponse.ProjectInfoResponse toProjectInfoResponse(Project project, List<Provider> providers, Long budget) {
+        return new ProjectResponse.ProjectInfoResponse(
+                project.getId(), project.getName(), project.getDescription(), budget, project.getCreatedAt().toLocalDate(), providers);
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectService.java
@@ -11,4 +11,6 @@ public interface ProjectService {
     ProjectResponse.ProjectListResponse getProjects(Long userId, Long orgId);
 
     void updateAllProjectsStatus(Long userId, Long orgId, Status status);
+
+    ProjectResponse.ProjectInfoResponse getProject(Long userId, Long orgId, Long projectId);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectService.java
@@ -10,7 +10,7 @@ public interface ProjectService {
 
     ProjectResponse.ProjectListResponse getProjects(Long userId, Long orgId);
 
-    void updateAllProjectsStatus(Long userId, Long orgId, Status status);
-
     ProjectResponse.ProjectInfoResponse getProject(Long userId, Long orgId, Long projectId);
+
+    void updateAllProjectsStatus(Long userId, Long orgId, Status status);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
@@ -172,9 +172,8 @@ public class ProjectServiceImpl implements ProjectService {
     public ProjectResponse.ProjectInfoResponse getProject(Long userId, Long orgId, Long projectId) {
         validateProject(userId, orgId);
 
-        Project project = projectRepository.findById(projectId).orElseThrow(() ->
-                    new ProjectHandler(ProjectErrorCode.PROJECT_NOT_FOUND)
-        );
+        Project project = projectRepository.findByIdAndOrganizationId(projectId, orgId)
+                .orElseThrow(() -> new ProjectHandler(ProjectErrorCode.PROJECT_NOT_FOUND));
 
         // 캠페인 정보 모음
         List<ProjectQueryDto.CampaignSummary> campaignSummaries = adCampaignRepository.findCampaignSummariesByProjectId(project.getId());

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
@@ -20,6 +20,8 @@ import com.whereyouad.WhereYouAd.domains.project.application.dto.ProjectQueryDto
 import com.whereyouad.WhereYouAd.domains.project.application.dto.request.ProjectRequest;
 import com.whereyouad.WhereYouAd.domains.project.application.dto.response.ProjectResponse;
 import com.whereyouad.WhereYouAd.domains.project.application.mapper.ProjectConverter;
+import com.whereyouad.WhereYouAd.domains.project.exception.ProjectHandler;
+import com.whereyouad.WhereYouAd.domains.project.exception.code.ProjectErrorCode;
 import com.whereyouad.WhereYouAd.domains.project.persistence.entity.Project;
 import com.whereyouad.WhereYouAd.domains.project.persistence.repository.ProjectRepository;
 import com.whereyouad.WhereYouAd.domains.user.exception.code.UserErrorCode;
@@ -109,26 +111,7 @@ public class ProjectServiceImpl implements ProjectService {
 
     //조직 내 모든 Project 조회 로직
     public ProjectResponse.ProjectListResponse getProjects(Long userId, Long orgId) {
-
-        //회원 Not Found 예외처리
-        userRepository.findById(userId)
-                .orElseThrow(() -> new UserHandler(UserErrorCode.USER_NOT_FOUND));
-
-        //조직 Not Found 예외처리
-        Organization organization = orgRepository.findById(orgId)
-                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
-
-        //조직 Soft Delete 상태시 예외
-        if (organization.getStatus() == OrgStatus.DELETED) {
-            throw new OrgHandler(OrgErrorCode.ORG_SOFT_DELETED);
-        }
-
-        Optional<OrgMember> orgMember = orgMemberRepository.findByUserIdAndOrgId(userId, orgId);
-
-        //조직에 속하지 않은 회원의 요청일 시 예외
-        if (orgMember.isEmpty()) {
-            throw new OrgHandler(OrgErrorCode.ORG_MEMBER_NOT_FOUND);
-        }
+        validateProject(userId, orgId);
 
         // 조직 내 모든 Project 조회
         List<Project> projects = projectRepository.findByOrganizationId(orgId);
@@ -187,6 +170,20 @@ public class ProjectServiceImpl implements ProjectService {
         return ProjectConverter.toProjectListResponse(responseList);
     }
 
+    // 개별 프로젝트 조회
+    @Override
+    public ProjectResponse.ProjectInfoResponse getProject(Long userId, Long orgId, Long projectId) {
+        validateProject(userId, orgId);
+
+        Project project = projectRepository.findById(projectId).orElseThrow(() ->
+                    new ProjectHandler(ProjectErrorCode.PROJECT_NOT_FOUND)
+        );
+
+        adCampaignRepository.findCampaignSummariesByProjectId(project.getId());
+
+        return ProjectConverter.toProjectInfoResponse(project, null, null);
+    }
+
     //예산 소진 현황 계산 메서드
     private double calculateBudgetUsageRate(List<ProjectQueryDto.CampaignSummary> projectCampaigns, BigDecimal totalSpend) {
         // 총 예산 (캠페인 budget의 합)
@@ -227,4 +224,30 @@ public class ProjectServiceImpl implements ProjectService {
         adGroupRepository.updateStatusByOrganizationId(orgId, status);
         adContentRepository.updateStatusByOrganizationId(orgId, status);
     }
+
+    public void validateProject (Long userId, Long orgId) {
+        //회원 Not Found 예외처리
+        userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(UserErrorCode.USER_NOT_FOUND));
+
+        //조직 Not Found 예외처리
+        Organization organization = orgRepository.findById(orgId)
+                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
+
+        //조직 Soft Delete 상태시 예외
+        if (organization.getStatus() == OrgStatus.DELETED) {
+            throw new OrgHandler(OrgErrorCode.ORG_SOFT_DELETED);
+        }
+
+        Optional<OrgMember> orgMember = orgMemberRepository.findByUserIdAndOrgId(userId, orgId);
+
+        //조직에 속하지 않은 회원의 요청일 시 예외
+        if (orgMember.isEmpty()) {
+            throw new OrgHandler(OrgErrorCode.ORG_MEMBER_NOT_FOUND);
+        }
+    }
+
+//    public void getCampaignResponses(List<ProjectQueryDto.CampaignSummary> campaignSummaries, ) {
+//
+//    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
@@ -179,9 +179,22 @@ public class ProjectServiceImpl implements ProjectService {
                     new ProjectHandler(ProjectErrorCode.PROJECT_NOT_FOUND)
         );
 
-        adCampaignRepository.findCampaignSummariesByProjectId(project.getId());
+        // 캠페인 정보 모음
+        List<ProjectQueryDto.CampaignSummary> campaignSummaries = adCampaignRepository.findCampaignSummariesByProjectId(project.getId());
 
-        return ProjectConverter.toProjectInfoResponse(project, null, null);
+        // Provider 추출
+        List<Provider> distinctProviders = campaignSummaries.stream()
+                .map(ProjectQueryDto.CampaignSummary::provider)
+                .distinct()
+                .sorted(Comparator.comparing(Provider::name))
+                .toList();
+
+        // 총 예산 (캠페인 budget의 합)
+        long totalBudget = campaignSummaries.stream()
+                .mapToLong(summary -> summary.budget() != null ? summary.budget() : 0L)
+                .sum();
+
+        return ProjectConverter.toProjectInfoResponse(project, distinctProviders, totalBudget);
     }
 
     //예산 소진 현황 계산 메서드
@@ -246,8 +259,4 @@ public class ProjectServiceImpl implements ProjectService {
             throw new OrgHandler(OrgErrorCode.ORG_MEMBER_NOT_FOUND);
         }
     }
-
-//    public void getCampaignResponses(List<ProjectQueryDto.CampaignSummary> campaignSummaries, ) {
-//
-//    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
@@ -110,6 +110,7 @@ public class ProjectServiceImpl implements ProjectService {
     }
 
     //조직 내 모든 Project 조회 로직
+    @Override
     public ProjectResponse.ProjectListResponse getProjects(Long userId, Long orgId) {
         validateProject(userId, orgId);
 
@@ -151,11 +152,7 @@ public class ProjectServiceImpl implements ProjectService {
             List<ProjectQueryDto.CampaignSummary> projectCampaigns = campaignMap.getOrDefault(projectId, Collections.emptyList());
 
             // Provider 추출
-            List<Provider> distinctProviders = projectCampaigns.stream()
-                    .map(ProjectQueryDto.CampaignSummary::provider)
-                    .distinct()
-                    .sorted(Comparator.comparing(Provider::name))
-                    .toList();
+            List<Provider> distinctProviders = extractDistinctProviders(projectCampaigns);
 
             // 총 지출 (MetricFact spend의 합)
             BigDecimal totalSpend = spendMap.getOrDefault(projectId, BigDecimal.ZERO);
@@ -183,26 +180,33 @@ public class ProjectServiceImpl implements ProjectService {
         List<ProjectQueryDto.CampaignSummary> campaignSummaries = adCampaignRepository.findCampaignSummariesByProjectId(project.getId());
 
         // Provider 추출
-        List<Provider> distinctProviders = campaignSummaries.stream()
-                .map(ProjectQueryDto.CampaignSummary::provider)
-                .distinct()
-                .sorted(Comparator.comparing(Provider::name))
-                .toList();
+        List<Provider> distinctProviders = extractDistinctProviders(campaignSummaries);
 
         // 총 예산 (캠페인 budget의 합)
-        long totalBudget = campaignSummaries.stream()
-                .mapToLong(summary -> summary.budget() != null ? summary.budget() : 0L)
-                .sum();
+        long totalBudget = calculateTotalBudget(campaignSummaries);
 
         return ProjectConverter.toProjectInfoResponse(project, distinctProviders, totalBudget);
     }
 
-    //예산 소진 현황 계산 메서드
-    private double calculateBudgetUsageRate(List<ProjectQueryDto.CampaignSummary> projectCampaigns, BigDecimal totalSpend) {
-        // 총 예산 (캠페인 budget의 합)
-        long totalBudget = projectCampaigns.stream()
+    // Provider 추출 공통 메서드
+    private List<Provider> extractDistinctProviders(List<ProjectQueryDto.CampaignSummary> campaignSummaries) {
+        return campaignSummaries.stream()
+                .map(ProjectQueryDto.CampaignSummary::provider)
+                .distinct()
+                .sorted(Comparator.comparing(Provider::name))
+                .toList();
+    }
+
+    // 총 예산 계산 공통 메서드
+    private long calculateTotalBudget(List<ProjectQueryDto.CampaignSummary> campaignSummaries) {
+        return campaignSummaries.stream()
                 .mapToLong(summary -> summary.budget() != null ? summary.budget() : 0L)
                 .sum();
+    }
+
+    // 예산 소진 현황 계산 메서드
+    private double calculateBudgetUsageRate(List<ProjectQueryDto.CampaignSummary> projectCampaigns, BigDecimal totalSpend) {
+        long totalBudget = calculateTotalBudget(projectCampaigns);
 
         // 예산이 없거나 지출이 없으면 0.0 반환
         if (totalBudget <= 0 || totalSpend == null) {

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
@@ -94,6 +94,7 @@ public class ProjectServiceImpl implements ProjectService {
         //Project 엔티티 생성 및 저장
         Project project = Project.builder()
                 .name(request.name())
+                .status(Status.ON_GOING)
                 .description(request.description())
                 .createdBy(userId)
                 .organization(organization)

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/persistence/entity/Project.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/persistence/entity/Project.java
@@ -1,10 +1,12 @@
 package com.whereyouad.WhereYouAd.domains.project.persistence.entity;
 
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdCampaign;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
 import com.whereyouad.WhereYouAd.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +26,11 @@ public class Project extends BaseEntity {
 
     @Column(name = "name", nullable = false)
     private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    @ColumnDefault("'ON_GOING'")
+    private Status status;
 
     @Column(name = "description")
     private String description;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/persistence/repository/ProjectRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/persistence/repository/ProjectRepository.java
@@ -6,8 +6,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
     @Query("select p from Project p where p.organization.id = :orgId")
     List<Project> findByOrganizationId(@Param(value = "orgId") Long orgId);
+
+    @Query("select p from Project p where p.id = :projectId and p.organization.id = :orgId")
+    Optional<Project> findByIdAndOrganizationId(@Param("projectId") Long projectId, @Param("orgId") Long orgId);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/presentation/ProjectController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/presentation/ProjectController.java
@@ -42,17 +42,30 @@ public class ProjectController implements ProjectControllerDocs {
     {
         ProjectResponse.ProjectListResponse response = projectService.getProjects(userId, orgId);
 
-                return ResponseEntity.ok(
-                                DataResponse.from(response));
-        }
+            return ResponseEntity.ok(
+                            DataResponse.from(response));
+    }
 
-        @PatchMapping("/{orgId}/status")
-        public ResponseEntity<DataResponse<Void>> updateAllProjectsStatus(
-                        @AuthenticationPrincipal(expression = "userId") Long userId,
-                        @PathVariable Long orgId,
-                        @RequestParam Status status) {
-                projectService.updateAllProjectsStatus(userId, orgId, status);
-                return ResponseEntity.ok(DataResponse.ok());
-        }
+    @GetMapping("/{orgId}/{projectId}")
+    public ResponseEntity<DataResponse<ProjectResponse.ProjectInfoResponse>> getProject(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId, @PathVariable Long projectId
+    )
+    {
+        ProjectResponse.ProjectInfoResponse response = projectService.getProject(userId, orgId, projectId);
+
+        return ResponseEntity.ok(
+                DataResponse.from(response));
+    }
+
+
+    @PatchMapping("/{orgId}/status")
+    public ResponseEntity<DataResponse<Void>> updateAllProjectsStatus(
+                    @AuthenticationPrincipal(expression = "userId") Long userId,
+                    @PathVariable Long orgId,
+                    @RequestParam Status status) {
+            projectService.updateAllProjectsStatus(userId, orgId, status);
+            return ResponseEntity.ok(DataResponse.ok());
+    }
 
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/presentation/docs/ProjectControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/presentation/docs/ProjectControllerDocs.java
@@ -29,7 +29,7 @@ public interface ProjectControllerDocs {
             @ApiResponse(responseCode = "404_1", description = "해당 id 의 캠페인 찾을 수 없음"),
             @ApiResponse(responseCode = "410_1", description = "조직 Soft Deleted")
     })
-    public ResponseEntity<DataResponse<ProjectResponse.CreatedResponse>> createProject(
+    ResponseEntity<DataResponse<ProjectResponse.CreatedResponse>> createProject(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
             @Valid @RequestBody ProjectRequest.CreateRequest request
@@ -38,7 +38,7 @@ public interface ProjectControllerDocs {
     @Operation(
             summary = "캠페인 그룹 정보 조회 API",
             description = "캠페인 그룹을 조회하려는 조직 Id 를 받아 해당 조직에 속한 모든 캠페인 그룹 정보를 조회 합니다. \n\n" +
-                    "반환 값에는 각 캠페인 그룹의 Id(projectId),  이름, 설명, 해당 캠페인 그룹에서 진행하는 광고 플랫폼들(providers), 예산 소진 현황(budgetUsageRate) 입니다."
+                    "반환 값에는 각 캠페인 그룹의 Id(projectId), 이름, 상태, 설명, 해당 캠페인 그룹에서 진행하는 광고 플랫폼들(providers), 예산 소진 현황(budgetUsageRate) 입니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
@@ -47,9 +47,26 @@ public interface ProjectControllerDocs {
             @ApiResponse(responseCode = "404_2", description = "해당 조직에 회원이 속하지 않음"),
             @ApiResponse(responseCode = "410_1", description = "조직 Soft Deleted")
     })
-    public ResponseEntity<DataResponse<ProjectResponse.ProjectListResponse>> getProjects(
+    ResponseEntity<DataResponse<ProjectResponse.ProjectListResponse>> getProjects(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId
+    );
+
+    @Operation(
+            summary = "특정 캠페인 그룹 조회 API",
+            description = "특정 캠페인 그룹을 조회하려는 조직 Id와 캠페인 그룹(project) id를 받아 해당 조직의 특정 캠페인 그룹 정보를 조회합니다. \n\n" +
+                    "반환 값에는 각 캠페인 그룹의 Id(projectId), 이름, 상태, 설명, 예산, 등록 날짜, 해당 캠페인 그룹에서 진행하는 광고 플랫폼들(providers)입니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "404_1", description = "회원 찾을 수 없음"),
+            @ApiResponse(responseCode = "404_1", description = "조직 찾을 수 없음"),
+            @ApiResponse(responseCode = "404_2", description = "해당 조직에 회원이 속하지 않음"),
+            @ApiResponse(responseCode = "410_1", description = "조직 Soft Deleted")
+    })
+    ResponseEntity<DataResponse<ProjectResponse.ProjectInfoResponse>> getProject(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId, @PathVariable Long projectId
     );
 
     @Operation(summary = "전체 프로젝트 중단/재개 API", description = "특정 조직에 속한 모든 프로젝트 및 그 하위의 모든 광고 그룹과 콘텐츠 상태를 일괄 중단(PAUSED) 하거나 재개(ON_GOING) 합니다.")
@@ -60,7 +77,7 @@ public interface ProjectControllerDocs {
             @ApiResponse(responseCode = "404_2", description = "해당 조직에 회원이 속하지 않음"),
             @ApiResponse(responseCode = "410_1", description = "조직 Soft Deleted")
     })
-    public ResponseEntity<DataResponse<Void>> updateAllProjectsStatus(
+    ResponseEntity<DataResponse<Void>> updateAllProjectsStatus(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
             @RequestParam Status status);


### PR DESCRIPTION
## 📌 관련 이슈
- Close #76

## 🚀 개요
Project 개별 조회를 구현하고, Project 엔티티를 수정하였습니다. AdContent에도 description 필드를 추가하였습니다.

## 📄 작업 내용
### Project 개별 조회 API
<img width="1304" height="568" alt="image" src="https://github.com/user-attachments/assets/1e5c9616-8def-4619-9201-7a1be2930614" />
<img width="830" height="500" alt="image" src="https://github.com/user-attachments/assets/5bd874dd-7461-41aa-8e9f-bfdcd6841d36" />

### Project에 status 필드 추가 후 목록 및 개별 조회 응답 수정
- 피그마 화면에 따라, 조회 시 응답에 '운영 중' 등의 상태를 함께 포함하도록 수정함.

### AdContent에 description 필드 축, 개별 상세 조회 시 응답 수정
- 피그마 화면에 따라, 개별 광고 조회 시 설명도 응답에 함께 포함하도록 수정함.

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
AdContent에 description 필드가 생겨 기존 mock data SQL도 수정 필요할 것 같습니다. 그리고 추후 작업으로는 예산 관련 서비스 코드를 분리하고,  배포 서버 DB에도 미리 mock data(organization, project, adCampaign, adGroup, adContent) 넣어두려 합니다!

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 개별 프로젝트 상세 조회용 신규 API 엔드포인트 추가
  * 프로젝트 상세 응답에 상태(status) 및 설명(description) 포함

* **개선 사항**
  * 광고 응답에 설명(description) 필드 추가로 광고 상세 정보 확장
  * 프로젝트 조회 로직 리팩토링 및 검증 절차 분리로 안정성 향상
  * 프로젝트·캠페인 조회용 쿼리 추가로 검색 유연성 강화

* **문서**
  * API 문서에 개별 프로젝트 조회 및 응답 변경사항 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->