### PR TITLE
Fix/#115  소셜로그인 오류 - 소셜로그인 배포환경 쿠키 설정 오류 수정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,6 @@ AES_SECRET=your_aes_secret_key
 
 #쿠키 설정 - 로컬에선 비워두면 기본값(false,빈값,Lax)
 #운영 배포는 배포 환경에 맞게 깃허브 secrets 로 관리중(노션 참조)
-COOKIE_SECURE=
+COOKIE_SECURE=false
 COOKIE_DOMAIN=
-COOKIE_SAME_SITE
+COOKIE_SAME_SITE=Lax

--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,9 @@ OPENAI_API_KEY=your_openai_api_key
 
 #10 AES
 AES_SECRET=your_aes_secret_key
+
+#쿠키 설정 - 로컬에선 비워두면 기본값(false,빈값,Lax)
+#운영 배포는 배포 환경에 맞게 깃허브 secrets 로 관리중(노션 참조)
+COOKIE_SECURE=
+COOKIE_DOMAIN=
+COOKIE_SAME_SITE

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/AuthController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/AuthController.java
@@ -6,6 +6,7 @@ import com.whereyouad.WhereYouAd.domains.user.presentation.docs.AuthControllerDo
 import com.whereyouad.WhereYouAd.global.response.DataResponse;
 import com.whereyouad.WhereYouAd.global.security.jwt.dto.TokenResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -19,19 +20,23 @@ public class AuthController implements AuthControllerDocs {
 
     private final AuthService authService;
 
+    @Value("${cookie.secure}")
+    private boolean cookieSecure;
+
+    @Value("${cookie.domain:}")
+    private String cookieDomain;
+
+    @Value("${cookie.same-site}")
+    private String cookieSameSite;
+
     @PostMapping("/login")
     public ResponseEntity<DataResponse<TokenResponse>> login(@RequestBody LoginRequest request) {
 
         TokenResponse tokenResponse = authService.login(request);
 
-        ResponseCookie httpOnlyCookie = ResponseCookie.from("refresh_token", tokenResponse.refreshToken())
+        ResponseCookie httpOnlyCookie = baseCookie("refresh_token", tokenResponse.refreshToken())
                 .httpOnly(true)
-//                .secure(true) //<-- HTTPS 에서만 쿠키 전송하도록 설정
-                .secure(false) //<-- Postman 테스트 용이를 위해 false
-                .path("/")
                 .maxAge(60 * 60 * 24 * 7) // 7일
-//                .sameSite("None") //<-- 크로스 사이트 전송 정책, 프론트와 연동시 해당 코드 활성화
-                .sameSite("Strict") //<-- 개발 or 테스트 or Postman 을 위해 임시 Strict
                 .build();
 
         return ResponseEntity.ok()
@@ -47,14 +52,9 @@ public class AuthController implements AuthControllerDocs {
     {
         TokenResponse tokenResponse = authService.reIssue(refreshToken);
 
-        ResponseCookie httpOnlyCookie = ResponseCookie.from("refresh_token", tokenResponse.refreshToken())
+        ResponseCookie httpOnlyCookie = baseCookie("refresh_token", tokenResponse.refreshToken())
                 .httpOnly(true)
-//                .secure(true)
-                .secure(false)
-                .path("/")
                 .maxAge(60 * 60 * 24 * 7) // 7일
-//                .sameSite("None")
-                .sameSite("Strict")
                 .build();
 
         return ResponseEntity.ok()
@@ -78,26 +78,32 @@ public class AuthController implements AuthControllerDocs {
         authService.logout(accessToken);
 
         //RefreshToken 쿠키 제거
-        ResponseCookie expiredRefresh = ResponseCookie.from("refresh_token", "")
+        ResponseCookie expiredRefresh = baseCookie("refresh_token", "")
                 .httpOnly(true)
-                .secure(false)
-                .path("/")
                 .maxAge(0)
-                .sameSite("Strict")
                 .build();
 
         //AccessToken 쿠키 제거 — 소셜 로그인에서 OAuth2 핸들러가 세팅한 쿠키 제거용(이메일 로그인 유저 브라우저엔 해당 쿠키가 없어 해당X)
-        ResponseCookie expiredAccess = ResponseCookie.from("access_token", "")
+        ResponseCookie expiredAccess = baseCookie("access_token", "")
                 .httpOnly(false)
-                .secure(false)
-                .path("/")
                 .maxAge(0)
-                .sameSite("Lax")
                 .build();
 
         return ResponseEntity.noContent()
                 .header(HttpHeaders.SET_COOKIE, expiredRefresh.toString())
                 .header(HttpHeaders.SET_COOKIE, expiredAccess.toString())
                 .build();
+    }
+
+    // 환경 설정(cookie.secure / cookie.domain / cookie.same-site)을 반영한 쿠키 빌더
+    private ResponseCookie.ResponseCookieBuilder baseCookie(String name, String value) {
+        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, value)
+                .secure(cookieSecure)
+                .path("/")
+                .sameSite(cookieSameSite);
+        if (StringUtils.hasText(cookieDomain)) {
+            builder.domain(cookieDomain);
+        }
+        return builder;
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/global/security/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/security/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 
@@ -27,6 +28,15 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     // TODO: 연동 시 프론트 주소로 변경(일단 스웨거로 redirect)
     @Value("${oauth2.redirect-url:http://localhost:8080/swagger-ui/index.html}")
     private String redirectUrl;
+
+    @Value("${cookie.secure}")
+    private boolean cookieSecure;
+
+    @Value("${cookie.domain:}")
+    private String cookieDomain;
+
+    @Value("${cookie.same-site}")
+    private String cookieSameSite;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -51,21 +61,15 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         refreshTokenRepository.save(refreshToken);
 
         // Access Token 쿠키 설정(httpOnly: false)
-        ResponseCookie accessTokenCookie = ResponseCookie.from("access_token", tokenResponse.accessToken())
+        ResponseCookie accessTokenCookie = baseCookie("access_token", tokenResponse.accessToken())
                 .httpOnly(false)
-                .secure(false) // 개발 환경용, 프로덕션에서는 true로 변경
-                .path("/")
                 .maxAge(60 * 60) // 1시간
-                .sameSite("Lax") // OAuth2 리다이렉트를 위해 Lax 사용
                 .build();
 
         // Refresh Token을 HttpOnly 쿠키로 설정
-        ResponseCookie refreshTokenCookie = ResponseCookie.from("refresh_token", tokenResponse.refreshToken())
+        ResponseCookie refreshTokenCookie = baseCookie("refresh_token", tokenResponse.refreshToken())
                 .httpOnly(true)
-                .secure(false) // 개발 환경용, 프로덕션에서는 true로 변경
-                .path("/")
                 .maxAge(60 * 60 * 24 * 7) // 7일
-                .sameSite("Lax") // OAuth2 리다이렉트를 위해 Lax 사용
                 .build();
 
         response.addHeader("Set-Cookie", accessTokenCookie.toString());
@@ -73,5 +77,17 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
         // 리다이렉트 (토큰은 쿠키로 전달)
         getRedirectStrategy().sendRedirect(request, response, redirectUrl);
+    }
+
+    // 환경 설정(cookie.secure / cookie.domain / cookie.same-site)을 반영한 쿠키 빌더
+    private ResponseCookie.ResponseCookieBuilder baseCookie(String name, String value) {
+        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, value)
+                .secure(cookieSecure)
+                .path("/")
+                .sameSite(cookieSameSite);
+        if (StringUtils.hasText(cookieDomain)) {
+            builder.domain(cookieDomain);
+        }
+        return builder;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -151,3 +151,9 @@ feign:
     config:
       openAiClient:
         loggerLevel: BASIC   # NONE / BASIC / HEADERS / FULL
+
+# 11. 인증 쿠키 설정 (로컬/운영 환경 분리)
+cookie:
+  secure: ${COOKIE_SECURE:false}
+  domain: ${COOKIE_DOMAIN:}
+  same-site: ${COOKIE_SAME_SITE:Lax}


### PR DESCRIPTION
## 📌 관련 이슈
- Close #115 

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.
배포 환경에서 소셜로그인, 일반 로그인 쿠키 자동 필터링 방지

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- OAuth2AuthenticationSuccessHandler 내부 쿠키 설정 배포/로컬 분리
- AuthController 내부 로그인, 로그아웃, reIssue 쿠키 설정 배포/로컬 분리
- application.yml, .env.example 추가

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.
1. .env(로컬) 에서 
COOKIE_SECURE=false
COOKIE_DOMAIN=
COOKIE_SAME_SITE=Lax
설정시 로그인 쿠키 값 확인 -> 응답 헤더에 Secure 나 Domain=~~ 없음.
로컬 구글 로그인 시 쿠키에 Domain 이 localhost 
<img width="1919" height="225" alt="image" src="https://github.com/user-attachments/assets/7f652132-c92a-43f3-84db-26784c9e42e7" />
<img width="2096" height="745" alt="image" src="https://github.com/user-attachments/assets/83115a92-ff19-4670-be5b-1b10129a8210" />
<img width="2559" height="489" alt="image" src="https://github.com/user-attachments/assets/6954c953-57ae-4609-b5bd-0238a445e0fd" />


쿠키 설정 값을 배포 환경과 같게 할 시 일반 로그인과 소셜로그인에 Domain=whereyouad.com, Secure  확인가능,
<img width="1865" height="195" alt="image" src="https://github.com/user-attachments/assets/7b834bff-e045-4e85-a38b-571b6271510c" />
<img width="2103" height="778" alt="image" src="https://github.com/user-attachments/assets/60eb4003-22e6-4f06-bc2d-08aefb90003f" />
<img width="2559" height="1473" alt="image" src="https://github.com/user-attachments/assets/a5844ee4-af4d-485f-9adc-f686946bb53b" />


## ✅ 체크리스트
- [✅] 브랜치 전략(GitHub Flow)을 준수했나요?
- [✅] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [✅] 테스트 통과 확인
- [✅] 서버 실행 확인
- [✅] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- 혹시 뭔가 이상하다면 알려주세요...!!
- 각자 로컬에 .env 에 해당 필드는 application.yml 에 기본값 반영되어있어서 굳이 추가하지 않아도 되긴 합니다...! 


> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 쿠키 보안 설정(Secure, Domain, SameSite)이 환경 변수로 구성 가능하게 개선되었습니다. 배포 환경에 맞게 유연하게 설정할 수 있습니다.

* **설정**
  * OpenAI 클라이언트 로깅 레벨 설정이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->