### PR TITLE
Fix/#101 - 실시간 클릭수 API 이상 클릭값 무시 버그 수정

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdContentRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/AdContentRepository.java
@@ -57,4 +57,11 @@ public interface AdContentRepository extends JpaRepository<AdContent, Long> {
         boolean existsByTrackingUrl(String trackingUrl);
 
         Optional<AdContent> findByTrackingUrl(String trackingUrl);
+
+        // Fetch Join을 사용하여 AdContent, AdGroup, AdCampaign을 한 번의 쿼리로 모두 가져옴
+        @Query("SELECT ac FROM AdContent ac " +
+                "JOIN FETCH ac.adGroup ag " +
+                "JOIN FETCH ag.adCampaign " +
+                "WHERE ac.id = :id")
+        Optional<AdContent> findByIdWithGroupAndCampaign(@Param("id") Long id);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/presentation/docs/DashboardControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/presentation/docs/DashboardControllerDocs.java
@@ -112,7 +112,7 @@ public interface DashboardControllerDocs {
                     "* **`timeSeriesData`**: 최근 60분간의 분 단위 클릭수 배열 `[{minute: '202603221439', count: 16}, ...]` (차트 렌더링용)\n" +
                     "* **`mode`**: 현재 응답 트래픽 모드 (`real` or `dummy`)\n" +
                     "* **`hasSuspect`**: 이상 징후(봇 의심) 트래픽 발생 여부 (`true` / `false`)\n" +
-                    "* **`suspectDetail`**: 이상 징후 상세 정보 객체 (경고 팝업용, 발생 시 1회 전송 후 `null` 처리됨)"
+                    "* **`suspectDetail`**: 이상 징후 상세 정보 객체 (경고 팝업용, 발생 시 1회 전송 후 `null` 처리됨), 내부 필드는 provider(플랫폼), campaignName(광고에 해당하는 캠페인 이름), adName(광고 이름), message 로 구성"
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),

--- a/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/kafka/ClickConsumer.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/kafka/ClickConsumer.java
@@ -1,5 +1,6 @@
 package com.whereyouad.WhereYouAd.infrastructure.client.kafka;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdContent;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdContentRepository;
 import com.whereyouad.WhereYouAd.domains.click.application.dto.ClickDto;
@@ -15,6 +16,8 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -28,6 +31,7 @@ public class ClickConsumer {
 
     private static final DateTimeFormatter MINUTE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmm");
     private static final long REDIS_TTL_SECONDS = 7200L; // 2시간
+    private final ObjectMapper objectMapper;
 
     // Redis 분 단위 집계 (더미/실제 클릭)
     // key: click:real:{adContentId}:{yyyyMMddHHmm} 또는 click:dummy:{adContentId}:{yyyyMMddHHmm}
@@ -58,7 +62,8 @@ public class ClickConsumer {
         // 더미 데이터 DB 저장 x
         if (event.isDummy()) return;
 
-        AdContent adContent = adContentRepository.findById(event.getAdContentId())
+        //OSIV 비활성화로 인해 AdContent 와 함께 AdGroup, AdCampaign 까지 모두 한번에 조회하는 Repository 메서드로 변경
+        AdContent adContent = adContentRepository.findByIdWithGroupAndCampaign(event.getAdContentId())
                 .orElse(null);
 
         if (adContent == null) {
@@ -67,6 +72,48 @@ public class ClickConsumer {
         }
 
         boolean isSuspect = botDetector.isSuspect(event.getIpAddress(), event.getUserAgent());
+
+        // 알림용 JSON 데이터 생성 및 Redis 적재 (JPA 연관관계 적용)
+        if (isSuspect && event.getOrgId() != null) {
+            String alertKey = String.format("click:suspect:alert:org:%s", event.getOrgId());
+
+            try {
+                Map<String, Object> suspectDetail = new HashMap<>();
+
+                // 기본값 세팅 (NPE 방어)
+                String providerStr = "알 수 없는 플랫폼";
+                String campaignNameStr = "알 수 없는 캠페인";
+                String adNameStr = (adContent.getName() != null) ? adContent.getName() : "알 수 없는 광고";
+
+                // 연관관계를 타고 올라가며 실제 값 추출 및 적용
+                if (adContent.getAdGroup() != null && adContent.getAdGroup().getAdCampaign() != null) {
+
+                    // 캠페인 이름 추출
+                    if (adContent.getAdGroup().getAdCampaign().getName() != null) {
+                        campaignNameStr = adContent.getAdGroup().getAdCampaign().getName();
+                    }
+
+                    // 플랫폼(Provider) 추출
+                    if (adContent.getAdGroup().getAdCampaign().getProvider() != null) {
+                        providerStr = String.valueOf(adContent.getAdGroup().getAdCampaign().getProvider());
+                    }
+                }
+
+                // Map에 이상 클릭 값 적재
+                suspectDetail.put("provider", providerStr);
+                suspectDetail.put("campaignName", campaignNameStr);
+                suspectDetail.put("adName", adNameStr);
+                suspectDetail.put("message", "비정상적인 트래픽(Bot)이 감지되었습니다. (IP: " + event.getIpAddress() + ")");
+
+                // JSON 변환 후 Redis 저장 (수명 60초)
+                String detailJson = objectMapper.writeValueAsString(suspectDetail);
+                redisUtil.setDataExpire(alertKey, detailJson, 60);
+
+                log.info(" 봇 감지 : 실제 데이터 매핑 완료 및 Redis 적재: {}", alertKey);
+            } catch (Exception e) {
+                log.error("봇 알림 JSON 변환/저장 실패", e);
+            }
+        }
 
         ClickLog clickLog = ClickConverter.toClickLog(adContent, event, isSuspect);
 


### PR DESCRIPTION
## 📌 관련 이슈
- Close #101 

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

ClickConsumer 에서 이상 클릭에 대한 정보를 Redis 에 적재하는 부분이 빠져있는 것을 확인해 Redis 에 적절하게 정보를 적재하는 로직추가

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- ClickConsumer 내부 이상 클릭 정보 Redis 에 적재하는 로직 추가 
- Spring OSIV 비활성화로 발생하는 오류 방지 위해 AdContentRepository 내부 fetch join 사용한 조회 메서드 추가

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.

수정 이후 Postman 을 통해 Redirect URL 에 요청을 보내면 정상적으로 이상 클릭 정보가 출력됩니다.
<img width="1906" height="1333" alt="image" src="https://github.com/user-attachments/assets/4baf9636-0bab-4c0d-95d7-785ebc729052" />
<img width="1897" height="1279" alt="image" src="https://github.com/user-attachments/assets/9cfdd4aa-df9c-46bc-998a-db31245dbb98" />

## ✅ 체크리스트
- [✅] 브랜치 전략(GitHub Flow)을 준수했나요?
- [✅] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [✅] 테스트 통과 확인
- [✅] 서버 실행 확인
- [✅] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- SSE 로직을 처음 써보는 거라 관련한 버그가 많은 것 같습니다...죄송합니다ㅠㅠ
- ClickConsumer 쪽에 Redis 데이터 적재 쪽 주로 봐주시면 될 것 같습니다...
- 광고 플랫폼 API 연동이랑 관련 엔티티 작업은 이 PR 머지하고 진행하겠습니다...

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경 사항

* **신기능**
  * 의심스러운 클릭 활동을 실시간으로 감지하고 조직별 짧은 알림(60초 보관)을 생성하여 대시보드에 반영

* **성능 개선**
  * 광고 관련 연관 정보(그룹·캠페인)를 함께 조회해 클릭 처리 흐름이 더 효율적으로 동작

* **문서**
  * 실시간 클릭 스트림의 의심 정보 필드 구성(provider, campaignName, adName, message) 명확화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->