### PR TITLE
Fix/#98  로그인 오류 수정 - Spring OSIV 설정 비활성화 & SSE Nginx 설정 추가

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/presentation/DashboardController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/presentation/DashboardController.java
@@ -5,6 +5,7 @@ import com.whereyouad.WhereYouAd.domains.dashboard.domain.service.DashboardClick
 import com.whereyouad.WhereYouAd.domains.dashboard.domain.service.DashboardService;
 import com.whereyouad.WhereYouAd.domains.dashboard.presentation.docs.DashboardControllerDocs;
 import com.whereyouad.WhereYouAd.global.response.DataResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -86,11 +87,13 @@ public class DashboardController implements DashboardControllerDocs {
     public ResponseEntity<SseEmitter> streamRealClicks(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
-            @RequestParam(required = false, defaultValue = "dummy") String mode
+            @RequestParam(required = false, defaultValue = "dummy") String mode,
+            HttpServletResponse response
     )
     {
         SseEmitter emitter = dashboardClickService.subscribe(userId, orgId, mode);
 
+        response.setHeader("X-Accel-Buffering", "no");
         return ResponseEntity.ok(emitter);
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/presentation/docs/DashboardControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/presentation/docs/DashboardControllerDocs.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -121,6 +122,7 @@ public interface DashboardControllerDocs {
     public ResponseEntity<SseEmitter> streamRealClicks(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
-            @RequestParam(required = false, defaultValue = "dummy") String mode
+            @RequestParam(required = false, defaultValue = "dummy") String mode,
+            HttpServletResponse response
     );
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/presentation/docs/DashboardControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/presentation/docs/DashboardControllerDocs.java
@@ -123,6 +123,6 @@ public interface DashboardControllerDocs {
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
             @RequestParam(required = false, defaultValue = "dummy") String mode,
-            HttpServletResponse response
+            @Parameter(hidden = true) HttpServletResponse response
     );
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,7 @@ spring:
     properties:
       hibernate:
         format_sql: true     # SQL 예쁘게 출력
+    open-in-view: false     #OSIV 비활성화 -> SSE Db 커넥션 풀 고갈 방지
 
   # 3. Redis 설정
   data:


### PR DESCRIPTION
## 📌 관련 이슈
- Close #98 

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

로그인 API 호출 시 DB 커넥션 풀 고갈 문제가 SSE 연결이 이루어진 경우에 DB 커넥션을 반납하지 않고 SSE 연결 지속시간(30분) 동안 데이터 전송하여 발생하는 것으로 보여 이를 수정합니다.

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- application.yml 내부 OSIV 비활성화
- SSE 로직에서 응답 헤더에 버퍼링 비활성화 옵션 필드 추가

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.

수정 이후 로그인 API 와 SSE 실시간 클릭수 API 정상 동작하는 것을 확인했고, Swagger 명세에 보이는 다른 Controller API 들도 모두 정상동작 확인했습니다.

<img width="1910" height="1055" alt="image" src="https://github.com/user-attachments/assets/0556027a-06b5-49d1-9f01-a6ef002b97e8" />

<img width="1900" height="1254" alt="image" src="https://github.com/user-attachments/assets/23cc8c0b-ecb6-45fe-ab2a-056465285b27" />


## ✅ 체크리스트
- [✅] 브랜치 전략(GitHub Flow)을 준수했나요?
- [✅] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [✅] 테스트 통과 확인
- [✅] 서버 실행 확인
- [✅] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- 일단 수정 이후 Swagger 에서 보이는 API 들 모두 동작 되는 것을 확인했습니다... 혹시라도 추후에 배포 서버 로그에 LazyInitializationException 이 발생한다면 이 OSIV 비활성화로 인해서 트랜잭션 바깥에서 Lazy Loading 조회를 시도했을 때 발생하는 것이니 참고하시면 될거 같습니다...ㅠㅠ
- API 모두 한번씩 확인하긴 했지만 혹시라도 작업하신 코드중에 Transactional 어노테이션 바깥에서 Lazy Loading 하는 로직(ex. adcontent.getAdGroup) 이 있다면 확인 부탁드립니다ㅠㅠ

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **버그 수정**
  * 실시간 클릭 스트리밍 시 서버 측 버퍼링을 비활성화하여 전송 안정성 개선
  * 뷰 렌더링 중 데이터베이스 연결 유지 방지를 적용해 전체 성능 및 연결 관리 안정성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->