### PR TITLE
Feat/#89 현재 워크스페이스 설정 및 조회 구현

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/response/OrgResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/response/OrgResponse.java
@@ -75,4 +75,8 @@ public class OrgResponse {
             String message,
             String email
     ) {}
+
+    public record CurrentWorkSpace (
+            Long orgId
+    ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/response/OrgResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/response/OrgResponse.java
@@ -18,7 +18,8 @@ public class OrgResponse {
             String name,
             String description,
             String logoUrl,
-            OrgRole myRole
+            OrgRole myRole,
+            boolean isCurrent
     ) {}
 
     //내 조직 정보는 SimpleInfo 를 List 로 반환

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/response/OrgResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/response/OrgResponse.java
@@ -19,7 +19,7 @@ public class OrgResponse {
             String description,
             String logoUrl,
             OrgRole myRole,
-            boolean isCurrent
+            boolean isCurrentWorkSpace
     ) {}
 
     //내 조직 정보는 SimpleInfo 를 List 로 반환

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/response/OrgResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/response/OrgResponse.java
@@ -19,7 +19,7 @@ public class OrgResponse {
             String description,
             String logoUrl,
             OrgRole myRole,
-            boolean isCurrentWorkSpace
+            boolean isCurrentWorkspace
     ) {}
 
     //내 조직 정보는 SimpleInfo 를 List 로 반환
@@ -77,7 +77,7 @@ public class OrgResponse {
             String email
     ) {}
 
-    public record CurrentWorkSpace (
+    public record CurrentWorkspace (
             Long orgId
     ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/mapper/OrgConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/mapper/OrgConverter.java
@@ -44,14 +44,20 @@ public class OrgConverter {
     }
 
     public static OrgResponse.SimpleInfo toOrgSimpleInfo(OrgMember orgMember) {
-        //OrgMember 내부에 존재하는 Role 활용
-        Organization organization = orgMember.getOrganization();
+        return toOrgSimpleInfo(orgMember, null);
+    }
 
-        return new OrgResponse.SimpleInfo(organization.getId(),
+    public static OrgResponse.SimpleInfo toOrgSimpleInfo(OrgMember orgMember, Long currentOrgId) {
+        Organization organization = orgMember.getOrganization();
+        boolean isCurrentWorkSpace = currentOrgId != null && currentOrgId.equals(organization.getId());
+
+        return new OrgResponse.SimpleInfo(
+                organization.getId(),
                 organization.getName(),
                 organization.getDescription(),
                 organization.getLogoUrl(),
-                orgMember.getRole()
+                orgMember.getRole(),
+                isCurrentWorkSpace
         );
     }
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
@@ -10,9 +10,9 @@ public interface OrgService {
 
     OrgResponse.MyOrganizations getMyOrganizations(Long userId);
 
-    OrgResponse.CurrentWorkSpace setCurrentWorkSpace(Long userId, Long orgId);
+    OrgResponse.CurrentWorkspace setCurrentWorkspace(Long userId, Long orgId);
 
-    OrgResponse.CurrentWorkSpace getCurrentWorkSpace(Long userId);
+    OrgResponse.CurrentWorkspace getCurrentWorkspace(Long userId);
 
     OrgResponse.OrgDetail getOrganizationDetail(Long orgId);
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
@@ -10,6 +10,8 @@ public interface OrgService {
 
     OrgResponse.MyOrganizations getMyOrganizations(Long userId);
 
+    OrgResponse.CurrentWorkSpace setCurrentWorkSpace(Long userId, Long orgId);
+
     OrgResponse.OrgDetail getOrganizationDetail(Long orgId);
 
     OrgResponse.MyOrganizations getSoftDeletedOrgs(Long userId);

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
@@ -12,6 +12,8 @@ public interface OrgService {
 
     OrgResponse.CurrentWorkSpace setCurrentWorkSpace(Long userId, Long orgId);
 
+    OrgResponse.CurrentWorkSpace getCurrentWorkSpace(Long userId);
+
     OrgResponse.OrgDetail getOrganizationDetail(Long orgId);
 
     OrgResponse.MyOrganizations getSoftDeletedOrgs(Long userId);

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -252,6 +252,13 @@ public class OrgServiceImpl implements OrgService {
         // 해당 조직에 가입된 모든 회원들의 가입 정보 삭제
         List<OrgMember> orgMembers = orgMemberRepository.findOrgMemberByOrg(organization);
 
+        // 현재 워크스페이스가 삭제되는 조직인 멤버들의 currentOrgId를 null로 초기화
+        for (OrgMember member : orgMembers) {
+            if (Objects.equals(member.getUser().getCurrentOrgId(), orgId)) {
+                member.getUser().setCurrentOrgId(null);
+            }
+        }
+
         orgMemberRepository.deleteAll(orgMembers);
 
         // 조직 실제 삭제
@@ -277,6 +284,14 @@ public class OrgServiceImpl implements OrgService {
         // 만약 조직 삭제 요청한 회원이 해당 조직을 생성한 회원이 아니라면,
         if (!organization.getOwnerUserId().equals(userId)) {
             throw new OrgHandler(OrgErrorCode.ORG_FORBIDDEN);
+        }
+
+        // 현재 워크스페이스가 삭제되는 조직인 멤버들의 currentOrgId를 null로 초기화
+        List<OrgMember> orgMembers = orgMemberRepository.findOrgMemberByOrg(organization);
+        for (OrgMember member : orgMembers) {
+            if (Objects.equals(member.getUser().getCurrentOrgId(), orgId)) {
+                member.getUser().setCurrentOrgId(null);
+            }
         }
 
         // 조직 status 만 DELETED 로 변경 후 종료
@@ -309,6 +324,11 @@ public class OrgServiceImpl implements OrgService {
         // 4. 대상 맴버가 ADMIN이라면 추방 불가
         if (targetMember.getRole() == OrgRole.ADMIN) {
             throw new OrgHandler(OrgErrorCode.ORG_CANNOT_KICK_ADMIN);
+        }
+
+        // 추방되는 멤버의 현재 워크스페이스가 해당 조직이라면 null로 초기화
+        if (Objects.equals(targetMember.getUser().getCurrentOrgId(), orgId)) {
+            targetMember.getUser().setCurrentOrgId(null);
         }
 
         // 5. 중간 테이블에서 해당 멤버 삭제

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -108,7 +108,7 @@ public class OrgServiceImpl implements OrgService {
     }
 
     @Override
-    public OrgResponse.CurrentWorkSpace setCurrentWorkSpace(Long userId, Long orgId) {
+    public OrgResponse.CurrentWorkspace setCurrentWorkspace(Long userId, Long orgId) {
         User user = userRepository.findById(userId).orElseThrow(() ->
                 new UserHandler(UserErrorCode.USER_NOT_FOUND));
 
@@ -117,11 +117,11 @@ public class OrgServiceImpl implements OrgService {
 
         user.setCurrentOrgId(orgId);
 
-        return new OrgResponse.CurrentWorkSpace(orgId);
+        return new OrgResponse.CurrentWorkspace(orgId);
     }
 
     @Override
-    public OrgResponse.CurrentWorkSpace getCurrentWorkSpace(Long userId) {
+    public OrgResponse.CurrentWorkspace getCurrentWorkspace(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() ->
                 new UserHandler(UserErrorCode.USER_NOT_FOUND));
 
@@ -130,7 +130,7 @@ public class OrgServiceImpl implements OrgService {
         if (currentOrgId == null)
             throw new OrgHandler(OrgErrorCode.CURRENT_WORKSPACE_NOT_SET);
 
-        return new OrgResponse.CurrentWorkSpace(currentOrgId);
+        return new OrgResponse.CurrentWorkspace(currentOrgId);
     }
 
     //하나의 조직에 대한 세부 사항(ID, 이름, 설명, logoUrl, createdAt)

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -103,6 +103,19 @@ public class OrgServiceImpl implements OrgService {
         return OrgConverter.toMyOrganizations(infos);
     }
 
+    @Override
+    public OrgResponse.CurrentWorkSpace setCurrentWorkSpace(Long userId, Long orgId) {
+        User user = userRepository.findById(userId).orElseThrow(() ->
+                new UserHandler(UserErrorCode.USER_NOT_FOUND));
+
+        orgMemberRepository.findByUserIdAndOrgId(userId, orgId).orElseThrow(() ->
+                new OrgHandler(OrgErrorCode.ORG_MEMBER_NOT_FOUND));
+
+        user.setCurrentOrgId(orgId);
+
+        return new OrgResponse.CurrentWorkSpace(orgId);
+    }
+
     //하나의 조직에 대한 세부 사항(ID, 이름, 설명, logoUrl, createdAt)
     public OrgResponse.OrgDetail getOrganizationDetail(Long orgId) {
         //해당 조직 id 로 Organization 조회

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -120,6 +120,16 @@ public class OrgServiceImpl implements OrgService {
         return new OrgResponse.CurrentWorkSpace(orgId);
     }
 
+    @Override
+    public OrgResponse.CurrentWorkSpace getCurrentWorkSpace(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() ->
+                new UserHandler(UserErrorCode.USER_NOT_FOUND));
+
+        Long currentOrgId = user.getCurrentOrgId();
+
+        return new OrgResponse.CurrentWorkSpace(currentOrgId);
+    }
+
     //하나의 조직에 대한 세부 사항(ID, 이름, 설명, logoUrl, createdAt)
     public OrgResponse.OrgDetail getOrganizationDetail(Long orgId) {
         //해당 조직 id 로 Organization 조회

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -127,9 +127,7 @@ public class OrgServiceImpl implements OrgService {
 
         Long currentOrgId = user.getCurrentOrgId();
 
-        if (currentOrgId == null)
-            throw new OrgHandler(OrgErrorCode.CURRENT_WORKSPACE_NOT_SET);
-
+        // 현재 설정한 워크스페이스가 없다면 null 반환
         return new OrgResponse.CurrentWorkspace(currentOrgId);
     }
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -91,12 +91,16 @@ public class OrgServiceImpl implements OrgService {
 
     //로그인한 회원이 속한 조직 모두 조회 메서드
     public OrgResponse.MyOrganizations getMyOrganizations(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() ->
+                new UserHandler(UserErrorCode.USER_NOT_FOUND));
+        Long currentOrgId = user.getCurrentOrgId();
+
         //회원 id 로 OrgMember 모두 조회 -> DB 조회에서 OrgStatus.ACTIVE 인 Organization 만 포함하는 OrgMember 만 조회해 온다.
         List<OrgMember> orgMembers = orgMemberRepository.findOrgMemberByUserId(userId);
 
         //각각의 OrgMember 에서 SimpleInfo DTO 로 매핑
         List<OrgResponse.SimpleInfo> infos = orgMembers.stream()
-                .map(OrgConverter::toOrgSimpleInfo)
+                .map( m -> OrgConverter.toOrgSimpleInfo(m, currentOrgId))
                 .toList();
 
         //마지막 반환 DTO 로 변환

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -127,6 +127,9 @@ public class OrgServiceImpl implements OrgService {
 
         Long currentOrgId = user.getCurrentOrgId();
 
+        if (currentOrgId == null)
+            throw new OrgHandler(OrgErrorCode.CURRENT_WORKSPACE_NOT_SET);
+
         return new OrgResponse.CurrentWorkSpace(currentOrgId);
     }
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
@@ -23,7 +23,6 @@ public enum OrgErrorCode implements BaseErrorCode {
     // 404
     ORG_NOT_FOUND(HttpStatus.NOT_FOUND, "ORG_404_1", "해당 id 의 조직이 존재하지 않습니다."),
     ORG_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORG_404_2", "해당 멤버가 조직에 존재하지 않습니다."),
-    CURRENT_WORKSPACE_NOT_SET(HttpStatus.NOT_FOUND, "ORG_404_3", "현재 워크스페이스가 설정되어 있지 않습니다."),
 
     //409
     ORG_ALREADY_ACTIVE(HttpStatus.CONFLICT, "ORG_409_1", "해당 조직은 이미 활성화 상태 입니다."),

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
@@ -23,6 +23,7 @@ public enum OrgErrorCode implements BaseErrorCode {
     // 404
     ORG_NOT_FOUND(HttpStatus.NOT_FOUND, "ORG_404_1", "해당 id 의 조직이 존재하지 않습니다."),
     ORG_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "ORG_404_2", "해당 멤버가 조직에 존재하지 않습니다."),
+    CURRENT_WORKSPACE_NOT_SET(HttpStatus.NOT_FOUND, "ORG_404_3", "현재 워크스페이스가 설정되어 있지 않습니다."),
 
     //409
     ORG_ALREADY_ACTIVE(HttpStatus.CONFLICT, "ORG_409_1", "해당 조직은 이미 활성화 상태 입니다."),

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
@@ -27,8 +27,8 @@ public interface OrgMemberRepository extends JpaRepository<OrgMember, Long> {
     @Query(value = "select om from OrgMember om join fetch om.organization o where om.user.id = :userId and o.status = 'DELETED' and om.organization.ownerUserId = :userId")
     List<OrgMember> findOrgMemberByUserIdSoftDeleted(@Param("userId") Long userId);
 
-    //특정 Organization 에 속한 OrgMember 모두 추출하는 메서드
-    @Query("select om from OrgMember om where om.organization = :organization")
+    //특정 Organization 에 속한 OrgMember 모두 추출하는 메서드 (N+1 방지, fetch join)
+    @Query("select om from OrgMember om join fetch om.user where om.organization = :organization")
     List<OrgMember> findOrgMemberByOrg(@Param(value = "organization") Organization organization);
 
     // 조직 멤버 조회 (무한 스크롤 - Slice 반환)

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
@@ -46,12 +46,23 @@ public class OrgController implements OrgControllerDocs {
         );
     }
 
-    @PostMapping("/{orgId}")
+    @PostMapping("/{orgId}/workspace")
     public ResponseEntity<DataResponse<OrgResponse.CurrentWorkSpace>> setCurrentWorkSpace(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId)
     {
         OrgResponse.CurrentWorkSpace response = orgService.setCurrentWorkSpace(userId, orgId);
+
+        return ResponseEntity.ok(
+                DataResponse.from(response)
+        );
+    }
+
+    @GetMapping("/my/workspace")
+    public ResponseEntity<DataResponse<OrgResponse.CurrentWorkSpace>> getCurrentWorkSpace(
+            @AuthenticationPrincipal(expression = "userId") Long userId)
+    {
+        OrgResponse.CurrentWorkSpace response = orgService.getCurrentWorkSpace(userId);
 
         return ResponseEntity.ok(
                 DataResponse.from(response)

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
@@ -46,6 +46,18 @@ public class OrgController implements OrgControllerDocs {
         );
     }
 
+    @PostMapping("/{orgId}")
+    public ResponseEntity<DataResponse<OrgResponse.CurrentWorkSpace>> setCurrentWorkSpace(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId)
+    {
+        OrgResponse.CurrentWorkSpace response = orgService.setCurrentWorkSpace(userId, orgId);
+
+        return ResponseEntity.ok(
+                DataResponse.from(response)
+        );
+    }
+
     @GetMapping("/{orgId}")
     public ResponseEntity<DataResponse<OrgResponse.OrgDetail>> getOrganizationDetail(@PathVariable Long orgId)
     {

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
@@ -47,11 +47,11 @@ public class OrgController implements OrgControllerDocs {
     }
 
     @PostMapping("/{orgId}/workspace")
-    public ResponseEntity<DataResponse<OrgResponse.CurrentWorkSpace>> setCurrentWorkSpace(
+    public ResponseEntity<DataResponse<OrgResponse.CurrentWorkspace>> setCurrentWorkspace(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId)
     {
-        OrgResponse.CurrentWorkSpace response = orgService.setCurrentWorkSpace(userId, orgId);
+        OrgResponse.CurrentWorkspace response = orgService.setCurrentWorkspace(userId, orgId);
 
         return ResponseEntity.ok(
                 DataResponse.from(response)
@@ -59,10 +59,10 @@ public class OrgController implements OrgControllerDocs {
     }
 
     @GetMapping("/my/workspace")
-    public ResponseEntity<DataResponse<OrgResponse.CurrentWorkSpace>> getCurrentWorkSpace(
+    public ResponseEntity<DataResponse<OrgResponse.CurrentWorkspace>> getCurrentWorkspace(
             @AuthenticationPrincipal(expression = "userId") Long userId)
     {
-        OrgResponse.CurrentWorkSpace response = orgService.getCurrentWorkSpace(userId);
+        OrgResponse.CurrentWorkspace response = orgService.getCurrentWorkspace(userId);
 
         return ResponseEntity.ok(
                 DataResponse.from(response)

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
@@ -51,7 +51,7 @@ public interface OrgControllerDocs {
             @ApiResponse(responseCode = "401_3", description = "토큰 없이 접근 시 실패"),
             @ApiResponse(responseCode = "404_2", description = "해당 조직의 멤버가 아닌 경우")
     })
-    ResponseEntity<DataResponse<OrgResponse.CurrentWorkSpace>> setCurrentWorkSpace(
+    ResponseEntity<DataResponse<OrgResponse.CurrentWorkspace>> setCurrentWorkspace(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId);
 
@@ -64,7 +64,7 @@ public interface OrgControllerDocs {
             @ApiResponse(responseCode = "401_3", description = "토큰 없이 접근 시 실패"),
             @ApiResponse(responseCode = "404_3", description = "현재 워크스페이스 미설정")
     })
-    ResponseEntity<DataResponse<OrgResponse.CurrentWorkSpace>> getCurrentWorkSpace(
+    ResponseEntity<DataResponse<OrgResponse.CurrentWorkspace>> getCurrentWorkspace(
             @AuthenticationPrincipal(expression = "userId") Long userId);
 
     @Operation(

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
@@ -25,7 +25,7 @@ public interface OrgControllerDocs {
             @ApiResponse(responseCode = "200", description = "성공"),
             @ApiResponse(responseCode = "400_1", description = "조직 이름 중복")
     })
-    public ResponseEntity<DataResponse<OrgResponse.Create>> createOrganization(
+    ResponseEntity<DataResponse<OrgResponse.Create>> createOrganization(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @RequestPart(value = "request") @Valid OrgRequest.Create request,
             @RequestPart(value = "image", required = false) MultipartFile image
@@ -33,13 +33,38 @@ public interface OrgControllerDocs {
 
     @Operation(
             summary = "내가 속한 조직 전체 조회 API",
-            description = "로그인한 회원이 속한 조직들의 DB id, 이름, 설명, 로고URL, 내 역할(ADMIN/MEMBER) 을 반환"
+            description = "로그인한 회원이 속한 조직들의 DB id, 이름, 설명, 로고URL, 내 역할(ADMIN/MEMBER), 조직이 현재 내 워크스페이스인지 여부를 반환"
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
             @ApiResponse(responseCode = "401_3", description = "토큰 없이 접근 시 실패")
     })
-    public ResponseEntity<DataResponse<OrgResponse.MyOrganizations>> getMyOrganizations(
+    ResponseEntity<DataResponse<OrgResponse.MyOrganizations>> getMyOrganizations(
+            @AuthenticationPrincipal(expression = "userId") Long userId);
+
+    @Operation(
+            summary = "현재 워크스페이스 설정 API",
+            description = "현재 워크스페이스로 설정할 조직의 id를 받아 유저의 현재 워크스페이스로 설정"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "401_3", description = "토큰 없이 접근 시 실패"),
+            @ApiResponse(responseCode = "404_2", description = "해당 조직의 멤버가 아닌 경우")
+    })
+    ResponseEntity<DataResponse<OrgResponse.CurrentWorkSpace>> setCurrentWorkSpace(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId);
+
+    @Operation(
+            summary = "현재 워크스페이스 조회 API",
+            description = "유저의 현재 워크스페이스를 조회"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "401_3", description = "토큰 없이 접근 시 실패"),
+            @ApiResponse(responseCode = "404_3", description = "현재 워크스페이스 미설정")
+    })
+    ResponseEntity<DataResponse<OrgResponse.CurrentWorkSpace>> getCurrentWorkSpace(
             @AuthenticationPrincipal(expression = "userId") Long userId);
 
     @Operation(
@@ -51,7 +76,7 @@ public interface OrgControllerDocs {
             @ApiResponse(responseCode = "404_1", description = "해당 id 값 조직 존재 X"),
             @ApiResponse(responseCode = "410_1", description = "해당 조직은 삭제되었습니다 (Soft Delete)")
     })
-    public ResponseEntity<DataResponse<OrgResponse.OrgDetail>> getOrganizationDetail(@PathVariable Long orgId);
+    ResponseEntity<DataResponse<OrgResponse.OrgDetail>> getOrganizationDetail(@PathVariable Long orgId);
 
     @Operation(
             summary = "회원이 만든 조직 중 Soft Deleted 된 조직 목록 조회",
@@ -61,7 +86,7 @@ public interface OrgControllerDocs {
             @ApiResponse(responseCode = "200", description = "성공"),
             @ApiResponse(responseCode = "404_1", description = "회원 존재 X")
     })
-    public ResponseEntity<DataResponse<OrgResponse.MyOrganizations>> getSoftDeletedOrganizations(
+    ResponseEntity<DataResponse<OrgResponse.MyOrganizations>> getSoftDeletedOrganizations(
             @AuthenticationPrincipal(expression = "userId") Long userId
     );
 
@@ -79,7 +104,7 @@ public interface OrgControllerDocs {
             @ApiResponse(responseCode = "403_1", description = "허가되지 않은 회원의 요청(조직 생성 회원 X)"),
             @ApiResponse(responseCode = "404_1", description = "해당 id 조직 존재 X")
     })
-    public ResponseEntity<DataResponse<OrgResponse.Update>> modifyOrganization(
+    ResponseEntity<DataResponse<OrgResponse.Update>> modifyOrganization(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
             @RequestPart(value = "request") @Valid OrgRequest.Update request,
@@ -96,7 +121,7 @@ public interface OrgControllerDocs {
             @ApiResponse(responseCode = "404_1", description = "해당 id 조직 존재 X"),
             @ApiResponse(responseCode = "409_1", description = "이미 활성화 상태인 조직")
     })
-    public ResponseEntity<DataResponse<OrgResponse.Delete>> restoreOrganization(
+    ResponseEntity<DataResponse<OrgResponse.Delete>> restoreOrganization(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId
     );
@@ -113,7 +138,7 @@ public interface OrgControllerDocs {
             @ApiResponse(responseCode = "403_1", description = "허가되지 않은 회원의 요청(조직 생성 회원 X)"),
             @ApiResponse(responseCode = "404_1", description = "해당 id 조직 존재 X")
     })
-    public ResponseEntity<DataResponse<String>> removeOrganization(
+    ResponseEntity<DataResponse<String>> removeOrganization(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
             @RequestParam(defaultValue = "false") boolean isHard
@@ -155,7 +180,7 @@ public interface OrgControllerDocs {
             @ApiResponse(responseCode = "403", description = "권한이 부족한 경우(요청을 보낸 유저의 권한이 ADMIN이 아닌 경우)"),
             @ApiResponse(responseCode = "404", description = "해당 id의 데이터 존재 X")
     })
-    public ResponseEntity<DataResponse<String>> removeMember(
+    ResponseEntity<DataResponse<String>> removeMember(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
             @PathVariable Long memberId
@@ -186,7 +211,7 @@ public interface OrgControllerDocs {
             @ApiResponse(responseCode = "404", description = "조직을 찾을 수 없음"),
             @ApiResponse(responseCode = "409", description = "이미 조직에 가입된 사용자")
     })
-    public ResponseEntity<DataResponse<OrgResponse.OrgInvitationResponse>> sendOrgInvitation(
+    ResponseEntity<DataResponse<OrgResponse.OrgInvitationResponse>> sendOrgInvitation(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
             @RequestBody @Valid OrgRequest.Invite request
@@ -199,7 +224,7 @@ public interface OrgControllerDocs {
             @ApiResponse(responseCode = "401", description = "로그인 필요"),
             @ApiResponse(responseCode = "403", description = "초대된 이메일과 로그인한 사용자가 불일치")
     })
-    public ResponseEntity<DataResponse<OrgResponse.OrgInvitationResponse>> acceptOrgInvitation(
+    ResponseEntity<DataResponse<OrgResponse.OrgInvitationResponse>> acceptOrgInvitation(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable String token
     );

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/persistence/entity/User.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/persistence/entity/User.java
@@ -43,6 +43,9 @@ public class User extends BaseEntity {
     @ColumnDefault("'ACTIVE'")  //기본값 ACTIVE
     private UserStatus status;  //ACTIVE, SUSPENDED, DELETED
 
+    @Column(name = "current_org_id")
+    private Long currentOrgId;
+
     // 소셜 로그인 시 유저 프로필 최신화
     public void updateProfile(String name){
         this.name = name;
@@ -56,5 +59,9 @@ public class User extends BaseEntity {
         this.name = name;
         this.profileImageUrl = profileImageUrl;
         this.password = encodedNewPwd;
+    }
+
+    public void setCurrentOrgId(Long currentOrgId) {
+        this.currentOrgId = currentOrgId;
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #89 

## 🚀 개요
유저의 현재 워크스페이스를 설정하고 이를 조회할 수 있는 API를 구현하였습니다. 또한 조직 목록 조회 시 워크스페이스 설정 여부를 함께 반환하도록 하였습니다.

## 📄 작업 내용
- User에 currentOrgId 필드 추가
- 현재 워크스페이스 설정` POST api/org/{orgId}/workspace`
: 요청으로 전달 받은 orgId를 유저의 현재 워크스페이스로 설정

- 현재 워크스페이스 조회 `GET api/org/my/workspace`
: 유저의 현재 워크스페이스로 설정된 조직 id를 반환

- 내 워크스페이스 목록 전체 조회 `GET /api/org/my`에서 응답 수정
: 워크스페이스 설정 여부를 함께 반환

## 📸 스크린샷 / 테스트 결과 (선택)
프론트의 워크스페이스 선택 화면 구현 시 활용될 수 있도록, 내 워크스페이스 목록을 전체 조회할 시 다음과 같이 isCurrentWorkspace의 값을 함께 조직 정보(SimpleInfo)에 반환하여, 현재 워크스페이스로 설정된 조직이 무엇인지 확인할 수 있게 함.
<img width="1066" height="619" alt="image" src="https://github.com/user-attachments/assets/14c2ad2d-f688-4842-b9fd-fcff57cdd505" />

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
워크스페이스 설정 및 조회 api의 응답을 우선 orgId만 반환하도록 하였는데, 더 자세하게 조직의 정보까지 포함하는 게 좋을지 고민이네요.. 또 기타 수정해야할 사항이 있다면 조언 부탁드리겠습니다! 

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 현재 작업 공간(활성 워크스페이스)을 설정하고 조회하는 기능이 추가되었습니다.
  * 조직 목록에서 각 조직이 현재 작업 공간인지 표시되어 한눈에 확인할 수 있습니다.
* **동작 개선**
  * 작업 공간 변경 및 조직/멤버 제거 시 사용자의 현재 작업 공간이 자동으로 반영 및 초기화됩니다.
* **문서**
  * 관련 API 문서와 조직 조회 설명에 현재 작업 공간 정보가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->