### PR TITLE
Feat/#109 로그아웃 API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ out/
 #src/main/resources/application.yml
 .env
 .env.prod
+
+#CLAUDE.md
+CLAUDE.md

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/AuthService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/AuthService.java
@@ -11,6 +11,7 @@ import com.whereyouad.WhereYouAd.global.security.jwt.dto.TokenResponse;
 import com.whereyouad.WhereYouAd.global.utils.RedisUtil;
 import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
@@ -19,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -118,6 +120,7 @@ public class AuthService {
             }
         } catch (JwtException | IllegalArgumentException e) {
             //SecurityConfig 에서 손상 아님이 보장되지만 안전을 위해 catch 처리
+            log.error("로그아웃 실행 중 JWT 토큰 손상 감지: {}", e);
         }
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/AuthService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/AuthService.java
@@ -8,6 +8,8 @@ import com.whereyouad.WhereYouAd.global.exception.AppException;
 import com.whereyouad.WhereYouAd.global.security.jwt.CustomUserDetailsService;
 import com.whereyouad.WhereYouAd.global.security.jwt.JwtTokenProvider;
 import com.whereyouad.WhereYouAd.global.security.jwt.dto.TokenResponse;
+import com.whereyouad.WhereYouAd.global.utils.RedisUtil;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -15,15 +17,19 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
+    private static final String BLACKLIST_PREFIX = "blacklist:";
+
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
     private final CustomUserDetailsService customUserDetailsService;
+    private final RedisUtil redisUtil;
 
     //최초 로그인을 통해 AccessToken 과 RefreshToken 발급 받는 메서드
     //Transactional 어노테이션 제거 -> 메서드 전체에 Transactional 을 걸 시 DB 커넥션 풀 고갈 가능
@@ -85,5 +91,33 @@ public class AuthService {
 
         //새로운 Access & RefreshToken 반환
         return tokenResponse;
+    }
+
+    // 로그아웃 — AccessToken 블랙리스트 등록 + RefreshToken DB에서 삭제
+    // 이메일/소셜 로그인 모두 email 을 key 로 동일한 RefreshToken row 를 공유하므로 분기 없이 처리
+    public void logout(String accessToken) {
+
+        // AccessToken 없을 시 return 처리 - 관대한 로그아웃 방식
+        // SecurityConfig 에서 이미 인증 요구하므로 토큰값 존재 보장되긴 하지만, 안전을 위해 return 처리
+        if (!StringUtils.hasText(accessToken)) {
+            return;
+        }
+
+        // AccessToken 남은 TTL 동안 Redis 에 블랙리스트로 등록 (만료/손상 토큰은 0 반환 -> 등록 생략)
+        long remainingMillis = jwtTokenProvider.getRemainingExpirationMillis(accessToken);
+        if (remainingMillis > 0) { //SecurityConfig 에서 만료 아님이 보장되지만 안전을 위해 확인
+            long remainingSeconds = Math.max(remainingMillis / 1000, 1);
+            redisUtil.setDataExpire(BLACKLIST_PREFIX + accessToken, "logout", remainingSeconds);
+        }
+
+        // RefreshToken 삭제 — 토큰에서 email(subject) 추출 실패 시에도 로그아웃 응답은 계속 진행
+        try {
+            String email = jwtTokenProvider.getSubject(accessToken);
+            if (StringUtils.hasText(email)) {
+                refreshTokenRepository.deleteById(email);
+            }
+        } catch (JwtException | IllegalArgumentException e) {
+            //SecurityConfig 에서 손상 아님이 보장되지만 안전을 위해 catch 처리
+        }
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/AuthService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/AuthService.java
@@ -2,6 +2,7 @@ package com.whereyouad.WhereYouAd.domains.user.domain.service;
 
 import com.whereyouad.WhereYouAd.domains.user.application.dto.request.LoginRequest;
 import com.whereyouad.WhereYouAd.domains.user.exception.code.AuthErrorCode;
+import com.whereyouad.WhereYouAd.domains.user.exception.handler.UserHandler;
 import com.whereyouad.WhereYouAd.domains.user.persistence.entity.RefreshToken;
 import com.whereyouad.WhereYouAd.domains.user.persistence.repository.RefreshTokenRepository;
 import com.whereyouad.WhereYouAd.global.exception.AppException;
@@ -19,6 +20,11 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
 
 @Slf4j
 @Service
@@ -106,6 +112,7 @@ public class AuthService {
         }
 
         // AccessToken 남은 TTL 동안 Redis 에 블랙리스트로 등록 (만료/손상 토큰은 0 반환 -> 등록 생략)
+        // 원문 JWT 가 외부에 노출되지 않도록 SHA-256 해시값을 키로 사용
         long remainingMillis = jwtTokenProvider.getRemainingExpirationMillis(accessToken);
         if (remainingMillis > 0) { //SecurityConfig 에서 만료 아님이 보장되지만 안전을 위해 확인
             long remainingSeconds = Math.max((remainingMillis + 999) / 1000, 1);
@@ -121,6 +128,18 @@ public class AuthService {
         } catch (JwtException | IllegalArgumentException e) {
             //SecurityConfig 에서 손상 아님이 보장되지만 안전을 위해 catch 처리
             log.error("로그아웃 실행 중 JWT 토큰 손상 감지: {}", e);
+        }
+    }
+
+    // AccessToken 해쉬화 메서드
+    // JwtAuthenticationFilter 의 블랙리스트 조회 키와 동일한 방식
+    private String sha256(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashed = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hashed);
+        } catch (NoSuchAlgorithmException e) { //SHA-256이 JVM 에서 지원안할시 발생 -> 사실상 발생확률 적음
+            throw new UserHandler(AuthErrorCode.TOKEN_HASH_FAILED);
         }
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/AuthService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/AuthService.java
@@ -108,8 +108,8 @@ public class AuthService {
         // AccessToken 남은 TTL 동안 Redis 에 블랙리스트로 등록 (만료/손상 토큰은 0 반환 -> 등록 생략)
         long remainingMillis = jwtTokenProvider.getRemainingExpirationMillis(accessToken);
         if (remainingMillis > 0) { //SecurityConfig 에서 만료 아님이 보장되지만 안전을 위해 확인
-            long remainingSeconds = Math.max(remainingMillis / 1000, 1);
-            redisUtil.setDataExpire(BLACKLIST_PREFIX + accessToken, "logout", remainingSeconds);
+            long remainingSeconds = Math.max((remainingMillis + 999) / 1000, 1);
+            redisUtil.setDataExpire(BLACKLIST_PREFIX + sha256(accessToken), "logout", remainingSeconds);
         }
 
         // RefreshToken 삭제 — 토큰에서 email(subject) 추출 실패 시에도 로그아웃 응답은 계속 진행

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/exception/code/AuthErrorCode.java
@@ -16,7 +16,10 @@ public enum AuthErrorCode implements BaseErrorCode {
     // 로그인 실패 (비밀번호 틀림 or 계정 없음)
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_401_1", "아이디 또는 비밀번호가 일치하지 않습니다."),
 
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_401_4", "해당 이메일의 회원이 존재하지 않습니다.")
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_401_4", "해당 이메일의 회원이 존재하지 않습니다."),
+
+    // 토큰 해시 처리 실패 (SHA-256 알고리즘 미지원 등 JVM/환경 문제 -> 사실상 발생 확률 적음)
+    TOKEN_HASH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH_500_1", "토큰 해시 처리에 실패했습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/AuthController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/AuthController.java
@@ -2,7 +2,6 @@ package com.whereyouad.WhereYouAd.domains.user.presentation;
 
 import com.whereyouad.WhereYouAd.domains.user.application.dto.request.LoginRequest;
 import com.whereyouad.WhereYouAd.domains.user.domain.service.AuthService;
-import com.whereyouad.WhereYouAd.domains.user.domain.service.EmailService;
 import com.whereyouad.WhereYouAd.domains.user.presentation.docs.AuthControllerDocs;
 import com.whereyouad.WhereYouAd.global.response.DataResponse;
 import com.whereyouad.WhereYouAd.global.security.jwt.dto.TokenResponse;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/AuthController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/AuthController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -61,5 +62,43 @@ public class AuthController implements AuthControllerDocs {
                 .header(HttpHeaders.SET_COOKIE, httpOnlyCookie.toString()) //생성한 RefreshToken 쿠키를 헤더에 설정
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokenResponse.accessToken()) //AccessToken 을 Authorization 헤더에도 추가(편의사항)
                 .body(DataResponse.from(tokenResponse));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+            @RequestHeader(name = "Authorization") String authorizationHeader
+    )
+    {
+        // Authorization 헤더에서 토큰 추출
+        // SecurityConfig 에서 인증 필수이므로 헤더 존재 보장
+        String accessToken = null;
+        if (StringUtils.hasText(authorizationHeader) && authorizationHeader.startsWith("Bearer ")) {
+            accessToken = authorizationHeader.substring(7);
+        }
+
+        authService.logout(accessToken);
+
+        //RefreshToken 쿠키 제거
+        ResponseCookie expiredRefresh = ResponseCookie.from("refresh_token", "")
+                .httpOnly(true)
+                .secure(false)
+                .path("/")
+                .maxAge(0)
+                .sameSite("Strict")
+                .build();
+
+        //AccessToken 쿠키 제거 — 소셜 로그인에서 OAuth2 핸들러가 세팅한 쿠키 제거용(이메일 로그인 유저 브라우저엔 해당 쿠키가 없어 해당X)
+        ResponseCookie expiredAccess = ResponseCookie.from("access_token", "")
+                .httpOnly(false)
+                .secure(false)
+                .path("/")
+                .maxAge(0)
+                .sameSite("Lax")
+                .build();
+
+        return ResponseEntity.noContent()
+                .header(HttpHeaders.SET_COOKIE, expiredRefresh.toString())
+                .header(HttpHeaders.SET_COOKIE, expiredAccess.toString())
+                .build();
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/docs/AuthControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/docs/AuthControllerDocs.java
@@ -35,7 +35,8 @@ public interface AuthControllerDocs {
 
     @Operation(
             summary = "로그아웃 API",
-            description = "AccessToken 을 Redis 블랙리스트에 등록(남은 만료시간 TTL)하고 RefreshToken을 DB에서 삭제한 뒤, access_token/refresh_token 쿠키를 만료시킴. 이메일/소셜 로그인 공통."
+            description = "AccessToken 을 Redis 블랙리스트에 등록(남은 만료시간 TTL)하고 RefreshToken을 DB에서 삭제한 뒤, access_token/refresh_token 쿠키를 만료시킴. 이메일/소셜 로그인 공통.\n\n" +
+                    "***프론트 유의점*** 해당 API 는 헤더에 Authorization: Bearer <token> 값이 반드시 필요합니다. 소셜 로그인의 경우 AccessToken 값이 쿠키에 저장되어있어 해당 값을 명시적으로 Authorization 헤더에 첨부해야합니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "성공 — 이후 동일 AccessToken 으로는 인증 불가"),

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/docs/AuthControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/docs/AuthControllerDocs.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 public interface AuthControllerDocs {
     @Operation(
@@ -31,4 +32,15 @@ public interface AuthControllerDocs {
             @ApiResponse(responseCode = "401_3", description = "실패(RefreshToken 옳지 않은 값)")
     })
     public ResponseEntity<DataResponse<TokenResponse>> reIssue(@CookieValue(name = "refresh_token") String refreshToken);
+
+    @Operation(
+            summary = "로그아웃 API",
+            description = "AccessToken 을 Redis 블랙리스트에 등록(남은 만료시간 TTL)하고 RefreshToken을 DB에서 삭제한 뒤, access_token/refresh_token 쿠키를 만료시킴. 이메일/소셜 로그인 공통."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "성공 — 이후 동일 AccessToken 으로는 인증 불가"),
+            @ApiResponse(responseCode = "401_2", description = "AccessToken 만료 — reissue 후 재호출 필요"),
+            @ApiResponse(responseCode = "401_3", description = "AccessToken 형식이 잘못되었거나 없음 / 이미 로그아웃된 토큰")
+    })
+    public ResponseEntity<Void> logout(@RequestHeader(name = "Authorization") String authorizationHeader);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/global/security/SecurityConfig.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/security/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll() //swagger 접근 허용
-                        .requestMatchers("/api/users/my").authenticated() //마이페이지는 인증 필요
+                        .requestMatchers("/api/users/my", "/api/auth/logout").authenticated() //마이페이지, 로그아웃은 인증 필요
                         .requestMatchers("/api/users/**", "/api/auth/**", "/api/clicks/track/**", "/api/ai/reports/**").permitAll() //로그인, 회원가입, 이메일 인증, 트래킹, AI 리포트 접근 허용
                         .anyRequest().authenticated() //이외 접근은 인증 필요
                 )

--- a/src/main/java/com/whereyouad/WhereYouAd/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/security/jwt/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.whereyouad.WhereYouAd.global.security.jwt;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.whereyouad.WhereYouAd.domains.user.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.domains.user.exception.code.AuthErrorCode;
+import com.whereyouad.WhereYouAd.domains.user.exception.handler.UserHandler;
 import com.whereyouad.WhereYouAd.global.response.ErrorResponse;
 import com.whereyouad.WhereYouAd.global.utils.RedisUtil;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -19,6 +20,10 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
 
 @Component
 @RequiredArgsConstructor
@@ -47,7 +52,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 jwtTokenProvider.validateToken(token); //예외 발생 가능 구간 -> ExpiredJwtException 등
 
                 //블랙리스트(로그아웃 처리된 토큰) 확인 — 만료 전이라도 차단
-                if (redisUtil.getData(BLACKLIST_PREFIX + token) != null) {
+                //AuthService.logout 에서 해시 처리된 값과 동일하게 AccessToken 값 해시해서 조회
+                if (redisUtil.getData(BLACKLIST_PREFIX + sha256(token)) != null) {
                     setErrorResponse(response, AuthErrorCode.INVALID_TOKEN_FORMAT, request);
                     return;
                 }
@@ -77,6 +83,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         } catch (JwtException | IllegalArgumentException e) { //토큰 위조 or 손상 시 예외 처리
             setErrorResponse(response, AuthErrorCode.INVALID_TOKEN_FORMAT, request);
             return;
+        } catch (UserHandler e) { // 로그아웃 블랙리스트 조회시 sha256 암호화 관련 오류 발생시 예외 처리 -> 사실상 발생 확률 적음
+            setErrorResponse(response, AuthErrorCode.TOKEN_HASH_FAILED, request);
         }
 
         filterChain.doFilter(request, response);
@@ -103,5 +111,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         // 객체를 JSON 문자열로 변환하여 출력
         response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+
+    // AuthService.logout 의 블랙리스트 등록 키와 동일한 방식
+    private String sha256(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashed = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hashed);
+        } catch (NoSuchAlgorithmException e) { //SHA-256이 JVM 에서 지원안할시 발생 -> 사실상 발생확률 적음
+            throw new UserHandler(AuthErrorCode.TOKEN_HASH_FAILED);
+        }
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/security/jwt/JwtAuthenticationFilter.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.whereyouad.WhereYouAd.domains.user.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.domains.user.exception.code.AuthErrorCode;
 import com.whereyouad.WhereYouAd.global.response.ErrorResponse;
+import com.whereyouad.WhereYouAd.global.utils.RedisUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
@@ -23,9 +24,12 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    private static final String BLACKLIST_PREFIX = "blacklist:";
+
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomUserDetailsService customUserDetailService; //DB 에서 User 정보 가져오는 Service 클래스
     private final ObjectMapper objectMapper;
+    private final RedisUtil redisUtil;
 
     //들어오는 로직에 대한 JWT 토큰 기반 실제 필터링 메서드
     @Override
@@ -41,6 +45,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 //AccessToken 유효성 확인
                 jwtTokenProvider.validateToken(token); //예외 발생 가능 구간 -> ExpiredJwtException 등
+
+                //블랙리스트(로그아웃 처리된 토큰) 확인 — 만료 전이라도 차단
+                if (redisUtil.getData(BLACKLIST_PREFIX + token) != null) {
+                    setErrorResponse(response, AuthErrorCode.INVALID_TOKEN_FORMAT, request);
+                    return;
+                }
 
                 //토큰에서 email 값 추출
                 String email = jwtTokenProvider.getSubject(token);

--- a/src/main/java/com/whereyouad/WhereYouAd/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/security/jwt/JwtTokenProvider.java
@@ -141,4 +141,15 @@ public class JwtTokenProvider {
 
         return provider;
     }
+
+    //로그아웃 블랙리스트 TTL 계산용 — 토큰 남은 만료 시간(ms). 만료/손상 토큰은 0 반환
+    public long getRemainingExpirationMillis(String token) {
+        try {
+            Date expiration = parseClaims(token).getExpiration();
+            long remaining = expiration.getTime() - System.currentTimeMillis();
+            return Math.max(remaining, 0L);
+        } catch (JwtException | IllegalArgumentException e) {
+            return 0L;
+        }
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #109 

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

로그아웃 API 추가

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- 이메일 로그인에 대해 AccessToken 를 Redis 에 블랙리스트로 등록 & RefreshToken DB 에서 삭제하는 로직 추가
- 소셜 로그인에 대해 브라우저 쿠키값에 존재하는 AccessToken 값 제거 & RefreshToken DB 에서 삭제하는 로직 추가 
- 추후 Claude code 사용을 위해 gitignore 내부 CLAUDE.md 추가

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.


먼저, test@example.com 으로 이메일 로그인 실행 & RefreshToken 존재 확인 & 마이페이지 API 정상 호출 확인
<img width="2096" height="1066" alt="image" src="https://github.com/user-attachments/assets/16d4720c-d07e-4820-a590-b272b616fefe" />
<img width="1275" height="331" alt="image" src="https://github.com/user-attachments/assets/63270550-d2d4-494c-9836-90c4a3d86a2f" />

<img width="2094" height="1154" alt="image" src="https://github.com/user-attachments/assets/3cdde1c4-f14a-48ad-a18f-b0cdc648d6ee" />  <br>



로그아웃 API 호출 후, RefreshToken 제거 확인 & 같은 AccessToken 값으로 마이페이지 API 호출 불가 확인
<img width="2097" height="849" alt="image" src="https://github.com/user-attachments/assets/e0463e35-59f1-464d-a51b-31224ae58425" />
<img width="1279" height="284" alt="image" src="https://github.com/user-attachments/assets/c57cc8aa-aa45-4c60-a296-e6675cffd2af" />

<img width="2097" height="1043" alt="image" src="https://github.com/user-attachments/assets/e388a9c0-42a5-4351-89fa-9469682324c1" />  <br>


소셜로그인 진행 후, RefreshToken 값 확인 & 로그아웃 API 호출
<img width="2559" height="542" alt="image" src="https://github.com/user-attachments/assets/9e540eb1-24c8-4968-b07b-747daf594981" />
<img width="1269" height="345" alt="image" src="https://github.com/user-attachments/assets/34dbfc6b-3e16-4270-8cc3-9568dc8d7a81" />

<img width="2559" height="1472" alt="image" src="https://github.com/user-attachments/assets/2070cf5a-a34e-42d5-b4f6-88935d29e558" />  <br>


RefreshToken 삭제 확인 & 같은 소셜로그인 AccessToken 값으로 마이페이지 호출 시도 시 오류
<img width="1268" height="348" alt="image" src="https://github.com/user-attachments/assets/46dc932c-a3e1-427b-9590-1226c0b48ddb" />
<img width="2559" height="1471" alt="image" src="https://github.com/user-attachments/assets/272b4513-c7b0-4a3c-9812-f2fd6723112b" />  <br>


## ✅ 체크리스트
- [✅] 브랜치 전략(GitHub Flow)을 준수했나요?
- [✅] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [✅] 테스트 통과 확인
- [✅] 서버 실행 확인
- [✅] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- 처음에는 단순히 RefreshToken 을 백에서 DB 제거 해주고, 프론트가 AccessToken 을 삭제처리하는 방식만 생각했는데, 조사를 하다보니 로그아웃 된 AccessToken 을 Redis 에 블랙리스트 처리해서 혹시라도 같은 AccessToken 으로 다시 요청하는 상황도 방지하는 방법이 있더라구요... 저희 프로젝트에 Redis 도 이미 있어서 한번 이 방법대로 구현해봤습니다. 블랙리스트 처리는 AccessToken 만료까지 남은 시간동안 Redis 에 등록하도록 했습니다. + 코드래빗 리뷰 반영하여 AccessToken 을 Redis 에 해시 처리해서 블랙리스트 등록하는 방식으로 수정했습니다.
- 추후에 클로드 코드 쓰면 CLAUDE.md 파일이 프로젝트 디렉터리 내부에 생성된다고 해서 gitignore 에 추가해봤는데 괜찮을까요?

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 로그아웃 기능이 추가되었습니다. 사용자는 이제 계정에서 로그아웃할 수 있으며, 로그아웃 시 액세스 토큰이 서버에서 무효화되고 인증 관련 쿠키가 모두 삭제됩니다.

## 보안 개선
* 로그아웃된 토큰에 대한 접근 제어가 강화되어 보안성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->