### PR TITLE
Feat/#105 외부 AD API 연동 util 클래스 및 뼈대 제작, aes 암호화 util 클래스 제작

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,6 @@ BASE_URL=http://localhost:8080
 
 #9 OpenAI
 OPENAI_API_KEY=your_openai_api_key
+
+#10 AES
+AES_SECRET=your_aes_secret_key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,4 @@ jobs:
           SMS_SENDER_NUMBER: 01000000000
           OPENAI_API_KEY: test_openai_key
           KAFKA_BOOTSTRAP_SERVERS: localhost:9092
+          AES_SECRET: test_aes_key

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
@@ -1,0 +1,56 @@
+package com.whereyouad.WhereYouAd.domains.advertisement.domain.service;
+
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
+import com.whereyouad.WhereYouAd.domains.platform.exception.PlatformHandler;
+import com.whereyouad.WhereYouAd.domains.platform.exception.code.PlatformErrorCode;
+import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformConnection;
+import com.whereyouad.WhereYouAd.domains.platform.persistence.repository.PlatformConnectionRepository;
+import com.whereyouad.WhereYouAd.global.utils.AdApiAuthUtil;
+import com.whereyouad.WhereYouAd.global.adapi.dto.AdAuthRequest;
+import com.whereyouad.WhereYouAd.infrastructure.client.naver.client.NaverClient;
+import com.whereyouad.WhereYouAd.infrastructure.client.naver.dto.NaverDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NaverAdApiService {
+
+    private final PlatformConnectionRepository connectionRepository;
+    private final AdApiAuthUtil adApiAuthUtil;
+    private final NaverClient naverClient;
+
+    // 캠페인 목록 조회
+    @Transactional(readOnly = true)
+    public List<NaverDTO.Campaign> getCampaigns(Long orgId) {
+        //
+        PlatformConnection conn = resolveNaverConnection(orgId);
+        try {
+            Map<String, String> headers = adApiAuthUtil.generateAuthHeaders(
+                    conn.getId(), AdAuthRequest.forMethodAndPath("GET", "/ncc/campaigns")
+            );
+            return naverClient.getCampaigns(headers);
+        } catch (Exception e) {
+            log.error("[NAVER] 캠페인 조회 실패 - orgId={}", orgId, e);
+            throw new RuntimeException("네이버 캠페인 조회 실패", e);
+        }
+    }
+
+    // private 내부 메서드
+
+    // orgId 기반으로 NAVER Connection을 찾아 반환
+    private PlatformConnection resolveNaverConnection(Long orgId) {
+        List<PlatformConnection> connections = connectionRepository
+                .findByPlatformAccount_Organization_IdAndPlatformAccount_Provider(orgId, Provider.NAVER);
+        if (connections.isEmpty()) {
+            throw new PlatformHandler(PlatformErrorCode.PLATFORM_CONNECTION_NOT_FOUND);
+        }
+        return connections.get(0);
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/NaverAdApiController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/NaverAdApiController.java
@@ -1,0 +1,27 @@
+package com.whereyouad.WhereYouAd.domains.advertisement.presentation;
+
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.service.NaverAdApiService;
+import com.whereyouad.WhereYouAd.domains.advertisement.presentation.docs.NaverAdApiControllerDocs;
+import com.whereyouad.WhereYouAd.global.response.DataResponse;
+import com.whereyouad.WhereYouAd.infrastructure.client.naver.dto.NaverDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/naver/{orgId}")
+public class NaverAdApiController implements NaverAdApiControllerDocs {
+
+    private final NaverAdApiService naverAdApiService;
+
+    // 캠페인 목록 조회
+    @GetMapping("/campaigns")
+    public ResponseEntity<DataResponse<List<NaverDTO.Campaign>>> getCampaigns(
+            @PathVariable Long orgId
+    ) {
+        return ResponseEntity.ok(DataResponse.from(naverAdApiService.getCampaigns(orgId)));
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/NaverAdApiControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/NaverAdApiControllerDocs.java
@@ -1,0 +1,26 @@
+package com.whereyouad.WhereYouAd.domains.advertisement.presentation.docs;
+
+import com.whereyouad.WhereYouAd.global.response.DataResponse;
+import com.whereyouad.WhereYouAd.infrastructure.client.naver.dto.NaverDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+public interface NaverAdApiControllerDocs {
+
+    @Operation(summary = "네이버 광고 캠페인 목록 조회", description = "연동된 네이버 광고 계정의 캠페인 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "캠페인 목록 반환"),
+            @ApiResponse(responseCode = "404", description = "해당 조직의 네이버 연결 정보 없음"),
+            @ApiResponse(responseCode = "500", description = "네이버 API 호출 실패")
+    })
+    ResponseEntity<DataResponse<List<NaverDTO.Campaign>>> getCampaigns(
+            @Parameter(description = "조직 ID", example = "1", required = true)
+            @PathVariable Long orgId
+    );
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/exception/PlatformHandler.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/exception/PlatformHandler.java
@@ -1,0 +1,10 @@
+package com.whereyouad.WhereYouAd.domains.platform.exception;
+
+import com.whereyouad.WhereYouAd.global.exception.AppException;
+import com.whereyouad.WhereYouAd.global.exception.BaseErrorCode;
+
+public class PlatformHandler extends AppException {
+    public PlatformHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/exception/code/PlatformErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/exception/code/PlatformErrorCode.java
@@ -1,0 +1,19 @@
+package com.whereyouad.WhereYouAd.domains.platform.exception.code;
+
+import com.whereyouad.WhereYouAd.global.exception.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum PlatformErrorCode implements BaseErrorCode {
+
+    // 404
+    PLATFORM_CONNECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "PLATFORM_404_1", "조직과 연결된 인증 정보를 찾을 수 없습니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/persistence/entity/PlatformConnection.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/persistence/entity/PlatformConnection.java
@@ -27,11 +27,11 @@ public class PlatformConnection extends BaseEntity {
     @ColumnDefault("'API_KEY'")
     private AuthType authType;
 
-    @Column(name = "access_token_enc", length = 4000)
-    private String accessTokenEnc;
+    @Column(name = "auth_identifier", length = 4000)
+    private String authIdentifier; // 주 인증 정보 (예: OAuth Access Token, API Client ID, Login ID)
 
-    @Column(name = "refresh_token_enc", length = 4000)
-    private String refreshTokenEnc;
+    @Column(name = "auth_credential", length = 4000)
+    private String authCredential; // 부 인증 정보 (예: OAuth Refresh Token, API Client Secret, Password)
 
     @Column(name = "token_expire_at")
     private LocalDateTime tokenExpireAt;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/persistence/repository/PlatformConnectionRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/persistence/repository/PlatformConnectionRepository.java
@@ -1,7 +1,13 @@
 package com.whereyouad.WhereYouAd.domains.platform.persistence.repository;
 
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformConnection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PlatformConnectionRepository extends JpaRepository<PlatformConnection, Long> {
+    
+    // 조직 ID와 플랫폼으로 등록된 연동 정보(Account/Connection) 목록 조회
+    List<PlatformConnection> findByPlatformAccount_Organization_IdAndPlatformAccount_Provider(Long orgId, Provider provider);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/global/adapi/AdAuthFactory.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/adapi/AdAuthFactory.java
@@ -1,0 +1,32 @@
+package com.whereyouad.WhereYouAd.global.adapi;
+
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
+import com.whereyouad.WhereYouAd.global.adapi.exception.AdApiHandler;
+import com.whereyouad.WhereYouAd.global.adapi.exception.code.AdApiErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class AdAuthFactory {
+
+    private final Map<Provider, AdAuthStrategy> strategies;
+
+    public AdAuthFactory(List<AdAuthStrategy> strategyList) {
+        this.strategies = strategyList.stream()
+                .collect(Collectors.toMap(AdAuthStrategy::getProvider, Function.identity()));
+    }
+
+    public AdAuthStrategy getStrategy(Provider provider) {
+        AdAuthStrategy strategy = strategies.get(provider);
+        if (strategy == null) {
+            throw new AdApiHandler(AdApiErrorCode.INVALID_PROVIDER_VALUE);
+        }
+        return strategy;
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/global/adapi/AdAuthStrategy.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/adapi/AdAuthStrategy.java
@@ -1,0 +1,17 @@
+package com.whereyouad.WhereYouAd.global.adapi;
+
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
+import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformConnection;
+import com.whereyouad.WhereYouAd.global.adapi.dto.AdAuthRequest;
+
+import java.security.GeneralSecurityException;
+import java.util.Map;
+
+public interface AdAuthStrategy {
+
+    // 지원하는 광고 플랫폼 반환
+    Provider getProvider();
+
+    // DB에서 조회된 인증 정보(connection)와 추가 request를 기반으로 헤더 Map을 생성
+    Map<String, String> generateHeaders(PlatformConnection connection, AdAuthRequest request) throws GeneralSecurityException;
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/global/adapi/dto/AdAuthRequest.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/adapi/dto/AdAuthRequest.java
@@ -1,0 +1,19 @@
+package com.whereyouad.WhereYouAd.global.adapi.dto;
+
+public record AdAuthRequest(
+        String method,
+        String path,
+        String body
+) {
+    // method, path O, body X
+    public static AdAuthRequest forMethodAndPath(String method, String path) {
+        return new AdAuthRequest(method, path, null);
+    }
+
+    // method, path, body X
+    public static AdAuthRequest empty() {
+        return new AdAuthRequest(null, null, null);
+    }
+
+    // 필요시 추가
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/global/adapi/exception/AdApiHandler.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/adapi/exception/AdApiHandler.java
@@ -1,0 +1,10 @@
+package com.whereyouad.WhereYouAd.global.adapi.exception;
+
+import com.whereyouad.WhereYouAd.global.exception.AppException;
+import com.whereyouad.WhereYouAd.global.exception.BaseErrorCode;
+
+public class AdApiHandler extends AppException {
+    public AdApiHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/global/adapi/exception/code/AdApiErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/adapi/exception/code/AdApiErrorCode.java
@@ -1,0 +1,19 @@
+package com.whereyouad.WhereYouAd.global.adapi.exception.code;
+
+import com.whereyouad.WhereYouAd.global.exception.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AdApiErrorCode implements BaseErrorCode {
+
+    // 400
+    INVALID_PROVIDER_VALUE(HttpStatus.BAD_REQUEST, "ADAPI_400_2", "지원하지 않는 Provider 타입입니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/global/adapi/strategy/GoogleAdAuthStrategy.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/adapi/strategy/GoogleAdAuthStrategy.java
@@ -29,7 +29,7 @@ public class GoogleAdAuthStrategy implements AdAuthStrategy {
         Map<String, String> headers = new HashMap<>();
 
         // 1. 암호화된 액세스 토큰 복호화
-        String accessToken = new String(aesUtil.decryptAES(connection.getAccessTokenEnc()), StandardCharsets.UTF_8);
+        String accessToken = new String(aesUtil.decryptAES(connection.getAuthIdentifier()), StandardCharsets.UTF_8);
 
         // 헤더 생성 로직 추가
 

--- a/src/main/java/com/whereyouad/WhereYouAd/global/adapi/strategy/GoogleAdAuthStrategy.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/adapi/strategy/GoogleAdAuthStrategy.java
@@ -1,0 +1,40 @@
+package com.whereyouad.WhereYouAd.global.adapi.strategy;
+
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
+import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformConnection;
+import com.whereyouad.WhereYouAd.global.utils.AESUtil;
+import com.whereyouad.WhereYouAd.global.adapi.AdAuthStrategy;
+import com.whereyouad.WhereYouAd.global.adapi.dto.AdAuthRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleAdAuthStrategy implements AdAuthStrategy {
+
+    private final AESUtil aesUtil;
+
+    @Override
+    public Provider getProvider() {
+        return Provider.GOOGLE;
+    }
+
+    @Override
+    public Map<String, String> generateHeaders(PlatformConnection connection, AdAuthRequest request) throws GeneralSecurityException {
+        Map<String, String> headers = new HashMap<>();
+
+        // 1. 암호화된 액세스 토큰 복호화
+        String accessToken = new String(aesUtil.decryptAES(connection.getAccessTokenEnc()), StandardCharsets.UTF_8);
+
+        // 헤더 생성 로직 추가
+
+
+
+        return headers;
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/global/adapi/strategy/KakaoAdAuthStrategy.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/adapi/strategy/KakaoAdAuthStrategy.java
@@ -1,0 +1,40 @@
+package com.whereyouad.WhereYouAd.global.adapi.strategy;
+
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
+import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformConnection;
+import com.whereyouad.WhereYouAd.global.utils.AESUtil;
+import com.whereyouad.WhereYouAd.global.adapi.AdAuthStrategy;
+import com.whereyouad.WhereYouAd.global.adapi.dto.AdAuthRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoAdAuthStrategy implements AdAuthStrategy {
+
+    private final AESUtil aesUtil;
+
+    @Override
+    public Provider getProvider() {
+        return Provider.KAKAO;
+    }
+
+    @Override
+    public Map<String, String> generateHeaders(PlatformConnection connection, AdAuthRequest request) throws GeneralSecurityException {
+        Map<String, String> headers = new HashMap<>();
+
+        // 1. 암호화된 액세스 토큰 복호화
+        String accessToken = new String(aesUtil.decryptAES(connection.getAccessTokenEnc()), StandardCharsets.UTF_8);
+
+        // 헤더 생성 로직 추가
+
+
+
+        return headers;
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/global/adapi/strategy/KakaoAdAuthStrategy.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/adapi/strategy/KakaoAdAuthStrategy.java
@@ -29,7 +29,7 @@ public class KakaoAdAuthStrategy implements AdAuthStrategy {
         Map<String, String> headers = new HashMap<>();
 
         // 1. 암호화된 액세스 토큰 복호화
-        String accessToken = new String(aesUtil.decryptAES(connection.getAccessTokenEnc()), StandardCharsets.UTF_8);
+        String accessToken = new String(aesUtil.decryptAES(connection.getAuthIdentifier()), StandardCharsets.UTF_8);
 
         // 헤더 생성 로직 추가
 

--- a/src/main/java/com/whereyouad/WhereYouAd/global/adapi/strategy/NaverAdAuthStrategy.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/adapi/strategy/NaverAdAuthStrategy.java
@@ -42,8 +42,8 @@ public class NaverAdAuthStrategy implements AdAuthStrategy {
         String timestamp = String.valueOf(System.currentTimeMillis());
 
         // DB에서 암호화된 키 복호화
-        String apiKey = new String(aesUtil.decryptAES(connection.getAccessTokenEnc()), StandardCharsets.UTF_8);
-        String secretKey = new String(aesUtil.decryptAES(connection.getRefreshTokenEnc()), StandardCharsets.UTF_8);
+        String apiKey = new String(aesUtil.decryptAES(connection.getAuthIdentifier()), StandardCharsets.UTF_8);
+        String secretKey = new String(aesUtil.decryptAES(connection.getAuthCredential()), StandardCharsets.UTF_8);
         String customerId = connection.getPlatformAccount().getExternalAccountId();
 
         // HMAC-SHA256 서명 생성

--- a/src/main/java/com/whereyouad/WhereYouAd/global/adapi/strategy/NaverAdAuthStrategy.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/adapi/strategy/NaverAdAuthStrategy.java
@@ -1,0 +1,63 @@
+package com.whereyouad.WhereYouAd.global.adapi.strategy;
+
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
+import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformConnection;
+import com.whereyouad.WhereYouAd.global.exception.AppException;
+import com.whereyouad.WhereYouAd.global.exception.ErrorCode;
+import com.whereyouad.WhereYouAd.global.utils.AESUtil;
+import com.whereyouad.WhereYouAd.global.adapi.AdAuthStrategy;
+import com.whereyouad.WhereYouAd.global.adapi.dto.AdAuthRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NaverAdAuthStrategy implements AdAuthStrategy {
+
+    private final AESUtil aesUtil;
+
+    @Override
+    public Provider getProvider() {
+        return Provider.NAVER;
+    }
+
+    @Override
+    public Map<String, String> generateHeaders(PlatformConnection connection, AdAuthRequest request) throws GeneralSecurityException {
+        if (request.method() == null || request.path() == null) {
+            log.error("Naver 요청에는 method와 path가 필수 입니다.");
+            throw new AppException(ErrorCode.BAD_REQUEST);
+        }
+
+        Map<String, String> headers = new HashMap<>();
+        String timestamp = String.valueOf(System.currentTimeMillis());
+
+        // DB에서 암호화된 키 복호화
+        String apiKey = new String(aesUtil.decryptAES(connection.getAccessTokenEnc()), StandardCharsets.UTF_8);
+        String secretKey = new String(aesUtil.decryptAES(connection.getRefreshTokenEnc()), StandardCharsets.UTF_8);
+        String customerId = connection.getPlatformAccount().getExternalAccountId();
+
+        // HMAC-SHA256 서명 생성
+        String message = timestamp + "." + request.method() + "." + request.path();
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+        String signature = Base64.getEncoder().encodeToString(mac.doFinal(message.getBytes(StandardCharsets.UTF_8)));
+
+        // 헤더 세팅
+        headers.put("X-Timestamp", timestamp);
+        headers.put("X-API-KEY", apiKey);
+        headers.put("X-Customer", customerId);
+        headers.put("X-Signature", signature);
+
+        return headers;
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/global/utils/AESUtil.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/utils/AESUtil.java
@@ -1,0 +1,57 @@
+package com.whereyouad.WhereYouAd.global.utils;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.GeneralSecurityException;
+import java.util.Base64;
+
+@Component
+@RequiredArgsConstructor
+public class AESUtil {
+
+    private static final String ALGORITHM = "AES";
+    private static final String CIPHER_ALGORITHM = "AES/CBC/PKCS5Padding";
+    @Value("${aes.secret}")
+    private String key;
+
+    /**
+     * AES로 암호화되어있는 문자열을 복호화합니다.
+     * @param encryptString 사용자의 시크릿 키 (AES 암호화된 상태)
+     * @return 복호화된 시크릿 키를 반환합니다.
+     */
+    public byte[] decryptAES(
+            String encryptString
+    ) throws GeneralSecurityException {
+        // 시크릿키 키 세팅 (복호화)
+        Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
+        SecretKey aesKey = new SecretKeySpec(key.getBytes(), ALGORITHM);
+        IvParameterSpec iv = new IvParameterSpec(key.getBytes());
+        cipher.init(Cipher.DECRYPT_MODE, aesKey, iv);
+
+        // Base64 디코딩 -> AES 복호화
+        return cipher.doFinal(Base64.getDecoder().decode(encryptString));
+    }
+
+    /**
+     * 평문을 AES로 암호화합니다.
+     * @param plainText 암호화할 평문
+     * @return AES로 암호화한 뒤 Base64로 인코딩한 문자열
+     */
+    public byte[] encryptAES(
+            String plainText
+    ) throws GeneralSecurityException {
+        Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
+        SecretKey aesKey = new SecretKeySpec(key.getBytes(), ALGORITHM);
+        IvParameterSpec iv = new IvParameterSpec(key.getBytes());
+        cipher.init(Cipher.ENCRYPT_MODE, aesKey, iv);
+
+        // AES 암호화 -> Base64 인코딩
+        return Base64.getEncoder().encode(cipher.doFinal(plainText.getBytes()));
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/global/utils/AdApiAuthUtil.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/utils/AdApiAuthUtil.java
@@ -1,0 +1,45 @@
+package com.whereyouad.WhereYouAd.global.utils;
+
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
+import com.whereyouad.WhereYouAd.domains.platform.exception.PlatformHandler;
+import com.whereyouad.WhereYouAd.domains.platform.exception.code.PlatformErrorCode;
+import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformConnection;
+import com.whereyouad.WhereYouAd.domains.platform.persistence.repository.PlatformConnectionRepository;
+import com.whereyouad.WhereYouAd.global.adapi.AdAuthFactory;
+import com.whereyouad.WhereYouAd.global.adapi.dto.AdAuthRequest;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.security.GeneralSecurityException;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AdApiAuthUtil {
+
+    private final PlatformConnectionRepository platformConnectionRepository;
+    private final AdAuthFactory adAuthFactory;
+
+    /**
+     * 외부 API 통신을 위한 HTTP 인증 헤더 Map을 생성합니다.
+     * @param connectionId 연결 정보
+     * @param request 파라미터 (method, path 등)
+     * @return HTTP Header에 삽입할 Key-Value Map
+     */
+    public Map<String, String> generateAuthHeaders(
+            @NotNull Long connectionId,
+            @NotNull AdAuthRequest request
+    ) throws GeneralSecurityException {
+
+        PlatformConnection connection = platformConnectionRepository.findById(connectionId)
+                .orElseThrow(() -> new PlatformHandler(PlatformErrorCode.PLATFORM_CONNECTION_NOT_FOUND));
+
+        Provider provider = connection.getPlatformAccount().getProvider();
+        log.debug("[{}] API 인증 헤더 생성 시작 - connectionId: {}", provider, connectionId);
+
+        return adAuthFactory.getStrategy(provider).generateHeaders(connection, request);
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/naver/client/NaverClient.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/naver/client/NaverClient.java
@@ -1,0 +1,20 @@
+package com.whereyouad.WhereYouAd.infrastructure.client.naver.client;
+
+import com.whereyouad.WhereYouAd.infrastructure.client.naver.dto.NaverDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+import java.util.List;
+import java.util.Map;
+
+@FeignClient(
+        name = "naverClient",
+        url = "https://api.searchad.naver.com"
+)
+public interface NaverClient {
+
+    // 캠페인 목록 조회
+    @GetMapping("/ncc/campaigns")
+    List<NaverDTO.Campaign> getCampaigns(@RequestHeader Map<String, String> headers);
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/naver/dto/NaverDTO.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/naver/dto/NaverDTO.java
@@ -1,5 +1,36 @@
 package com.whereyouad.WhereYouAd.infrastructure.client.naver.dto;
 
 public class NaverDTO {
-    // Naver 응답 원문
+    // 캠페인 응답 원문
+    public record Campaign(
+            String nccCampaignId,
+            Long customerId,
+            String campaignTp,
+            String name,
+            String status,
+            String statusReason,
+            Boolean useDailyBudget,
+            Long dailyBudget,
+            Boolean usePeriod,
+            String periodStartDt,
+            String periodEndDt,
+            String deliveryMethod,
+            String trackingMode,
+            String trackingUrl,
+            String trackingUrlCustomParams,
+            Boolean userLock,
+            Integer numberInUse,
+
+            // 공유 예산 관련
+            String sharedBudgetId,
+            String sharedBudgetName,
+            Long sharedDailyBudget,
+            String sharedBudgetDeliveryMethod,
+            Long sharedBudgetExpectCost,
+            Boolean sharedBudgetLock,
+
+            // 등록/수정 시간
+            String regTm,
+            String editTm
+    ) {}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -121,9 +121,12 @@ spring:
       region:
         static: ap-northeast-2
 
-# 6. JWT 설정
+# 6. JWT 및 AES 설정
 jwt:
   secret: ${JWT_SECRET}
+
+aes:
+  secret: ${AES_SECRET}
 #  expiration: 86400000
 
 # 7. OAuth2 로그인 성공 후 프론트엔드 리다이렉트 URL


### PR DESCRIPTION
## 📌 관련 이슈
- Close #105 

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.
- db에 API키 보안을 위해 DB에 평문으로 저장하지 않고 암/복호화가 가능하도록 AES 유틸 클래스 제작
- 플랫폼 3개 API 통신을 위해 strategy 패턴 적용
- 테스트를 위한 켐페인 조회 API 제작(Naver)

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- API 키 DB 저장 시 암호화 저장 & API 통신 시 필요한 API 키를 복호화하여 API 통신에 이용할 수 있도록 AES 유틸 클래스 제작
- API 통신은 `AdApiAuthUtil` 클래스를 이용해서 서비스 로직에서 필요한 헤더 제작하여 통신, 각 플랫폼 별 API 통신 인증에 필요한 헤더 제작은 globla/adapi/strategy안에서 제작 (`GoogleAdAuthStrategy`랑 `KakaoAdAuthStrategy`만 수정해주시면 됩니다)
- API 통신에 필요한 요청값은 AdAuthRequest를 통해 받음
- infrastructure쪽에서 각 플랫폼 별 외부 API 통신은 client를 통해, 응답 원문은 DTO를 통해 받아 필요한 것만 converter를 통해 반환 혹은 저장

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.
1. AES 암호화
- API 키
<img width="1470" height="712" alt="image" src="https://github.com/user-attachments/assets/51466e0a-7afe-419b-bdd6-7220b978f396" />

- 엑세스라이선스 AES 암호화 결과
<img width="967" height="767" alt="image" src="https://github.com/user-attachments/assets/1a83e931-b7f8-44c5-b48b-b552f766c877" />

- 비밀키 AES 암호화 결과
<img width="872" height="680" alt="image" src="https://github.com/user-attachments/assets/61e8feee-3968-4328-a990-a7a3d677816c" />


2. DB 저장 상태
- platformConnection에 암호화하여 저장
<img width="793" height="141" alt="image" src="https://github.com/user-attachments/assets/e4c96935-af5e-4393-aa57-f0cbcd78f4a0" />


3. 캠페인 조회 API
- 이를 복호화하여 API 통신 테스트(켐페인 조회 API)
<img width="1594" height="743" alt="image" src="https://github.com/user-attachments/assets/fdf6fa8e-035d-4138-bad3-13dd798b4d9a" />

<img width="1487" height="519" alt="image" src="https://github.com/user-attachments/assets/afd1f7b9-bff0-488d-adf5-da2d672226d9" />

<img width="1449" height="494" alt="image" src="https://github.com/user-attachments/assets/013362d0-adb0-4fc1-8c97-33b11d17ab73" />

- 현재 등록된 광고
<img width="1534" height="149" alt="image" src="https://github.com/user-attachments/assets/02ccf22d-2187-46e5-bb0f-d50b29c582b5" />


## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- DB에 API키를 암호화해서 저장하기 위해 이전 프로젝트에서 적용했던 AES 암호화 방식을 사용했는데 혹시 해보고 싶은 다른 암호화 방식이나 더 좋은 암호화 방식 있으시면 바꿔도 됩니다!
- 일단 AES 암호화 키는 노션에 최신화 해놓겠습니다.
- API 통신할 때 리펙터링하거나 확장하기 쉽게 공통적된 방법으로 통신하면 좋을 것 같아서 일단 올려봅니다.. 혹시 strategy 패턴 + Factory 메서드 말고 하고 계신 좋은 방법이 있다면 피드백 해주시면 바꿔보겠습니다!
- 추가로 캠페인 조회 시 DB에 저장한 데이터 불러오는 방식을 유지할 지 아니면 API 통신하는 방법으로 리펙터링 할지 (API 통신 시 항상 최신 데이터를 가져옴) 고민이 됩니다
+ 추가로 네이버 엑세스라이선스랑 시크릿 키 저장할 곳이 마땅치 않아서 accessToken이랑 refreshToken쪽에 저장했는데 이름을 좀 범용적으로 바꿀까요? 아니면 내부 속성을 추가하는 것이 좋을까요?

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * NAVER 광고 연동을 통해 조직별 캠페인 목록 조회 API 추가

* **문서**
  * NAVER 캠페인 조회에 대한 OpenAPI/Swagger 문서화 추가

* **Chores**
  * AES 비밀키 환경변수 및 애플리케이션 설정 추가
  * CI 워크플로우에 테스트용 AES 환경변수 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->