### PR TITLE
Feat/#73 트래킹 링크 생성 및 리다이렉트 API

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/WhereYouAdApplication.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/WhereYouAdApplication.java
@@ -5,11 +5,13 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableFeignClients
 @EnableAsync
+@EnableScheduling
 public class WhereYouAdApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdContent.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdContent.java
@@ -47,4 +47,8 @@ public class AdContent extends BaseEntity {
     public void updateTrackingUrl(String trackingUrl) {
         this.trackingUrl = trackingUrl;
     }
+
+    public void updateLandingUrl(String landingUrl) {
+        this.landingUrl = landingUrl;
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdContent.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdContent.java
@@ -41,4 +41,8 @@ public class AdContent extends BaseEntity {
     public void updateStatus(Status status) {
         this.status = status;
     }
+
+    public void updateTrackingUrl(String trackingUrl) {
+        this.trackingUrl = trackingUrl;
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdContentRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdContentRepository.java
@@ -44,4 +44,6 @@ public interface AdContentRepository extends JpaRepository<AdContent, Long> {
 
         // trackingUrl이 존재하는지 확인(트래킹 링크 중복 생성 방지)
         boolean existsByTrackingUrl(String trackingUrl);
+
+        Optional<AdContent> findByTrackingUrl(String trackingUrl);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdContentRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdContentRepository.java
@@ -41,4 +41,7 @@ public interface AdContentRepository extends JpaRepository<AdContent, Long> {
         @Modifying
         @Query("UPDATE AdContent a SET a.status = :status WHERE a.adGroup.adCampaign.project.organization.id = :orgId")
         void updateStatusByOrganizationId(@Param("orgId") Long orgId, @Param("status") Status status);
+
+        // trackingUrl이 존재하는지 확인(트래킹 링크 중복 생성 방지)
+        boolean existsByTrackingUrl(String trackingUrl);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdContentRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdContentRepository.java
@@ -26,6 +26,17 @@ public interface AdContentRepository extends JpaRepository<AdContent, Long> {
                         @Param("orgId") Long orgId);
 
         @Query("SELECT ac FROM AdContent ac " +
+                        "JOIN ac.adGroup ag " +
+                        "JOIN ag.adCampaign c " +
+                        "JOIN c.project p " +
+                        "JOIN p.organization o " +
+                        "WHERE ac.id = :adContentId " +
+                        "AND o.id = :orgId")
+        Optional<AdContent> findByIdAndOrganizationId(
+                        @Param("adContentId") Long adContentId,
+                        @Param("orgId") Long orgId);
+
+        @Query("SELECT ac FROM AdContent ac " +
                         "JOIN FETCH ac.adGroup ag " +
                         "JOIN ag.adCampaign c " +
                         "JOIN c.project p " +

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/application/dto/request/ClickRequest.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/application/dto/request/ClickRequest.java
@@ -1,4 +1,15 @@
 package com.whereyouad.WhereYouAd.domains.click.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
 public class ClickRequest {
+
+    public record CreateTrackingUrl(
+            @Schema(description = "광고 연결 랜딩 URL", example = "https://www.whereyouad.com")
+            @NotBlank(message = "Landing URL cannot be empty")
+            @Pattern(regexp = "^(https?://).+", message = "랜딩 url은 http:// or https://로 시작해야 합니다.")
+            String landingUrl
+    ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/application/dto/request/ClickRequest.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/application/dto/request/ClickRequest.java
@@ -1,0 +1,4 @@
+package com.whereyouad.WhereYouAd.domains.click.application.dto.request;
+
+public class ClickRequest {
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/application/dto/request/ClickRequest.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/application/dto/request/ClickRequest.java
@@ -3,6 +3,7 @@ package com.whereyouad.WhereYouAd.domains.click.application.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 public class ClickRequest {
 
@@ -10,6 +11,7 @@ public class ClickRequest {
             @Schema(description = "광고 연결 랜딩 URL", example = "https://www.whereyouad.com")
             @NotBlank(message = "Landing URL cannot be empty")
             @Pattern(regexp = "^(https?://).+", message = "랜딩 url은 http:// or https://로 시작해야 합니다.")
+            @Size(max = 255, message = "랜딩 URL은 255자 이하여야 합니다.")
             String landingUrl
     ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/application/dto/response/ClickResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/application/dto/response/ClickResponse.java
@@ -1,4 +1,9 @@
 package com.whereyouad.WhereYouAd.domains.click.application.dto.response;
 
 public class ClickResponse {
+
+    // 새로운 트래킹 링크 발급 응답
+    public record NewTrackingUrl(
+            String trackingUrl
+    ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/application/dto/response/ClickResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/application/dto/response/ClickResponse.java
@@ -1,9 +1,21 @@
 package com.whereyouad.WhereYouAd.domains.click.application.dto.response;
 
+import com.whereyouad.WhereYouAd.domains.click.domain.constant.DeviceType;
+
+import java.time.LocalDateTime;
+
 public class ClickResponse {
 
     // 새로운 트래킹 링크 발급 응답
     public record NewTrackingUrl(
             String trackingUrl
+    ) {}
+
+    // 클릭 로그 응답 저장 DTO
+    public record ClickEvent(
+            Long adContentId,
+            String ipAddress,
+            String userAgent,
+            LocalDateTime clickedAt
     ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/application/dto/response/ClickResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/application/dto/response/ClickResponse.java
@@ -1,0 +1,4 @@
+package com.whereyouad.WhereYouAd.domains.click.application.dto.response;
+
+public class ClickResponse {
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/application/mapper/ClickConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/application/mapper/ClickConverter.java
@@ -1,4 +1,34 @@
 package com.whereyouad.WhereYouAd.domains.click.application.mapper;
 
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdContent;
+import com.whereyouad.WhereYouAd.domains.click.application.dto.response.ClickResponse;
+import com.whereyouad.WhereYouAd.domains.click.domain.constant.DeviceType;
+import com.whereyouad.WhereYouAd.domains.click.persistence.entity.ClickLog;
+
+import org.springframework.util.StringUtils;
+
 public class ClickConverter {
+
+    public static ClickLog toClickLog(AdContent adContent, ClickResponse.ClickEvent event, boolean isSuspect) {
+        DeviceType deviceType = extractDeviceType(event.userAgent());
+        
+        return ClickLog.builder()
+                .adContent(adContent)
+                .ipAddress(event.ipAddress())
+                .device(deviceType)
+                .clickedAt(event.clickedAt())
+                .isSuspect(isSuspect)
+                .build();
+    }
+
+    private static DeviceType extractDeviceType(String userAgent) {
+        if (!StringUtils.hasText(userAgent)) {
+            return DeviceType.UNKNOWN;
+        }
+        String lowerAgent = userAgent.toLowerCase();
+        if (lowerAgent.contains("mobi") || lowerAgent.contains("android") || lowerAgent.contains("iphone")) {
+            return DeviceType.MOBILE;
+        }
+        return DeviceType.PC;
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/application/mapper/ClickConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/application/mapper/ClickConverter.java
@@ -1,0 +1,4 @@
+package com.whereyouad.WhereYouAd.domains.click.application.mapper;
+
+public class ClickConverter {
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/constant/DeviceType.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/constant/DeviceType.java
@@ -1,0 +1,5 @@
+package com.whereyouad.WhereYouAd.domains.click.domain.constant;
+
+public enum DeviceType {
+    MOBILE, PC, UNKNOWN
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickEventConsumerService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickEventConsumerService.java
@@ -1,0 +1,196 @@
+package com.whereyouad.WhereYouAd.domains.click.domain.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdContent;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdContentRepository;
+import com.whereyouad.WhereYouAd.domains.click.application.dto.response.ClickResponse;
+import com.whereyouad.WhereYouAd.domains.click.application.mapper.ClickConverter;
+import com.whereyouad.WhereYouAd.domains.click.persistence.entity.ClickLog;
+import com.whereyouad.WhereYouAd.domains.click.persistence.repository.ClickLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+// 큐에 적재된 클릭 이벤트를 5초마다 100개씩 db에 insert하는 메서드
+// TODO: kafka 도입 시 1번 로직 수정 필요, 현재는 redis 구조
+public class ClickEventConsumerService {
+
+    private static final String QUEUE_NAME = "click_queue";
+    private static final int BATCH_SIZE = 100;
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+    private final ClickLogRepository clickLogRepository;
+    private final AdContentRepository adContentRepository;
+
+    @Scheduled(fixedDelay = 5000) // 5초마다 실행
+    @Transactional
+    public void consumeClickEvents() {
+        List<ClickResponse.ClickEvent> events = new ArrayList<>();
+
+        // 1. Redis에서 배치 사이즈만큼 RPOP
+        for (int i = 0; i < BATCH_SIZE; i++) {
+            String jsonEvent = redisTemplate.opsForList().rightPop(QUEUE_NAME);
+            if (jsonEvent == null) {
+                break; // 큐가 비어있으면 루프 종료
+            }
+
+            try {
+                ClickResponse.ClickEvent event = objectMapper.readValue(jsonEvent, ClickResponse.ClickEvent.class);
+                events.add(event);
+            } catch (JsonProcessingException e) {
+                log.error("클릭 이벤트 역직렬화 실패: {}", jsonEvent, e);
+            }
+        }
+
+        if (events.isEmpty()) {
+            return;
+        }
+
+        // 2. 유효한 이벤트 필터링 (adContentId 추출)
+        List<ClickLog> clickLogsToSave = new ArrayList<>();
+        List<Long> adContentIdsToFetch = new ArrayList<>();
+
+        for (ClickResponse.ClickEvent event : events) {
+            adContentIdsToFetch.add(event.adContentId());
+        }
+
+        // 3. 광고 정보 조회
+        Map<Long, AdContent> adContentMap = adContentRepository
+                .findAllById(adContentIdsToFetch.stream().distinct().toList())
+                .stream()
+                .collect(Collectors.toMap(AdContent::getId, ad -> ad));
+
+        // 4. ClickLog 엔티티 생성
+        for (ClickResponse.ClickEvent event : events) {
+            AdContent adContent = adContentMap.get(event.adContentId());
+            if (adContent == null) {
+                log.warn("{} 번 광고를 찾을 수 없음", event.adContentId());
+                continue;
+            }
+
+            // 봇 판별
+            boolean isUserAgentBot = isBot(event.userAgent()); // 알려진 봇이나 개발 도구들을 이용한 접근한 경우 봇
+            boolean isAbnormalIp = checkAbnormalIp(event.ipAddress()); // 동일 IP에서 1분에 20회 이상 요청을 보낸 경우 봇
+            boolean suspect = isUserAgentBot || isAbnormalIp; // 위 경우 중 둘 중 하나라도 봇인 경우 봇
+
+            ClickLog clickLog = ClickConverter.toClickLog(adContent, event, suspect);
+
+            clickLogsToSave.add(clickLog);
+        }
+
+        // 5. db 저장
+        if (!clickLogsToSave.isEmpty()) {
+            clickLogRepository.saveAll(clickLogsToSave);
+            log.info("DB에 {}개 저장", clickLogsToSave.size());
+        }
+    }
+
+    // 봇 판별 내부 메서드
+    private boolean isBot(String userAgent) {
+        // 값이 없거나 너무 짧은 경우 정상적인 브라우저 X
+        if (!StringUtils.hasText(userAgent) || userAgent.length() < 10) {
+            return true;
+        }
+
+        String lowerAgent = userAgent.toLowerCase();
+
+        // 1. 헤더에서 봇이라고 밝히는 경우 (검색엔진, 미리보기 등)
+        if (isKnownBot(lowerAgent)) {
+            return true;
+        }
+
+        // 2. 악의적인 봇이거나 스크래퍼/자동화 도구인 경우
+        if (isMaliciousBot(lowerAgent)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean isKnownBot(String lowerAgent) {
+        String[] botKeywords = { // 봇 키워드
+                "bot", "crawler", "spider", "ping", "slurp",
+                "lighthouse", "postman", "curl", "kakaotalk-scrap",
+                "yeti", "googlebot", "bingbot"
+        };
+
+        for (String keyword : botKeywords) {
+            if (lowerAgent.contains(keyword)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // 악의적이거나 비정상적인 접근 패턴을 걸러내는 내부 메서드
+    private boolean isMaliciousBot(String lowerAgent) {
+        // 1. 프로그래밍 언어 및 HTTP 클라이언트 라이브러리의 기본 User-Agent
+        String[] scraperKeywords = {
+                "python-requests", "python-urllib", "java/", "go-http-client", "axios",
+                "node-fetch", "okhttp", "wget", "scrapy", "httpclient", "apache-httpclient"
+        };
+        for (String keyword : scraperKeywords) {
+            if (lowerAgent.contains(keyword)) {
+                return true;
+            }
+        }
+
+        // 2. 자동화/테스트용 Headless 브라우저
+        String[] headlessKeywords = {
+                "headlesschrome", "phantomjs", "puppeteer", "selenium", "playwright", "cypress"
+        };
+        for (String keyword : headlessKeywords) {
+            if (lowerAgent.contains(keyword)) {
+                return true;
+            }
+        }
+
+        // 3. 비정상적인 구조 검사 (대부분 userAgent에 mozilla 또는 opera를 포함)
+        if (!lowerAgent.contains("mozilla") && !lowerAgent.contains("opera")) {
+            return true;
+        }
+
+        return false;
+    }
+
+    // 특정 IP에서 비정상적으로 많은 클릭이 발생하는지 검사 (예: 1분에 20회 초과 시 봇으로 간주)
+    private boolean checkAbnormalIp(String ipAddress) {
+        if (!StringUtils.hasText(ipAddress)) {
+            return false;
+        }
+
+        String key = "click_ip_count:" + ipAddress;
+
+        // 해당 IP의 카운트를 1 증가
+        Long count = redisTemplate.opsForValue().increment(key);
+
+        if (count != null && count == 1) {
+            // 처음 측정되는 IP면 만료 시간(TTL)을 1분으로 설정
+            redisTemplate.expire(key, 1, TimeUnit.MINUTES);
+        }
+
+        // 1분 내에 20회 초과 접속 시 봇으로 취급
+        if (count != null && count > 20) {
+            // 봇으로 취급된 경우 10분 차단
+            redisTemplate.expire(key, 10, TimeUnit.MINUTES);
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickEventConsumerService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickEventConsumerService.java
@@ -8,9 +8,9 @@ import com.whereyouad.WhereYouAd.domains.click.application.dto.response.ClickRes
 import com.whereyouad.WhereYouAd.domains.click.application.mapper.ClickConverter;
 import com.whereyouad.WhereYouAd.domains.click.persistence.entity.ClickLog;
 import com.whereyouad.WhereYouAd.domains.click.persistence.repository.ClickLogRepository;
+import com.whereyouad.WhereYouAd.global.utils.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,7 +32,7 @@ public class ClickEventConsumerService {
     private static final String QUEUE_NAME = "click_queue";
     private static final int BATCH_SIZE = 100;
 
-    private final StringRedisTemplate redisTemplate;
+    private final RedisUtil redisUtil;
     private final ObjectMapper objectMapper;
     private final ClickLogRepository clickLogRepository;
     private final AdContentRepository adContentRepository;
@@ -44,7 +44,7 @@ public class ClickEventConsumerService {
 
         // 1. Redis에서 배치 사이즈만큼 RPOP
         for (int i = 0; i < BATCH_SIZE; i++) {
-            String jsonEvent = redisTemplate.opsForList().rightPop(QUEUE_NAME);
+            String jsonEvent = redisUtil.rightPop(QUEUE_NAME);
             if (jsonEvent == null) {
                 break; // 큐가 비어있으면 루프 종료
             }
@@ -177,17 +177,17 @@ public class ClickEventConsumerService {
         String key = "click_ip_count:" + ipAddress;
 
         // 해당 IP의 카운트를 1 증가
-        Long count = redisTemplate.opsForValue().increment(key);
+        Long count = redisUtil.increment(key);
 
         if (count != null && count == 1) {
             // 처음 측정되는 IP면 만료 시간(TTL)을 1분으로 설정
-            redisTemplate.expire(key, 1, TimeUnit.MINUTES);
+            redisUtil.expire(key, 1, TimeUnit.MINUTES);
         }
 
         // 1분 내에 20회 초과 접속 시 봇으로 취급
         if (count != null && count > 20) {
             // 봇으로 취급된 경우 10분 차단
-            redisTemplate.expire(key, 10, TimeUnit.MINUTES);
+            redisUtil.expire(key, 10, TimeUnit.MINUTES);
             return true;
         }
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickService.java
@@ -5,7 +5,7 @@ import com.whereyouad.WhereYouAd.domains.click.application.dto.response.ClickRes
 public interface ClickService {
 
     // 트래킹 링크 생성 메서드
-    ClickResponse.NewTrackingUrl createTrackingUrl(Long userId, Long adContentId, Long orgId);
+    ClickResponse.NewTrackingUrl createTrackingUrl(Long userId, Long adContentId, Long orgId, String landingUrl);
 
     // 트래킹 링크 접속 시 랜딩 Url 반환 및 이벤트 생성
     String handleTrackingRedirect(String code, String ipAddress, String userAgent);

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickService.java
@@ -1,0 +1,4 @@
+package com.whereyouad.WhereYouAd.domains.click.domain.service;
+
+public interface ClickService {
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickService.java
@@ -1,4 +1,9 @@
 package com.whereyouad.WhereYouAd.domains.click.domain.service;
 
+import com.whereyouad.WhereYouAd.domains.click.application.dto.response.ClickResponse;
+
 public interface ClickService {
+
+    // 트래킹 링크 생성 메서드
+    ClickResponse.NewTrackingUrl createTrackingUrl(Long userId, Long adContentId, Long orgId);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickService.java
@@ -6,4 +6,7 @@ public interface ClickService {
 
     // 트래킹 링크 생성 메서드
     ClickResponse.NewTrackingUrl createTrackingUrl(Long userId, Long adContentId, Long orgId);
+
+    // 트래킹 링크 접속 시 랜딩 Url 반환 및 이벤트 생성
+    String handleTrackingRedirect(String code, String ipAddress, String userAgent);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickServiceImpl.java
@@ -1,4 +1,59 @@
 package com.whereyouad.WhereYouAd.domains.click.domain.service;
 
-public class ClickServiceImpl implements ClickService{
+import com.whereyouad.WhereYouAd.domains.advertisement.exception.AdvertisementHandler;
+import com.whereyouad.WhereYouAd.domains.advertisement.exception.code.AdvertisementErrorCode;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdContent;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdContentRepository;
+import com.whereyouad.WhereYouAd.domains.click.application.dto.response.ClickResponse;
+import com.whereyouad.WhereYouAd.domains.click.exception.ClickHandler;
+import com.whereyouad.WhereYouAd.domains.click.exception.code.ClickErrorCode;
+import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ClickServiceImpl implements ClickService {
+
+    private final AdContentRepository adContentRepository;
+    private final OrgMemberRepository orgMemberRepository;
+
+    @Value("${spring.application.base-url}")
+    private String baseUrl;
+
+    @Override
+    @Transactional
+    public ClickResponse.NewTrackingUrl createTrackingUrl(Long userId, Long adContentId, Long orgId) {
+
+        // 1. 유저가 해당 조직 구성원인지 검증
+        if (!orgMemberRepository.existsByUserIdAndOrganizationId(userId, orgId)) {
+            throw new ClickHandler(ClickErrorCode.CLICK_UNAUTHORIZED);
+        }
+
+        // 2. 광고 조회
+        AdContent adContent = adContentRepository.findById(adContentId)
+                .orElseThrow(() -> new AdvertisementHandler(AdvertisementErrorCode.ADCONTENT_NOT_FOUND));
+
+        // 3. 이미 트래킹 URL이 존재하면 새로 생성하지 않고 기존 URL 반환
+        if (StringUtils.hasText(adContent.getTrackingUrl())) {
+            return new ClickResponse.NewTrackingUrl(adContent.getTrackingUrl());
+        }
+
+        // 4. 동일 코드가 DB에 이미 존재하면 재시도
+        String trackingUrl;
+        do {
+            String code = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+            trackingUrl = baseUrl + "/api/track/" + code;
+        } while (adContentRepository.existsByTrackingUrl(trackingUrl));
+
+        // 5. 트래킹 주소 저장(더티 체킹)
+        adContent.updateTrackingUrl(trackingUrl);
+
+        return new ClickResponse.NewTrackingUrl(trackingUrl);
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickServiceImpl.java
@@ -1,0 +1,4 @@
+package com.whereyouad.WhereYouAd.domains.click.domain.service;
+
+public class ClickServiceImpl implements ClickService{
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickServiceImpl.java
@@ -31,7 +31,7 @@ public class ClickServiceImpl implements ClickService {
 
     @Override
     @Transactional
-    public ClickResponse.NewTrackingUrl createTrackingUrl(Long userId, Long adContentId, Long orgId) {
+    public ClickResponse.NewTrackingUrl createTrackingUrl(Long userId, Long adContentId, Long orgId, String landingUrl) {
 
         // 1. 유저가 해당 조직 구성원인지 검증
         if (!orgMemberRepository.existsByUserIdAndOrganizationId(userId, orgId)) {
@@ -42,19 +42,22 @@ public class ClickServiceImpl implements ClickService {
         AdContent adContent = adContentRepository.findById(adContentId)
                 .orElseThrow(() -> new AdvertisementHandler(AdvertisementErrorCode.ADCONTENT_NOT_FOUND));
 
-        // 3. 이미 트래킹 URL이 존재하면 새로 생성하지 않고 기존 URL 반환
+        // 3. 입력받은 landingUrl로 최신화하여 저장
+        adContent.updateLandingUrl(landingUrl);
+
+        // 4. 이미 트래킹 URL이 존재하면 새로 생성하지 않고 기존 URL 반환
         if (StringUtils.hasText(adContent.getTrackingUrl())) {
             return new ClickResponse.NewTrackingUrl(adContent.getTrackingUrl());
         }
 
-        // 4. 동일 코드가 DB에 이미 존재하면 재시도
+        // 5. 동일 코드가 DB에 이미 존재하면 재시도
         String trackingUrl;
         do {
             String code = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
             trackingUrl = baseUrl + "/api/clicks/track/" + code;
         } while (adContentRepository.existsByTrackingUrl(trackingUrl));
 
-        // 5. 트래킹 주소 저장(더티 체킹)
+        // 6. 트래킹 주소 저장(더티 체킹)
         adContent.updateTrackingUrl(trackingUrl);
 
         return new ClickResponse.NewTrackingUrl(trackingUrl);

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickServiceImpl.java
@@ -48,7 +48,7 @@ public class ClickServiceImpl implements ClickService {
         String trackingUrl;
         do {
             String code = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
-            trackingUrl = baseUrl + "/api/track/" + code;
+            trackingUrl = baseUrl + "/api/clicks/track/" + code;
         } while (adContentRepository.existsByTrackingUrl(trackingUrl));
 
         // 5. 트래킹 주소 저장(더티 체킹)

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickServiceImpl.java
@@ -38,8 +38,8 @@ public class ClickServiceImpl implements ClickService {
             throw new ClickHandler(ClickErrorCode.CLICK_UNAUTHORIZED);
         }
 
-        // 2. 광고 조회
-        AdContent adContent = adContentRepository.findById(adContentId)
+        // 2. 광고 조회 및 AdContent가 해당 조직것인지 검증
+        AdContent adContent = adContentRepository.findByIdAndOrganizationId(adContentId, orgId)
                 .orElseThrow(() -> new AdvertisementHandler(AdvertisementErrorCode.ADCONTENT_NOT_FOUND));
 
         // 3. 입력받은 landingUrl로 최신화하여 저장

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/domain/service/ClickServiceImpl.java
@@ -12,8 +12,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.whereyouad.WhereYouAd.infrastructure.client.click.ClickEventPublisher;
 import org.springframework.util.StringUtils;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Service
@@ -22,6 +24,7 @@ public class ClickServiceImpl implements ClickService {
 
     private final AdContentRepository adContentRepository;
     private final OrgMemberRepository orgMemberRepository;
+    private final ClickEventPublisher clickEventPublisher;
 
     @Value("${spring.application.base-url}")
     private String baseUrl;
@@ -55,5 +58,28 @@ public class ClickServiceImpl implements ClickService {
         adContent.updateTrackingUrl(trackingUrl);
 
         return new ClickResponse.NewTrackingUrl(trackingUrl);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public String handleTrackingRedirect(String code, String ipAddress, String userAgent) {
+        String trackingUrl = baseUrl + "/api/clicks/track/" + code;
+
+        // 1. 광고 조회 (trackingUrl 기반)
+        AdContent adContent = adContentRepository.findByTrackingUrl(trackingUrl)
+                .orElseThrow(() -> new AdvertisementHandler(AdvertisementErrorCode.ADCONTENT_NOT_FOUND));
+
+        // 2. 클릭 이벤트 생성
+        ClickResponse.ClickEvent event = new ClickResponse.ClickEvent(adContent.getId(), ipAddress, userAgent,
+                LocalDateTime.now());
+        // 클릭 이벤트 인터페이스에서 redis에 LPush (이후 ClickEventConsumerService에서 RPOP하며 DB에 insert)
+        clickEventPublisher.publish(event);
+
+        // 3. 랜딩 Url 반환
+        if (StringUtils.hasText(adContent.getLandingUrl())) {
+            return adContent.getLandingUrl();
+        }
+        // 랜딩 Url이 없을 경우 홈으로
+        return baseUrl;
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/exception/ClickHandler.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/exception/ClickHandler.java
@@ -1,0 +1,8 @@
+package com.whereyouad.WhereYouAd.domains.click.exception;
+
+import com.whereyouad.WhereYouAd.global.exception.AppException;
+import com.whereyouad.WhereYouAd.global.exception.BaseErrorCode;
+
+public class ClickHandler extends AppException {
+    public ClickHandler(BaseErrorCode code) { super(code); }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/exception/code/ClickErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/exception/code/ClickErrorCode.java
@@ -1,0 +1,17 @@
+package com.whereyouad.WhereYouAd.domains.click.exception.code;
+
+import com.whereyouad.WhereYouAd.global.exception.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ClickErrorCode implements BaseErrorCode {
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/exception/code/ClickErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/exception/code/ClickErrorCode.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ClickErrorCode implements BaseErrorCode {
 
+    // 403
+    CLICK_UNAUTHORIZED(HttpStatus.FORBIDDEN, "CLICK_403_1", "해당 광고에 접근할 권한이 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/persistence/entity/ClickLog.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/persistence/entity/ClickLog.java
@@ -1,6 +1,7 @@
 package com.whereyouad.WhereYouAd.domains.click.persistence.entity;
 
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdContent;
+import com.whereyouad.WhereYouAd.domains.click.domain.constant.DeviceType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -22,8 +23,9 @@ public class ClickLog {
     @Column(name = "ip_address", length = 45)
     private String ipAddress;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "device", length = 512)
-    private String device;
+    private DeviceType device;
 
     @Column(name = "clicked_at", nullable = false)
     private LocalDateTime clickedAt;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/persistence/repository/ClickLogRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/persistence/repository/ClickLogRepository.java
@@ -1,0 +1,7 @@
+package com.whereyouad.WhereYouAd.domains.click.persistence.repository;
+
+import com.whereyouad.WhereYouAd.domains.click.persistence.entity.ClickLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClickLogRepository extends JpaRepository<ClickLog, Long> {
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/presentation/ClickController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/presentation/ClickController.java
@@ -1,0 +1,6 @@
+package com.whereyouad.WhereYouAd.domains.click.presentation;
+
+import com.whereyouad.WhereYouAd.domains.click.presentation.docs.ClickControllerDocs;
+
+public class ClickController implements ClickControllerDocs {
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/presentation/ClickController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/presentation/ClickController.java
@@ -1,6 +1,30 @@
 package com.whereyouad.WhereYouAd.domains.click.presentation;
 
+import com.whereyouad.WhereYouAd.domains.click.application.dto.response.ClickResponse;
+import com.whereyouad.WhereYouAd.domains.click.domain.service.ClickService;
 import com.whereyouad.WhereYouAd.domains.click.presentation.docs.ClickControllerDocs;
+import com.whereyouad.WhereYouAd.global.response.DataResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
+@RestController
+@RequestMapping("/api/clicks")
+@RequiredArgsConstructor
 public class ClickController implements ClickControllerDocs {
+
+    private final ClickService clickService;
+
+    @PostMapping("/{orgId}/{adContentId}/tracking-url")
+    public ResponseEntity<DataResponse<ClickResponse.NewTrackingUrl>> createTrackingUrl(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId,
+            @PathVariable Long adContentId
+    ) {
+        ClickResponse.NewTrackingUrl response = clickService.createTrackingUrl(userId, adContentId, orgId);
+        return ResponseEntity.ok(
+                DataResponse.created(response)
+        );
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/presentation/ClickController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/presentation/ClickController.java
@@ -4,10 +4,15 @@ import com.whereyouad.WhereYouAd.domains.click.application.dto.response.ClickRes
 import com.whereyouad.WhereYouAd.domains.click.domain.service.ClickService;
 import com.whereyouad.WhereYouAd.domains.click.presentation.docs.ClickControllerDocs;
 import com.whereyouad.WhereYouAd.global.response.DataResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
 
 @RestController
 @RequestMapping("/api/clicks")
@@ -26,5 +31,24 @@ public class ClickController implements ClickControllerDocs {
         return ResponseEntity.ok(
                 DataResponse.created(response)
         );
+    }
+
+    @Override
+    @GetMapping("/track/{code}")
+    public ResponseEntity<Void> processTracking(
+            @PathVariable String code,
+            HttpServletRequest request
+    ) {
+        String ipAddress = request.getRemoteAddr();
+        String userAgent = request.getHeader("User-Agent");
+        if (userAgent == null) userAgent = "Unknown";
+
+        String landingUrl = clickService.handleTrackingRedirect(code, ipAddress, userAgent);
+
+        HttpHeaders headers = new HttpHeaders();
+        // 헤더 location에 랜딩 url 삽입
+        headers.setLocation(URI.create(landingUrl));
+        // 302 리다이렉트
+        return new ResponseEntity<>(headers, HttpStatus.FOUND);
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/presentation/ClickController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/presentation/ClickController.java
@@ -1,10 +1,12 @@
 package com.whereyouad.WhereYouAd.domains.click.presentation;
 
+import com.whereyouad.WhereYouAd.domains.click.application.dto.request.ClickRequest;
 import com.whereyouad.WhereYouAd.domains.click.application.dto.response.ClickResponse;
 import com.whereyouad.WhereYouAd.domains.click.domain.service.ClickService;
 import com.whereyouad.WhereYouAd.domains.click.presentation.docs.ClickControllerDocs;
 import com.whereyouad.WhereYouAd.global.response.DataResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -25,9 +27,10 @@ public class ClickController implements ClickControllerDocs {
     public ResponseEntity<DataResponse<ClickResponse.NewTrackingUrl>> createTrackingUrl(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
-            @PathVariable Long adContentId
+            @PathVariable Long adContentId,
+            @Valid @RequestBody ClickRequest.CreateTrackingUrl request
     ) {
-        ClickResponse.NewTrackingUrl response = clickService.createTrackingUrl(userId, adContentId, orgId);
+        ClickResponse.NewTrackingUrl response = clickService.createTrackingUrl(userId, adContentId, orgId, request.landingUrl());
         return ResponseEntity.ok(
                 DataResponse.created(response)
         );

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/presentation/docs/ClickControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/presentation/docs/ClickControllerDocs.java
@@ -19,7 +19,7 @@ public interface ClickControllerDocs {
             summary = "트래킹 링크 발급 API",
             description = "광고(adContentId)에 대한 트래킹 URL 발급\n\n" +
                     "- 하나의 광고당 URL은 1개만 존재\n" +
-                    "- 이미 발급된 URL이 있으면 기존 URL을 그대로 반환" +
+                    "- 이미 발급된 URL이 있으면 기존 URL을 그대로 반환\n" +
                     "- 트래킹 링크를 발급하기 위해서 landingURL이 있어야 정상적으로 redirect 되므로 필수적으로 입력"
     )
     @ApiResponses({

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/presentation/docs/ClickControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/presentation/docs/ClickControllerDocs.java
@@ -1,0 +1,4 @@
+package com.whereyouad.WhereYouAd.domains.click.presentation.docs;
+
+public interface ClickControllerDocs {
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/presentation/docs/ClickControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/presentation/docs/ClickControllerDocs.java
@@ -1,14 +1,17 @@
 package com.whereyouad.WhereYouAd.domains.click.presentation.docs;
 
+import com.whereyouad.WhereYouAd.domains.click.application.dto.request.ClickRequest;
 import com.whereyouad.WhereYouAd.domains.click.application.dto.response.ClickResponse;
 import com.whereyouad.WhereYouAd.global.response.DataResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 public interface ClickControllerDocs {
 
@@ -16,7 +19,8 @@ public interface ClickControllerDocs {
             summary = "트래킹 링크 발급 API",
             description = "광고(adContentId)에 대한 트래킹 URL 발급\n\n" +
                     "- 하나의 광고당 URL은 1개만 존재\n" +
-                    "- 이미 발급된 URL이 있으면 기존 URL을 그대로 반환"
+                    "- 이미 발급된 URL이 있으면 기존 URL을 그대로 반환" +
+                    "- 트래킹 링크를 발급하기 위해서 landingURL이 있어야 정상적으로 redirect 되므로 필수적으로 입력"
     )
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "성공 (trackingUrl 반환)"),
@@ -27,7 +31,8 @@ public interface ClickControllerDocs {
     ResponseEntity<DataResponse<ClickResponse.NewTrackingUrl>> createTrackingUrl(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
-            @PathVariable Long adContentId
+            @PathVariable Long adContentId,
+            @Valid @RequestBody ClickRequest.CreateTrackingUrl request
     );
     @Operation(
             summary = "광고 트래킹 리다이렉트 API",

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/presentation/docs/ClickControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/presentation/docs/ClickControllerDocs.java
@@ -1,4 +1,31 @@
 package com.whereyouad.WhereYouAd.domains.click.presentation.docs;
 
+import com.whereyouad.WhereYouAd.domains.click.application.dto.response.ClickResponse;
+import com.whereyouad.WhereYouAd.global.response.DataResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
 public interface ClickControllerDocs {
+
+    @Operation(
+            summary = "트래킹 링크 발급 API",
+            description = "광고(adContentId)에 대한 트래킹 URL 발급\n\n" +
+                    "- 하나의 광고당 URL은 1개만 존재\n" +
+                    "- 이미 발급된 URL이 있으면 기존 URL을 그대로 반환"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "성공 (trackingUrl 반환)"),
+            @ApiResponse(responseCode = "401", description = "로그인 필요 (토큰 없음 또는 만료)"),
+            @ApiResponse(responseCode = "403", description = "해당 조직의 구성원이 아닌 경우"),
+            @ApiResponse(responseCode = "404", description = "해당 adContentId의 광고가 존재하지 않는 경우")
+    })
+    ResponseEntity<DataResponse<ClickResponse.NewTrackingUrl>> createTrackingUrl(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId,
+            @PathVariable Long adContentId
+    );
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/click/presentation/docs/ClickControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/click/presentation/docs/ClickControllerDocs.java
@@ -5,6 +5,7 @@ import com.whereyouad.WhereYouAd.global.response.DataResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,5 +28,17 @@ public interface ClickControllerDocs {
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
             @PathVariable Long adContentId
+    );
+    @Operation(
+            summary = "광고 트래킹 리다이렉트 API",
+            description = "발급된 트래킹 링크 접속 시 클릭 이벤트 기록 후 광고 페이지로 리다이렉트"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "302", description = "리다이렉트 성공"),
+            @ApiResponse(responseCode = "404", description = "유효하지 않은 트래킹 링크")
+    })
+    ResponseEntity<Void> processTracking(
+            @PathVariable String code,
+            HttpServletRequest request
     );
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/global/security/SecurityConfig.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/security/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll() //swagger 접근 허용
                         .requestMatchers("/api/users/my").authenticated() //마이페이지는 인증 필요
-                        .requestMatchers("/api/users/**", "/api/auth/**").permitAll() //로그인, 회원가입, 이메일 인증 접근 허용
+                        .requestMatchers("/api/users/**", "/api/auth/**", "/api/clicks/track/**").permitAll() //로그인, 회원가입, 이메일 인증, 트래킹 접근 허용
                         .anyRequest().authenticated() //이외 접근은 인증 필요
                 )
                 //Spring Security 의 기본 UsernamePasswordAuthenticationFilter 앞에 JwtAuthenticationFilter 등록

--- a/src/main/java/com/whereyouad/WhereYouAd/global/utils/RedisUtil.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/utils/RedisUtil.java
@@ -6,6 +6,7 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -29,5 +30,25 @@ public class RedisUtil {
     //Redis 에서 데이터 지우기(key 값 기반)
     public void deleteData(String key) {
         template.delete(key);
+    }
+
+    // List 데이터 저장 (왼쪽 끝에 저장)
+    public Long leftPush(String key, String value) {
+        return template.opsForList().leftPush(key, value);
+    }
+
+    // List 데이터 꺼내기 (오른쪽 끝에서 추출 및 제거)
+    public String rightPop(String key) {
+        return template.opsForList().rightPop(key);
+    }
+
+    // 카운터
+    public Long increment(String key) {
+        return template.opsForValue().increment(key);
+    }
+
+    // 특정 키의 만료 시간 설정
+    public Boolean expire(String key, long timeout, TimeUnit unit) {
+        return template.expire(key, timeout, unit);
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/click/ClickEventPublisher.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/click/ClickEventPublisher.java
@@ -1,0 +1,9 @@
+package com.whereyouad.WhereYouAd.infrastructure.client.click;
+
+import com.whereyouad.WhereYouAd.domains.click.application.dto.response.ClickResponse;
+
+// 클릭 로그를 큐(지금은 redis, 추후에 kafka)에 적재하기 위한 인터페이스
+public interface ClickEventPublisher {
+    
+    void publish(ClickResponse.ClickEvent event);
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/click/RedisClickEventPublisher.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/click/RedisClickEventPublisher.java
@@ -1,0 +1,36 @@
+package com.whereyouad.WhereYouAd.infrastructure.client.click;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.whereyouad.WhereYouAd.domains.click.application.dto.response.ClickResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component // TODO: kafka 도입 시 어노테이션 제거
+@RequiredArgsConstructor
+// 클릭 이벤트를 redis에 LPush하는 메서드
+public class RedisClickEventPublisher implements ClickEventPublisher {
+
+    private static final String QUEUE_NAME = "click_queue";
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void publish(ClickResponse.ClickEvent event) {
+        try {
+            String jsonEvent = objectMapper.writeValueAsString(event);
+            redisTemplate.opsForList().leftPush(QUEUE_NAME, jsonEvent);
+            log.debug("redis 큐에 클릭 이벤트 저장: {}", jsonEvent);
+        }
+        catch (JsonProcessingException e) {
+            log.error("Json 객체 직렬화 실패: {}", event, e);
+        }
+        catch (Exception e) {
+            log.error("redis 큐에 클릭 이벤트 저장 실패: {}", event, e);
+        }
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/click/RedisClickEventPublisher.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/click/RedisClickEventPublisher.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.whereyouad.WhereYouAd.domains.click.application.dto.response.ClickResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.StringRedisTemplate;
+import com.whereyouad.WhereYouAd.global.utils.RedisUtil;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -16,14 +16,14 @@ public class RedisClickEventPublisher implements ClickEventPublisher {
 
     private static final String QUEUE_NAME = "click_queue";
 
-    private final StringRedisTemplate redisTemplate;
+    private final RedisUtil redisUtil;
     private final ObjectMapper objectMapper;
 
     @Override
     public void publish(ClickResponse.ClickEvent event) {
         try {
             String jsonEvent = objectMapper.writeValueAsString(event);
-            redisTemplate.opsForList().leftPush(QUEUE_NAME, jsonEvent);
+            redisUtil.leftPush(QUEUE_NAME, jsonEvent);
             log.debug("redis 큐에 클릭 이벤트 저장: {}", jsonEvent);
         }
         catch (JsonProcessingException e) {


### PR DESCRIPTION
## 📌 관련 이슈
- Close #73 

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.
- 트래킹 링크 생성 API 추가
- 트래킹 링크 리다이렉트 API 추가
- 클릭 이벤트 redis에 저장 및 5초마다 DB에 insert하는 로직 추가


## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
1. 트래킹 링크 생성 API
- ClickerviceImpl에서 만약 트래킹 링크가 존재한다면 기존 값을 반환, 그렇지 않다면 랜덤 UUID를 생성하여 반환합니다.
- 만약 생성된 랜덤 UUID가 DB에 이미 존재하는 경우를 방지하기 위해 DB에 이미 존재한다면 다시 생성합니다.
2. 트래킹 링크 리다이렉트 API
- 1에서 발급한 트래킹 링크로 GET 요청이 오는 경우 HttpServletRequest 헤더에 있는 값들을 서비스 로직으로 넘깁니다.
- 그 후 ClickServiceImpl에서 광고를 조회하고 클릭 이벤트 DTO를 만들어 redis에 저장하고 조회된 광고의 landingUrl을 반환합니다.
- ClickController에서 받은 랜딩 url을 헤더 location에 삽입하고 302 리다이렉트 처리합니다.
3. 클릭 이벤트 저장
- ClickServiceImpl에서 ClickEventPublisher 인터페이스를 통해 RedisClickEventPublisher 구현체를 이용해 redis에 클릭 이벤트 DTO를 LPush 합니다.
- 스프링 스케줄러를 통해서 5초마다 redis에 저장된 클릭 이벤트 DTO를 RPop하여 DB에 저장합니다.

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.
1. 트래킹 링크 생성 API
- AdContent id 1번에 트래킹 링크가 없는 상태, 랜딩 url은 로컬 스웨거 주소인 상태
<img width="1373" height="83" alt="image" src="https://github.com/user-attachments/assets/ce238704-f12a-482d-ae26-648154bd292a" />

- 요청
<img width="1610" height="620" alt="image" src="https://github.com/user-attachments/assets/7d815fbf-afa4-4570-9070-4eb01b1f6282" />

<img width="1614" height="190" alt="image" src="https://github.com/user-attachments/assets/c660b215-0e65-4c5a-91db-6c3379d9041b" />


3. 트래킹 링크 리다이렉트 API 및 저장
- 생성된 트레킹 링크로 접속
<img width="1919" height="1152" alt="image" src="https://github.com/user-attachments/assets/f834eb26-9383-47f6-869c-87ae4c3abd5b" />

<img width="1919" height="1086" alt="image" src="https://github.com/user-attachments/assets/7c8a2853-88ff-4ec4-9946-e804d6709b46" />

302 redirect 성공, 세부 내용 확인
<img width="859" height="513" alt="image" src="https://github.com/user-attachments/assets/eb62596d-4148-4929-a309-da04ffa86c54" />

- Redirect URL: http://localhost:8080/api/clicks/track/c72a30f9
- Location: http://localhost:8080/swagger-ui/index.html

- 클릭 로그 저장(0:0:0:0:0:0:0:1는 로컬 테스트 환경이라고 합니다..!)
<img width="1448" height="416" alt="image" src="https://github.com/user-attachments/assets/fe203dba-44dc-475f-93e8-d34bc76b7a93" />

- 봇 판별 -> postman으로 요청 보내기 (요청 헤더에 postman이 포함됨)
<img width="893" height="505" alt="image" src="https://github.com/user-attachments/assets/aab19f0a-0367-4601-bd17-30cd14db694a" />

- 결과 저장(봇)
<img width="1473" height="132" alt="image" src="https://github.com/user-attachments/assets/8484bf63-7258-4257-95f1-df88fbcc2261" />



참고) 테스트 하는 방법은 트래킹 링크로 GET 요청을 보내기 전에 개발자 도구를 키고 network 탭에서 preserve log활성화 하신다음에 GET 요청을 보내면 302 응답이 옵니다!

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- redis에서 5초마다 db로 insert하는데 이정도도 실시간으로 괜찮을까요?
- 준영님 sse 테스트할 때 postman 사용하신다고 하셨는데 혹시 영향이 간다면 ClickEventConsumerService에서 postman 지우고 하시면 될 것 같습니다..!
- 지민님이 kafka 도입하신다고 하셔서 일단 최대한 kafka로 바꾸기 쉽도록 ClickEventConsumerService에서 ClickEventPublisher 인터페이스 받아서 구현했고, RedisClickEventPublisher에 @Component 어노테이션 제거하고 ClickEventConsumerService에서 1번 로직만 좀 바꾸면 될 것 같긴한데 지민님 구현하신 방법을 봐야 알 것 같습니다!
- 봇 판별 로직도 ClickEventConsumerService에서 저장할 때 구현해봤는데 괜찮은 지 확인해주시면 감사하겠습니다..! 보통 봇이라고 하면 프로그램 만들어서 하는 경우나 아니면 userAgent에 봇이라고 표기하는 경우, userAgent까지 같이 속여서 하는 경우가 있다고 해서 3가지 경우 고려해서 작성해봤습니다


++ 추가 트래킹 링크를 발급 받으려면 랜딩 url도 필수적으로 받아야 할 것 같아서 랜딩 url 입력받도록 리펙터링 했습니다

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 광고 클릭 추적: 추적 URL 생성 API 및 추적 코드로 리다이렉트(HTTP 302) 기능 추가.
  * 클릭 이벤트 비동기 발행(큐) 및 주기적 배치 소비로 DB 적재.
  * 클릭 로그 응답/요청 스펙 및 디바이스 타입(MOBILE/PC/UNKNOWN) 도입, 랜딩 URL 입력 검증 추가.
  * 의심 클릭 판별(봇 탐지 및 IP 이상행위) 및 플래그 처리.

* **Chores**
  * 추적 엔드포인트를 인증 없이 허용.
  * 애플리케이션 스케줄링 활성화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->