### PR TITLE
Fix/#82 S3 사진 관련 버그 수정 - 조직 사진 관련

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/request/OrgRequest.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/request/OrgRequest.java
@@ -11,8 +11,7 @@ public class OrgRequest {
     public record Create (
             @NotBlank(message = "조직 이름은 필수입니다.")
             String name,
-            String description,
-            String logoUrl
+            String description
     ) {}
 
     public record Read (
@@ -23,7 +22,7 @@ public class OrgRequest {
             @NotBlank(message = "조직 이름은 필수입니다.")
             String name,
             String description,
-            String logoUrl
+            boolean isImageDeleted
     ) {}
 
     public record UpdateRole (

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/mapper/OrgConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/mapper/OrgConverter.java
@@ -56,11 +56,11 @@ public class OrgConverter {
     }
 
     //DTO -> Entity
-    public static Organization toOrganization(Long userId, OrgRequest.Create request) {
+    public static Organization toOrganization(Long userId, OrgRequest.Create request, String imageUrl) {
         return Organization.builder()
                 .name(request.name())
                 .description(request.description())
-                .logoUrl(request.logoUrl())
+                .logoUrl(imageUrl)
                 .ownerUserId(userId)
                 .status(OrgStatus.ACTIVE)
                 .build();

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
@@ -2,10 +2,11 @@ package com.whereyouad.WhereYouAd.domains.organization.domain.service;
 
 import com.whereyouad.WhereYouAd.domains.organization.application.dto.request.OrgRequest;
 import com.whereyouad.WhereYouAd.domains.organization.application.dto.response.OrgResponse;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface OrgService {
 
-    OrgResponse.Create createOrganization(Long userId, OrgRequest.Create request);
+    OrgResponse.Create createOrganization(Long userId, OrgRequest.Create request, MultipartFile imageFile);
 
     OrgResponse.MyOrganizations getMyOrganizations(Long userId);
 
@@ -13,7 +14,7 @@ public interface OrgService {
 
     OrgResponse.MyOrganizations getSoftDeletedOrgs(Long userId);
 
-    OrgResponse.Update modifyOrganization(Long userId, Long orgId, OrgRequest.Update request);
+    OrgResponse.Update modifyOrganization(Long userId, Long orgId, OrgRequest.Update request, MultipartFile imageFile);
 
     void removeOrganization(Long userId, Long orgId);
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -20,6 +20,7 @@ import com.whereyouad.WhereYouAd.domains.user.persistence.repository.UserReposit
 import com.whereyouad.WhereYouAd.global.utils.RedisUtil;
 import com.whereyouad.WhereYouAd.infrastructure.client.aws.s3.S3UploadService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -29,6 +30,7 @@ import java.util.*;
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class OrgServiceImpl implements OrgService {
 
     private final OrgRepository orgRepository;
@@ -62,16 +64,24 @@ public class OrgServiceImpl implements OrgService {
             imageUrl = s3UploadService.uploadImage(imageFile);
         }
 
-        // 조직 생성
-        Organization organization = OrgConverter.toOrganization(userId, request, imageUrl);
+        try {
+            // 조직 생성
+            Organization organization = OrgConverter.toOrganization(userId, request, imageUrl);
 
-        // OrgMember 생성
-        OrgMember orgMember = OrgMemberConverter.toOrgMemberADMIN(user, organization);
+            // OrgMember 생성
+            OrgMember orgMember = OrgMemberConverter.toOrgMemberADMIN(user, organization);
 
-        orgRepository.save(organization);
-        orgMemberRepository.save(orgMember);
+            orgRepository.save(organization);
+            orgMemberRepository.save(orgMember);
 
-        return OrgConverter.toCreatedResponse(organization);
+            return OrgConverter.toCreatedResponse(organization);
+        } catch (Exception e) { //조직 생성 중 오류 발생 시
+            if (imageUrl != null) { //로고 이미지 S3 에서 삭제 진행 (orphan 방지)
+                s3UploadService.deleteImageFromUrl(imageUrl);
+            }
+
+            throw new OrgHandler(OrgErrorCode.ORG_CREATE_FAILED);
+        }
     }
 
     //로그인한 회원이 속한 조직 모두 조회 메서드
@@ -195,12 +205,7 @@ public class OrgServiceImpl implements OrgService {
             throw new OrgHandler(OrgErrorCode.ORG_FORBIDDEN); // 예외처리
         }
 
-        //추가 : 조직 로고 이미지 존재 시, 이미지를 S3 에서 삭제하는 로직 추가
         String logoUrl = organization.getLogoUrl();
-
-        if (logoUrl != null) {
-            s3UploadService.deleteImageFromUrl(logoUrl);
-        }
 
         // 해당 조직에 가입된 모든 회원들의 가입 정보 삭제
         List<OrgMember> orgMembers = orgMemberRepository.findOrgMemberByOrg(organization);
@@ -209,6 +214,17 @@ public class OrgServiceImpl implements OrgService {
 
         // 조직 실제 삭제
         orgRepository.delete(organization);
+
+        //추가 : 조직 로고 이미지 존재 시, 이미지를 S3 에서 삭제하는 로직 추가
+        //조직 삭제 이후 이미지 삭제하여 이미지 삭제 실패 시 조직 삭제 실패 방지
+        if (logoUrl != null) {
+            try {
+                s3UploadService.deleteImageFromUrl(logoUrl);
+            } catch (Exception e) {
+                log.warn("S3 이미지 삭제 실패: {}", logoUrl, e);
+            }
+
+        }
     }
 
     // 조직 삭제 메서드 -> Soft Delete (status 만 DELETED 로 변경)

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -18,9 +18,11 @@ import com.whereyouad.WhereYouAd.domains.user.exception.handler.UserHandler;
 import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
 import com.whereyouad.WhereYouAd.domains.user.persistence.repository.UserRepository;
 import com.whereyouad.WhereYouAd.global.utils.RedisUtil;
+import com.whereyouad.WhereYouAd.infrastructure.client.aws.s3.S3UploadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.*;
 
@@ -35,9 +37,10 @@ public class OrgServiceImpl implements OrgService {
 
     private final RedisUtil redisUtil;
     private final EmailService emailService;
+    private final S3UploadService s3UploadService;
 
     // 조직(워크스페이스) 생성 메서드
-    public OrgResponse.Create createOrganization(Long userId, OrgRequest.Create request) {
+    public OrgResponse.Create createOrganization(Long userId, OrgRequest.Create request, MultipartFile imageFile) {
 
         // 유저 정보 추출
         User user = userRepository.findById(userId)
@@ -53,8 +56,14 @@ public class OrgServiceImpl implements OrgService {
             }
         }
 
+        //추가 : 로고 이미지 처리
+        String imageUrl = null;
+        if (imageFile != null && !imageFile.isEmpty()) {
+            imageUrl = s3UploadService.uploadImage(imageFile);
+        }
+
         // 조직 생성
-        Organization organization = OrgConverter.toOrganization(userId, request);
+        Organization organization = OrgConverter.toOrganization(userId, request, imageUrl);
 
         // OrgMember 생성
         OrgMember orgMember = OrgMemberConverter.toOrgMemberADMIN(user, organization);
@@ -115,7 +124,7 @@ public class OrgServiceImpl implements OrgService {
     }
 
     // 조직 정보 수정 메서드
-    public OrgResponse.Update modifyOrganization(Long userId, Long orgId, OrgRequest.Update request) {
+    public OrgResponse.Update modifyOrganization(Long userId, Long orgId, OrgRequest.Update request, MultipartFile imageFile) {
         Organization organization = orgRepository.findById(orgId)
                 .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
 
@@ -124,8 +133,34 @@ public class OrgServiceImpl implements OrgService {
             throw new OrgHandler(OrgErrorCode.ORG_FORBIDDEN); // 예외처리
         }
 
+        //조직 로고 이미지 처리 추가
+        String oldLogoUrl = organization.getLogoUrl();
+        //기본적으로는 기존 이미지 유지
+        String finalLogoImageUrl = oldLogoUrl;
+
+        //로고 이미지를 기본 공백 이미지로 하는 거라면
+        if (request.isImageDeleted()) {
+            finalLogoImageUrl = null; //URL 을 null 처리
+
+            //기존 로고 이미지 존재 시 삭제
+            if (oldLogoUrl != null) {
+                s3UploadService.deleteImageFromUrl(oldLogoUrl);
+            }
+
+        } else if (imageFile != null && !imageFile.isEmpty()) { //이미지 변경이라면,
+            //이미지 업로드
+            finalLogoImageUrl = s3UploadService.uploadImage(imageFile);
+
+            //기존 로고 이미지 존재 시 삭제
+            if (oldLogoUrl != null) {
+                s3UploadService.deleteImageFromUrl(oldLogoUrl);
+            }
+
+        }
+
         // 조직 정보 수정
         organization.modifyInfo(request);
+        organization.modifyLogoImage(finalLogoImageUrl);
 
         // 변환 된 필드값과 해당 조직의 Id, updatedAt 가 포함된 DTO 로 반환
         return OrgConverter.toUpdatedResponse(organization);
@@ -158,6 +193,13 @@ public class OrgServiceImpl implements OrgService {
         // 만약 조직 삭제 요청한 회원이 해당 조직을 생성한 회원이 아니라면,
         if (!organization.getOwnerUserId().equals(userId)) {
             throw new OrgHandler(OrgErrorCode.ORG_FORBIDDEN); // 예외처리
+        }
+
+        //추가 : 조직 로고 이미지 존재 시, 이미지를 S3 에서 삭제하는 로직 추가
+        String logoUrl = organization.getLogoUrl();
+
+        if (logoUrl != null) {
+            s3UploadService.deleteImageFromUrl(logoUrl);
         }
 
         // 해당 조직에 가입된 모든 회원들의 가입 정보 삭제

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -76,8 +76,13 @@ public class OrgServiceImpl implements OrgService {
 
             return OrgConverter.toCreatedResponse(organization);
         } catch (Exception e) { //조직 생성 중 오류 발생 시
+            log.error("조직 생성 실패: {}", e.getMessage(), e);
             if (imageUrl != null) { //로고 이미지 S3 에서 삭제 진행 (orphan 방지)
-                s3UploadService.deleteImageFromUrl(imageUrl);
+                try {
+                    s3UploadService.deleteImageFromUrl(imageUrl);
+                } catch (Exception deleteException) {
+                    log.warn("조직 생성 실패 후 S3 이미지 삭제 실패: {}", imageUrl, deleteException);
+                }
             }
 
             throw new OrgHandler(OrgErrorCode.ORG_CREATE_FAILED);
@@ -159,7 +164,6 @@ public class OrgServiceImpl implements OrgService {
                 } catch (Exception e) {
                     log.warn("조직 정보 수정 진행간에 S3 이미지 삭제 실패: {}", oldLogoUrl, e);
                 }
-                s3UploadService.deleteImageFromUrl(oldLogoUrl);
             }
 
         } else if (imageFile != null && !imageFile.isEmpty()) { //이미지 변경이라면,

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -154,6 +154,11 @@ public class OrgServiceImpl implements OrgService {
 
             //기존 로고 이미지 존재 시 삭제
             if (oldLogoUrl != null) {
+                try {
+                    s3UploadService.deleteImageFromUrl(oldLogoUrl);
+                } catch (Exception e) {
+                    log.warn("조직 정보 수정 진행간에 S3 이미지 삭제 실패: {}", oldLogoUrl, e);
+                }
                 s3UploadService.deleteImageFromUrl(oldLogoUrl);
             }
 
@@ -163,7 +168,12 @@ public class OrgServiceImpl implements OrgService {
 
             //기존 로고 이미지 존재 시 삭제
             if (oldLogoUrl != null) {
-                s3UploadService.deleteImageFromUrl(oldLogoUrl);
+                try {
+                    s3UploadService.deleteImageFromUrl(oldLogoUrl);
+                } catch (Exception e) {
+                    log.warn("조직 정보 수정 진행간에 S3 이미지 삭제 실패: {}", oldLogoUrl, e);
+                }
+
             }
 
         }
@@ -221,7 +231,7 @@ public class OrgServiceImpl implements OrgService {
             try {
                 s3UploadService.deleteImageFromUrl(logoUrl);
             } catch (Exception e) {
-                log.warn("S3 이미지 삭제 실패: {}", logoUrl, e);
+                log.warn("조직 삭제 간에 S3 이미지 삭제 실패: {}", logoUrl, e);
             }
 
         }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
@@ -31,6 +31,9 @@ public enum OrgErrorCode implements BaseErrorCode {
     //410
     ORG_SOFT_DELETED(HttpStatus.GONE, "ORG_410_1", "해당 조직은 삭제된 조직입니다.(Soft Delete)"),
     ORG_INVITATION_INVALID(HttpStatus.BAD_REQUEST, "ORG_INVITATION_400", "조직 초대 토큰이 만료되었거나 유효하지 않습니다."),
+
+    //500
+    ORG_CREATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "ORG_500_1", "조직 생성 중 서버 오류가 발생했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/entity/Organization.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/entity/Organization.java
@@ -40,7 +40,10 @@ public class Organization extends BaseEntity {
     public void modifyInfo(OrgRequest.Update request) {
         this.name = request.name();
         this.description = request.description();
-        this.logoUrl = request.logoUrl();
+    }
+
+    public void modifyLogoImage(String imageUrl) {
+        this.logoUrl = imageUrl;
     }
 
     public void softDelete() {

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,9 +24,11 @@ public class OrgController implements OrgControllerDocs {
     @PostMapping("/create")
     public ResponseEntity<DataResponse<OrgResponse.Create>> createOrganization(
             @AuthenticationPrincipal(expression = "userId") Long userId,
-            @RequestBody @Valid OrgRequest.Create request
-    ) {
-        OrgResponse.Create response = orgService.createOrganization(userId, request);
+            @RequestPart(value = "request") @Valid OrgRequest.Create request,
+            @RequestPart(value = "image", required = false) MultipartFile image
+    )
+    {
+        OrgResponse.Create response = orgService.createOrganization(userId, request, image);
         return ResponseEntity.ok(
                 DataResponse.created(response)
         );
@@ -70,10 +73,11 @@ public class OrgController implements OrgControllerDocs {
     public ResponseEntity<DataResponse<OrgResponse.Update>> modifyOrganization(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
-            @RequestBody @Valid OrgRequest.Update request
+            @RequestPart(value = "request") @Valid OrgRequest.Update request,
+            @RequestPart(value = "image", required = false) MultipartFile imageFile
     )
     {
-        OrgResponse.Update response = orgService.modifyOrganization(userId, orgId, request);
+        OrgResponse.Update response = orgService.modifyOrganization(userId, orgId, request, imageFile);
         return ResponseEntity.ok(
                 DataResponse.from(response)
         );

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
@@ -68,7 +68,7 @@ public interface OrgControllerDocs {
     @Operation(
             summary = "조직 정보 수정 API",
             description = "새로운 조직 이름, 설명, 로고 이미지 파일을 받아 저장(해당 조직을 생성한 회원만 정보 변경 가능)\n\n"
-                    + "request 에서 boolean 값인 isImageDeleted 를 true 로 하고 image 파일에 null 값을 담아 전송하면 조직 로고 이미지를 null 값으로 지정하고, isImageDeleted 를 true 로 하고 image 파일에 false 값을 담아 전송하면 기존 조직 로고 이미지를 유지합니다.\n\n"
+                    + "request 에서 boolean 값인 isImageDeleted 를 true 로 하고 image 파일에 null 값을 담아 전송하면 조직 로고 이미지를 null 값으로 지정하고, isImageDeleted 를 true 로 하고 image 파일에 null 값을 담아 전송하면 기존 조직 로고 이미지를 유지합니다.\n\n"
                     + "🚨 **[프론트엔드 연동 주의사항]** 🚨\n"
                     + "- 요청 시 반드시 `multipart/form-data` 형식으로 전송해야 합니다.\n"
                     + "- `request` 파트는 단순 문자열이나 객체가 아닌, **`application/json` 타입의 Blob 객체**로 변환하여 append 해야 합니다.\n"

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
@@ -10,18 +10,26 @@ import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface OrgControllerDocs {
     @Operation(
             summary = "조직 생성 API",
-            description = "조직 이름, 설명, 로고 이미지 URL 을 받아 저장(로그인이 진행된 회원만 가능)"
+            description = "조직 이름, 설명, 로고 이미지 파일을 받아 저장(로그인이 진행된 회원만 가능)\n\n"
+                    + "🚨 **[프론트엔드 연동 주의사항]** 🚨\n"
+                    + "- 요청 시 반드시 `multipart/form-data` 형식으로 전송해야 합니다.\n"
+                    + "- `request` 파트는 단순 문자열이나 객체가 아닌, **`application/json` 타입의 Blob 객체**로 변환하여 append 해야 합니다.\n"
+                    + "- `image` 파트는 파일 객체를 그대로 append 합니다. (변경하지 않을 경우 생략 가능)"
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
             @ApiResponse(responseCode = "400_1", description = "조직 이름 중복")
     })
-    public ResponseEntity<DataResponse<OrgResponse.Create>> createOrganization(@AuthenticationPrincipal(expression = "userId") Long userId,
-                                                                               @RequestBody @Valid OrgRequest.Create request);
+    public ResponseEntity<DataResponse<OrgResponse.Create>> createOrganization(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @RequestPart(value = "request") @Valid OrgRequest.Create request,
+            @RequestPart(value = "image", required = false) MultipartFile image
+    );
 
     @Operation(
             summary = "내가 속한 조직 전체 조회 API",
@@ -59,7 +67,12 @@ public interface OrgControllerDocs {
 
     @Operation(
             summary = "조직 정보 수정 API",
-            description = "새로운 조직 이름, 설명, 로고 이미지 URL 을 받아 저장(해당 조직을 생성한 회원만 정보 변경 가능)"
+            description = "새로운 조직 이름, 설명, 로고 이미지 파일을 받아 저장(해당 조직을 생성한 회원만 정보 변경 가능)\n\n"
+                    + "request 에서 boolean 값인 isImageDeleted 를 true 로 하고 image 파일에 null 값을 담아 전송하면 조직 로고 이미지를 null 값으로 지정하고, isImageDeleted 를 true 로 하고 image 파일에 false 값을 담아 전송하면 기존 조직 로고 이미지를 유지합니다.\n\n"
+                    + "🚨 **[프론트엔드 연동 주의사항]** 🚨\n"
+                    + "- 요청 시 반드시 `multipart/form-data` 형식으로 전송해야 합니다.\n"
+                    + "- `request` 파트는 단순 문자열이나 객체가 아닌, **`application/json` 타입의 Blob 객체**로 변환하여 append 해야 합니다.\n"
+                    + "- `image` 파트는 파일 객체를 그대로 append 합니다. (변경하지 않을 경우 생략 가능)"
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공(변경된 필드 값들과 조직Id, 변경 시각 반환)"),
@@ -69,7 +82,8 @@ public interface OrgControllerDocs {
     public ResponseEntity<DataResponse<OrgResponse.Update>> modifyOrganization(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
-            @RequestBody @Valid OrgRequest.Update request
+            @RequestPart(value = "request") @Valid OrgRequest.Update request,
+            @RequestPart(value = "image", required = false) MultipartFile imageFile
     );
 
     @Operation(
@@ -91,7 +105,8 @@ public interface OrgControllerDocs {
     @Operation(
             summary = "조직 삭제 API",
             description = "조직 Id 를 PathVariable 로 받아 해당 조직 삭제(해당 조직을 생성한 회원만 삭제 가능) \n\n" +
-                    "param 인 isHard = true 이면 Hard Delete (DB에서 삭제), isHard = false 이면 Soft Delete (status 만 DELETED 로 변경)"
+                    "param 인 isHard = true 이면 Hard Delete (DB에서 삭제), isHard = false 이면 Soft Delete (status 만 DELETED 로 변경)\n\n"
+                    + "*추가* Hard Delete 시 조직 로고 이미지가 S3 에서 자동 삭제됩니다. Soft Delete 시에는 삭제되지 않습니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/docs/UserControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/docs/UserControllerDocs.java
@@ -100,7 +100,7 @@ public interface UserControllerDocs {
     @Operation(
             summary = "회원 정보 수정 API",
             description = "회원이 수정하려는 이름, 프로필 이미지 파일, 기존 비밀번호와 새로운 비밀번호 값을 입력받아 정보 수정을 진행합니다.\n\n" +
-                    "request 에서 boolean 값인 isImageDeleted 를 true 로 하고 image 파일에 null 값을 담아 전송하면 회원 프로필 이미지를 null 값으로 지정하고, isImageDeleted 를 true 로 하고 image 파일에 null 값을 담아 전송하면 기존 프로필 이미지를 유지합니다.\n\n"
+                    "request 에서 boolean 값인 isImageDeleted 를 true 로 하고 image 파일에 null 값을 담아 전송하면 회원 프로필 이미지를 null 값으로 지정하고, isImageDeleted 를 false 로 하고 image 파일에 null 값을 담아 전송하면 기존 프로필 이미지를 유지합니다.\n\n"
                     + "🚨 **[프론트엔드 연동 주의사항]** 🚨\n"
                     + "- 요청 시 반드시 `multipart/form-data` 형식으로 전송해야 합니다.\n"
                     + "- `request` 파트는 단순 문자열이나 객체가 아닌, **`application/json` 타입의 Blob 객체**로 변환하여 append 해야 합니다.\n"


### PR DESCRIPTION
## 📌 관련 이슈
- Close #82 

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

조직 생성, 정보변경, 삭제 시 로고 이미지 파일 받기 & 기존 로고 이미지 S3 에서 제거 로직 추가

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- 조직 생성 시 로고 이미지 URL 이 아닌 이미지 파일 자체를 받도록 수정
- 조직 정보 변경 시 이미지 파일 자체를 받아 정보 변경하도록 수정
- 조직 Hard Delete 시 S3 에서 로고 이미지 제거하도록 수정

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.

1. 조직 생성 -> 이미지 파일을 받아 S3 에 업로드 하도록 수정했습니다.
<img width="958" height="512" alt="조직 생성 Swagger" src="https://github.com/user-attachments/assets/fab03a63-fa1f-44b5-9384-e39a27b7499a" />
<img width="668" height="160" alt="조직 생성 DB" src="https://github.com/user-attachments/assets/619cf640-8a6d-429b-a210-912c507ac847" />

2. 조직 정보 변경 -> boolean isImageDeleted 필드를 도입하여 로고 이미지를 빈 이미지로 하는지 기존 이미지를 유지하는지 구분하도록 했습니다.

2-1 조직 정보 변경 전 DB (org_id = 1 인 조직 정보 변경 예정)
<img width="665" height="62" alt="조직 수정 전 DB" src="https://github.com/user-attachments/assets/3a7f2216-a466-4d63-b8b3-3646c9c6394f" />

2-2 조직 정보 변경
<img width="953" height="545" alt="조직 수정 Postman" src="https://github.com/user-attachments/assets/bab3b8ed-cb9b-4393-b891-0a70bd18b471" />

<img width="662" height="61" alt="조직 수정 후 DB" src="https://github.com/user-attachments/assets/00804b06-43e2-4743-87d1-231df2e3e017" />

2-3 조직 로고 이미지 빈 이미지로 변경
<img width="953" height="564" alt="조직 이미지 제거 Postman" src="https://github.com/user-attachments/assets/8a142c86-e204-4f05-b888-90cbd5d165d3" />
<img width="664" height="77" alt="조직 이미지 제거 DB" src="https://github.com/user-attachments/assets/2fd331b9-1b78-4cb6-a8e7-2f02da37b4a7" />

## ✅ 체크리스트
- [✅] 브랜치 전략(GitHub Flow)을 준수했나요?
- [✅] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [✅] 테스트 통과 확인
- [✅] 서버 실행 확인
- [✅] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- 저번 교수님 피드백 때 프론트에서 요청한 부분 반영해서 조직 CRUD API 에서 S3 처리도 함께 하도록 수정해봤습니다.
- 조직 삭제의 경우 응답값이 동일해서 테스트 이미지를 올리진 않았고, Hard Delete 시에 조직 로고 이미지 URL 존재할때만 S3 에서 삭제하도록 진행했습니다. Soft Delete 시에는 S3 에서 삭제하진 않는 것으로 진행했습니다.
- 회원 프로필 이미지 관련은 따로 만든 회원 정보 수정 API 에서 처리하므로 조직 관련 이미지 수정만 진행했습니다.
- PR 완료되면 프론트 측에 API 변경되었다고 공지할 예정입니다!

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 조직 로고 파일 업로드 및 S3 저장 지원 추가

* **개선사항**
  * 조직 생성/수정 API가 multipart/form-data(요청 본문 + 선택적 이미지)로 변경
  * 조직 생성/수정 흐름에 이미지 업로드·삭제 처리 및 로고 별도 갱신 적용
  * 조직 완전 삭제 시 업로드된 로고 자동 제거 처리
  * 조직 생성 실패 전용 오류 코드 추가

* **문서**
  * API 문서에 멀티파트 전송 방식, 이미지 삭제 동작 및 프로필 이미지 삭제 의미 변경 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->