### PR TITLE
Refactor#70 예산 로직 분리 및 캠페인 조회 관련 수정

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/application/dto/response/AdvertisementResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/application/dto/response/AdvertisementResponse.java
@@ -1,6 +1,7 @@
 package com.whereyouad.WhereYouAd.domains.advertisement.application.dto.response;
 
 
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
 
 import java.util.List;
@@ -8,6 +9,8 @@ import java.util.List;
 public class AdvertisementResponse {
     public record AdContentInfoResponse (
             Long id,
+            String name,
+            Provider provider,
             String trackingUrl,
             String landingUrl,
             String description,

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/application/mapper/AdvertisementConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/application/mapper/AdvertisementConverter.java
@@ -1,6 +1,7 @@
 package com.whereyouad.WhereYouAd.domains.advertisement.application.mapper;
 
 import com.whereyouad.WhereYouAd.domains.advertisement.application.dto.response.AdvertisementResponse;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdCampaign;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdContent;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdGroup;
@@ -11,8 +12,11 @@ public class AdvertisementConverter {
 
     public static AdvertisementResponse.AdContentInfoResponse toAdContentInfo(AdContent adContent,
             AdvertisementResponse.AdGroupInfoResponse adGroupInfoResponse) {
+        Provider provider = adContent.getAdGroup().getAdCampaign().getProvider();
         return new AdvertisementResponse.AdContentInfoResponse(
-                adContent.getId(), adContent.getTrackingUrl(), adContent.getLandingUrl(), adContent.getDescription(), adContent.getStatus(), adGroupInfoResponse.targetInfo());
+                adContent.getId(), adContent.getName(), provider,
+                adContent.getTrackingUrl(), adContent.getLandingUrl(),
+                adContent.getDescription(), adContent.getStatus(), adGroupInfoResponse.targetInfo());
     }
 
     public static AdvertisementResponse.AdContentInfosResponse toAdContentsInfo(List<AdContent> adContents) {

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/AdvertisementCommandServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/AdvertisementCommandServiceImpl.java
@@ -73,6 +73,7 @@ public class AdvertisementCommandServiceImpl implements AdvertisementCommandServ
         adCampaignRepository.updateStatusByProjectId(projectId, status);
         adGroupRepository.updateStatusByProjectId(projectId, status);
         adContentRepository.updateStatusByProjectId(projectId, status);
+        projectRepository.updateStatusById(projectId, status);
     }
 
     @Override

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdContent.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdContent.java
@@ -19,6 +19,8 @@ public class AdContent extends BaseEntity {
     @Column(name = "ad_content_id")
     private Long id;
 
+    private String name;
+
     private String trackingUrl;
 
     private String landingUrl;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
@@ -240,6 +240,8 @@ public class ProjectServiceImpl implements ProjectService {
         adCampaignRepository.updateStatusByOrganizationId(orgId, status);
         adGroupRepository.updateStatusByOrganizationId(orgId, status);
         adContentRepository.updateStatusByOrganizationId(orgId, status);
+
+        projectRepository.updateStatusByOrganizationId(orgId, status);
     }
 
     public void validateProject (Long userId, Long orgId) {

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/persistence/repository/ProjectRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/persistence/repository/ProjectRepository.java
@@ -1,7 +1,9 @@
 package com.whereyouad.WhereYouAd.domains.project.persistence.repository;
 
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
 import com.whereyouad.WhereYouAd.domains.project.persistence.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,4 +16,12 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
 
     @Query("select p from Project p where p.id = :projectId and p.organization.id = :orgId")
     Optional<Project> findByIdAndOrganizationId(@Param("projectId") Long projectId, @Param("orgId") Long orgId);
+
+    @Modifying
+    @Query("UPDATE Project p SET p.status = :status WHERE p.id = :projectId")
+    void updateStatusById(@Param("projectId") Long projectId, @Param("status") Status status);
+
+    @Modifying
+    @Query("UPDATE Project p SET p.status = :status WHERE p.organization.id = :orgId")
+    void updateStatusByOrganizationId(@Param("orgId") Long orgId, @Param("status") Status status);
 }


### PR DESCRIPTION
## 📌 관련 이슈
#70 

## 🚀 개요
ProjectService와 DashboardService에 겹치는 예산 계산 로직을, 추후 예산 관련 조회 구현 시 확장성을 위해 유틸 클래스로 분리하였습니다. 또한 기타 수정 사항인 개별 광고 조회 시 응답값 수정과 프로젝트 상태 update시 Project status도 함께 추가되도록 변경하였습니다.


## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- BudgetCalculator 유틸 클래스 분리 (ProjectService, DashboardService 공통 로직)
- 개별 조회 광고 조회 시 provider type과 name(제목) 함께 반환
: AdContent에 name 필드 추가
<img width="728" height="760" alt="image" src="https://github.com/user-attachments/assets/6ce40701-e83f-45e9-8f73-c2e08727d55a" />

> 해당 코드 머지 후 해당 컬럼의 값(AdContent name)도 임의로 배포 서버 DB에서 update해놓겠습니다..!
- 프로젝트 상태 변경 시 Project status 함께 업데이트

## 📸 스크린샷 / 테스트 결과 (선택)

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
예산 로직은 구체적으로 작동하는(ex. 대시보드 서비스 단은 db 쿼리 조회를 활용, 프로젝트 서비스 단은 이미 로드된 리스트에서 stream하여 예산을 가져옴) 게 다르기도 하고, 더 구체적으로 구현해서 분리하는 것보다 간단한 예산 계산 로직만 분리하는 게 추후 다른 기능에도 적용하기 좋을 것 같아 제 예상보다 단순화 해서 BudgetCalculator로 분리했습니다! 

(+ 추가적으로 실시간 데이터 수집 및 집계 구현도 제 코드가 올라와야 다른 분들도 수정이 가능한 것으로 파악중인데, 제가 계속 다른 일정들이 겹쳐서 빠른 작업이 안되고 있네요 ㅠㅠ.. 최대한 빨리 진행해보겠습니다 죄송합니다..!!)

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 광고 콘텐츠 정보에 이름 및 공급자(Provider) 필드 추가

* **개선사항**
  * 프로젝트 상태 관리 기능 강화 - 개별 프로젝트 및 조직별 대량 상태 업데이트 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->