### PR TITLE
:bug: fix: 로그인 Service 메서드 Transactional 어노테이션 제거 (DB 커넥션 고갈 방지)

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/AuthService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/AuthService.java
@@ -26,7 +26,7 @@ public class AuthService {
     private final CustomUserDetailsService customUserDetailsService;
 
     //최초 로그인을 통해 AccessToken 과 RefreshToken 발급 받는 메서드
-    @Transactional
+    //Transactional 어노테이션 제거 -> 메서드 전체에 Transactional 을 걸 시 DB 커넥션 풀 고갈 가능
     public TokenResponse login(LoginRequest request) {
         //email, password 기반 Spring Security가 사용할 인증 객체(AuthenticationToken) 생성
         UsernamePasswordAuthenticationToken authenticationToken =
@@ -34,12 +34,14 @@ public class AuthService {
 
         //실제 password 검증
         // authenticate()가 실행되면 CustomUserDetailsService.loadUserByUsername이 호출되어 DB의 유저 정보와 비교합니다.
+        // CustomUserDetailsService 내부적으로만 짧게 DB 커넥션을 사용하고 반납
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
 
-        //인증 정보 기반 JWT 토큰(Access & Refresh) 생성
+        //인증 정보 기반 JWT 토큰(Access & Refresh) 생성 (DB 커넥션 없이 순수 CPU 연산으로 진행)
         TokenResponse tokenResponse = jwtTokenProvider.generateToken(authentication);
 
         //RefreshToken 저장 -> 없으면 생성, 이미 있으면 update
+        //Spring Data JPA의 findBy... 와 save 메서드는 자체적으로 트랜잭션이 적용되어 있어 Transactional 어노테이션 없어도 안전
         RefreshToken refreshToken = refreshTokenRepository.findByKeyId(request.email())
                 .map(entity -> entity.updateValue(tokenResponse.refreshToken()))
                 .orElse(RefreshToken.builder()
@@ -47,6 +49,7 @@ public class AuthService {
                         .value(tokenResponse.refreshToken()).
                         build());
 
+        // RefreshToken save 에도 짧게 커넥션을 다시 맺고 데이터를 저장 후 반환
         refreshTokenRepository.save(refreshToken);
 
         return tokenResponse;


### PR DESCRIPTION
## 📌 관련 이슈
- Close #96 

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

로그인 API 트래픽 부하 발생 시 DB 커넥션 풀 고갈로 인한 오류 수정

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- AuthService 내부 login 메서드에 Transactional 어노테이션 제거

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.

어노테이션 제거 이후에도 로그인이 정상 동작하는 것을 확인했고,
<img width="1919" height="1065" alt="image" src="https://github.com/user-attachments/assets/1c4d2dce-7aba-4018-a72a-ec323c2f9e4f" />

Postman 에서 1분동안 20개의 가상 요청을 날리는 부하 테스트에서도 오류 없음 확인 완료
<img width="1920" height="1350" alt="image" src="https://github.com/user-attachments/assets/c44e19c8-2141-4902-bde9-17bf57bab379" />



## ✅ 체크리스트
- [✅] 브랜치 전략(GitHub Flow)을 준수했나요?
- [✅] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [✅] 테스트 통과 확인
- [✅] 서버 실행 확인
- [✅] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- AuthService 내부 login 메서드에서 Transactional 을 제거해 DB 커넥션 풀이 고갈되는 것을 방지하도록 했습니다.
- 프론트 작업 과정에서 트래픽이 몰리게 되면 다시 서버를 재시작해야 할 수 있어서, 머지 오류 없으면 바로 머지해서 반영하겠습니다.


> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 인증 서비스의 트랜잭션 처리 구조 최적화. 토큰 생성 및 저장소 작업의 트랜잭션 관리 방식을 개선하여 전체 처리 효율성을 향상시켰습니다. 기능 동작은 변함이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->