### PR TITLE
Refactor/#70 예산 로직 분리 및 캠페인 조회 관련 수정

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/application/dto/response/AdvertisementResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/application/dto/response/AdvertisementResponse.java
@@ -1,6 +1,7 @@
 package com.whereyouad.WhereYouAd.domains.advertisement.application.dto.response;
 
 
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
 
 import java.util.List;
@@ -8,6 +9,8 @@ import java.util.List;
 public class AdvertisementResponse {
     public record AdContentInfoResponse (
             Long id,
+            String name,
+            Provider provider,
             String trackingUrl,
             String landingUrl,
             String description,

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/application/mapper/AdvertisementConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/application/mapper/AdvertisementConverter.java
@@ -1,6 +1,7 @@
 package com.whereyouad.WhereYouAd.domains.advertisement.application.mapper;
 
 import com.whereyouad.WhereYouAd.domains.advertisement.application.dto.response.AdvertisementResponse;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdCampaign;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdContent;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdGroup;
@@ -11,8 +12,11 @@ public class AdvertisementConverter {
 
     public static AdvertisementResponse.AdContentInfoResponse toAdContentInfo(AdContent adContent,
             AdvertisementResponse.AdGroupInfoResponse adGroupInfoResponse) {
+        Provider provider = adContent.getAdGroup().getAdCampaign().getProvider();
         return new AdvertisementResponse.AdContentInfoResponse(
-                adContent.getId(), adContent.getTrackingUrl(), adContent.getLandingUrl(), adContent.getDescription(), adContent.getStatus(), adGroupInfoResponse.targetInfo());
+                adContent.getId(), adContent.getName(), provider,
+                adContent.getTrackingUrl(), adContent.getLandingUrl(),
+                adContent.getDescription(), adContent.getStatus(), adGroupInfoResponse.targetInfo());
     }
 
     public static AdvertisementResponse.AdContentInfosResponse toAdContentsInfo(List<AdContent> adContents) {

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/AdvertisementCommandServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/AdvertisementCommandServiceImpl.java
@@ -73,6 +73,7 @@ public class AdvertisementCommandServiceImpl implements AdvertisementCommandServ
         adCampaignRepository.updateStatusByProjectId(projectId, status);
         adGroupRepository.updateStatusByProjectId(projectId, status);
         adContentRepository.updateStatusByProjectId(projectId, status);
+        projectRepository.updateStatusById(projectId, status);
     }
 
     @Override

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdContent.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdContent.java
@@ -19,6 +19,8 @@ public class AdContent extends BaseEntity {
     @Column(name = "ad_content_id")
     private Long id;
 
+    private String name;
+
     private String trackingUrl;
 
     private String landingUrl;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/domain/service/DashboardServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/domain/service/DashboardServiceImpl.java
@@ -17,6 +17,7 @@ import com.whereyouad.WhereYouAd.domains.organization.exception.code.OrgErrorCod
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgRepository;
 import com.whereyouad.WhereYouAd.domains.project.exception.code.ProjectErrorCode;
+import com.whereyouad.WhereYouAd.global.utils.BudgetCalculator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,6 +42,7 @@ public class DashboardServiceImpl implements DashboardService {
     private final MetricFactRepository metricFactRepository;
     private final OrgMemberRepository orgMemberRepository;
     private final OrgRepository orgRepository;
+    private final BudgetCalculator budgetCalculator;
 
     @Override
     @Transactional(readOnly = true)
@@ -75,12 +77,9 @@ public class DashboardServiceImpl implements DashboardService {
         totalBudget = (totalBudget != null) ? totalBudget : 0L;
         Long totalSpend = (totalSpendDec != null) ? totalSpendDec.longValue() : 0L;
 
-        // 잔액 및 퍼센트
-        Long remainingBudget = totalBudget - totalSpend;
-
-        // 예산이 0원이면 0%, 아니면 (소진액 / 총예산 * 100) 값의 소수점 첫째 자리까지 반올림
-        Double usagePercentage = (totalBudget == 0) ? 0.0
-                : Math.round(((double) totalSpend / totalBudget) * 1000) / 10.0;
+        // 잔액 및 퍼센트 (BudgetCalculator에 위임)
+        Long remainingBudget = budgetCalculator.calculateRemainingBudget(totalBudget, totalSpend);
+        Double usagePercentage = budgetCalculator.calculateUsageRate(totalBudget, BigDecimal.valueOf(totalSpend));
 
         return new DashboardResponse.BudgetSummaryResponse(
                 providerType,

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
@@ -27,13 +27,13 @@ import com.whereyouad.WhereYouAd.domains.project.persistence.repository.ProjectR
 import com.whereyouad.WhereYouAd.domains.user.exception.code.UserErrorCode;
 import com.whereyouad.WhereYouAd.domains.user.exception.handler.UserHandler;
 import com.whereyouad.WhereYouAd.domains.user.persistence.repository.UserRepository;
+import com.whereyouad.WhereYouAd.global.utils.BudgetCalculator;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -50,6 +50,7 @@ public class ProjectServiceImpl implements ProjectService {
     private final OrgRepository orgRepository;
     private final OrgMemberRepository orgMemberRepository;
     private final MetricFactRepository metricFactRepository;
+    private final BudgetCalculator budgetCalculator;
 
     @Override
     public ProjectResponse.CreatedResponse createProject(Long userId, Long orgId,ProjectRequest.CreateRequest request) {
@@ -159,7 +160,7 @@ public class ProjectServiceImpl implements ProjectService {
             BigDecimal totalSpend = spendMap.getOrDefault(projectId, BigDecimal.ZERO);
 
             // 예산 소진 현황 계산 메서드 호출
-            double budgetUsageRate = calculateBudgetUsageRate(projectCampaigns, totalSpend);
+            double budgetUsageRate = budgetCalculator.calculateBudgetUsageRate(projectCampaigns, totalSpend);
 
             return ProjectConverter.toSimpleProjectResponse(project, distinctProviders, budgetUsageRate);
 
@@ -183,7 +184,7 @@ public class ProjectServiceImpl implements ProjectService {
         List<Provider> distinctProviders = extractDistinctProviders(campaignSummaries);
 
         // 총 예산 (캠페인 budget의 합)
-        long totalBudget = calculateTotalBudget(campaignSummaries);
+        long totalBudget = budgetCalculator.calculateTotalBudget(campaignSummaries);
 
         return ProjectConverter.toProjectInfoResponse(project, distinctProviders, totalBudget);
     }
@@ -197,28 +198,7 @@ public class ProjectServiceImpl implements ProjectService {
                 .toList();
     }
 
-    // 총 예산 계산 공통 메서드
-    private long calculateTotalBudget(List<ProjectQueryDto.CampaignSummary> campaignSummaries) {
-        return campaignSummaries.stream()
-                .mapToLong(summary -> summary.budget() != null ? summary.budget() : 0L)
-                .sum();
-    }
 
-    // 예산 소진 현황 계산 메서드
-    private double calculateBudgetUsageRate(List<ProjectQueryDto.CampaignSummary> projectCampaigns, BigDecimal totalSpend) {
-        long totalBudget = calculateTotalBudget(projectCampaigns);
-
-        // 예산이 없거나 지출이 없으면 0.0 반환
-        if (totalBudget <= 0 || totalSpend == null) {
-            return 0.0;
-        }
-
-        // 소진율 계산 (비용 / 예산 * 100), 소수점 첫째 자리 이후로는 버림 처리
-        return totalSpend
-                .multiply(BigDecimal.valueOf(100))
-                .divide(BigDecimal.valueOf(totalBudget), 1, RoundingMode.DOWN)
-                .doubleValue();
-    }
 
     @Override
     public void updateAllProjectsStatus(Long userId, Long orgId, Status status) {

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/domain/service/ProjectServiceImpl.java
@@ -240,6 +240,8 @@ public class ProjectServiceImpl implements ProjectService {
         adCampaignRepository.updateStatusByOrganizationId(orgId, status);
         adGroupRepository.updateStatusByOrganizationId(orgId, status);
         adContentRepository.updateStatusByOrganizationId(orgId, status);
+
+        projectRepository.updateStatusByOrganizationId(orgId, status);
     }
 
     public void validateProject (Long userId, Long orgId) {

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/project/persistence/repository/ProjectRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/project/persistence/repository/ProjectRepository.java
@@ -1,7 +1,9 @@
 package com.whereyouad.WhereYouAd.domains.project.persistence.repository;
 
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
 import com.whereyouad.WhereYouAd.domains.project.persistence.entity.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,4 +16,12 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
 
     @Query("select p from Project p where p.id = :projectId and p.organization.id = :orgId")
     Optional<Project> findByIdAndOrganizationId(@Param("projectId") Long projectId, @Param("orgId") Long orgId);
+
+    @Modifying
+    @Query("UPDATE Project p SET p.status = :status WHERE p.id = :projectId")
+    void updateStatusById(@Param("projectId") Long projectId, @Param("status") Status status);
+
+    @Modifying
+    @Query("UPDATE Project p SET p.status = :status WHERE p.organization.id = :orgId")
+    void updateStatusByOrganizationId(@Param("orgId") Long orgId, @Param("status") Status status);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/global/utils/BudgetCalculator.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/utils/BudgetCalculator.java
@@ -1,0 +1,43 @@
+package com.whereyouad.WhereYouAd.global.utils;
+
+import com.whereyouad.WhereYouAd.domains.project.application.dto.ProjectQueryDto;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+// 공통으로 사용하는 예산 계산 로직
+@Component
+public class BudgetCalculator {
+
+    // 캠페인 리스트에서 총 예산 합산 (null budget은 0 처리)
+    public long calculateTotalBudget(List<ProjectQueryDto.CampaignSummary> campaignSummaries) {
+        return campaignSummaries.stream()
+                .mapToLong(summary -> summary.budget() != null ? summary.budget() : 0L)
+                .sum();
+    }
+
+    // 잔액 계산 (총 예산 - 총 지출)
+    public long calculateRemainingBudget(long totalBudget, long totalSpend) {
+        return totalBudget - totalSpend;
+    }
+
+    // 캠페인 리스트 기반 예산 소진율 계산 (BigDecimal 지출)
+    public double calculateBudgetUsageRate(List<ProjectQueryDto.CampaignSummary> campaignSummaries,
+            BigDecimal totalSpend) {
+        long totalBudget = calculateTotalBudget(campaignSummaries);
+        return calculateUsageRate(totalBudget, totalSpend);
+    }
+
+    // 예산 소진율 계산 (지출 / 예산 * 100), 소수점 첫째 자리까지 버림
+    public double calculateUsageRate(long totalBudget, BigDecimal totalSpend) {
+        if (totalBudget <= 0 || totalSpend == null) {
+            return 0.0;
+        }
+        return totalSpend
+                .multiply(BigDecimal.valueOf(100))
+                .divide(BigDecimal.valueOf(totalBudget), 1, RoundingMode.DOWN)
+                .doubleValue();
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
Close #70 

## 🚀 개요
ProjectService와 DashboardService에 겹치는 예산 계산 로직을, 추후 예산 관련 조회 구현 시 확장성을 위해 유틸 클래스로 분리하였습니다. 또한 기타 수정 사항인 개별 광고 조회 시 응답값 수정과 프로젝트 상태 update시 Project status도 함께 추가되도록 변경하였습니다.


## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- BudgetCalculator 유틸 클래스 분리 (ProjectService, DashboardService 공통 로직)
- 개별 조회 광고 조회 시 provider type과 name(제목) 함께 반환
: AdContent에 name 필드 추가
<img width="728" height="760" alt="image" src="https://github.com/user-attachments/assets/6ce40701-e83f-45e9-8f73-c2e08727d55a" />

> 해당 코드 머지 후 해당 컬럼의 값(AdContent name)도 임의로 배포 서버 DB에서 update해놓겠습니다..!
- 프로젝트 상태 변경 시 Project status 함께 업데이트

## 📸 스크린샷 / 테스트 결과 (선택)

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
(브랜치 이름을 잘못 파서 push 해버려서 다시 PR 올립니다..ㅠㅠ)

예산 로직은 구체적으로 작동하는(ex. 대시보드 서비스 단은 db 쿼리 조회를 활용, 프로젝트 서비스 단은 이미 로드된 리스트에서 stream하여 예산을 가져옴) 게 다르기도 하고, 더 구체적으로 구현해서 분리하는 것보다 간단한 예산 계산 로직만 분리하는 게 추후 다른 기능에도 적용하기 좋을 것 같아 제 예상보다 단순화 해서 BudgetCalculator로 분리했습니다! 

(+ 추가적으로 실시간 데이터 수집 및 집계 구현도 제 코드가 올라와야 다른 분들도 수정이 가능한 것으로 파악중인데, 제가 계속 다른 일정들이 겹쳐서 빠른 작업이 안되고 있네요 ㅠㅠ.. 최대한 빨리 진행해보겠습니다 죄송합니다..!!)

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 광고 정보에 이름, 공급자, 상태, 대상 정보 필드 추가
  * 프로젝트 상태 업데이트 범위 확대

* **리팩터**
  * 예산 계산 로직을 공유 유틸리티로 통합하여 코드 재사용성 개선
  * 대시보드 및 프로젝트 관리 기능의 예산 계산 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->