### PR TITLE
Feat/#119 광고 API 키 등록 & 관리- 각 플랫폼 광고 API 키 값 등록 및 관리 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ cp .env.example .env
 필요한 환경 변수 그룹:
 - DB / Redis / Kafka 접속 정보
 - OAuth2 클라이언트 자격증명 (Naver / Google / Kakao)
-- 광고 플랫폼 자격증명 (Meta, Google Ads)
+- 광고 플랫폼 자격증명 (Meta Marketing, Google Ads, Naver Ads)
 - JWT / AES 시크릿
 - AWS S3, OpenAI, CoolSMS, Gmail 자격증명
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ WhereYouAd는 **광고 성과 및 워크스페이스 관리를 효율적으로 �
 ### 주요 기능
 
 - **소셜 로그인 & JWT 인증** — Naver / Google / Kakao OAuth2 로그인 및 JWT 세션 관리
-- **광고 플랫폼 연동** — Google Ads, Meta Marketing, Naver Ads API와 OAuth2 토큰 기반 연결
+- **광고 플랫폼 연동** — Google Ads, Meta Marketing API와 OAuth2 토큰 기반 연결, Naver Ads API와 Key/Secret 기반 API 연결
 - **캠페인 / 광고 관리** — 다중 플랫폼 데이터를 통합 모델로 정규화하여 제공
 - **광고 성과 대시보드** — 플랫폼별·기간별 지표 집계 및 커서 기반 페이지네이션
 - **클릭 이벤트 수집** — Kafka를 통한 비동기 클릭 이벤트 처리

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ WhereYouAd는 **광고 성과 및 워크스페이스 관리를 효율적으로 �
 
 ### Cloud & Infra
 - **Storage**: AWS S3 (Spring Cloud AWS)
-- **Notification**: Gmail SMTP, CoolSMS
+- **Verification**: Gmail SMTP, CoolSMS (계정 찾기 · 비밀번호 재설정 인증 코드 발송)
 - **Container**: Docker, Docker Compose
 
 ### Docs
@@ -126,21 +126,24 @@ src/main/java/com/whereyouad/WhereYouAd/
 │       ├── presentation/ # Controller + Swagger 문서 인터페이스
 │       └── exception/    # 도메인 예외 + ErrorCode
 ├── global/               # 전역 공통 설정 및 유틸
+│   ├── common/           # 공용 베이스 클래스 (BaseEntity 등)
 │   ├── security/         # JWT, OAuth2 필터/핸들러
-│   ├── config/           # Feign, Redis, Kafka 설정
+│   ├── config/           # Swagger, Redis, OpenAI, WebClient 설정
 │   ├── response/         # 응답 래퍼 (BaseResponse, DataResponse)
 │   ├── exception/        # 전역 예외 핸들러
-│   └── util/             # AESUtil, RedisUtil, CursorUtil 등
+│   ├── adapi/            # 광고 플랫폼 API 인증 (Factory + Strategy 패턴)
+│   ├── sse/              # SSE Emitter (실시간 이벤트 전송)
+│   └── utils/            # AESUtil, RedisUtil, CursorUtil 등
 └── infrastructure/       # 외부 시스템 연동
-    ├── meta/             # Meta Marketing API Feign 클라이언트
+    ├── meta/             # Meta Marketing API 클라이언트
     ├── naver/            # Naver Ads API 클라이언트
+    ├── google/           # Google Ads API 클라이언트
     ├── openai/           # OpenAI Feign 클라이언트
     ├── s3/               # AWS S3 이미지 업로드
-    ├── kafka/            # Kafka Producer / Consumer
-    └── notification/     # Gmail SMTP, CoolSMS
+    └── kafka/            # Kafka Producer / Consumer
 ```
 
-**핵심 도메인**: `user` · `advertisement` · `project` · `organization` · `platform` · `dashboard` · `image` · `click` · `ai`
+**핵심 도메인**: `user` · `advertisement` · `organization` · `platform` · `dashboard` · `click` · `ai`
 
 &nbsp;
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,200 @@
-# WhereYouAd-Backend
+# WhereYouAd Backend
+**2026 Capstone · Graduation Project**
+
+WhereYouAd는 **광고 성과 및 워크스페이스 관리를 효율적으로 지원하는 웹 서비스**입니다.
+</br>본 레포지토리는 2026 캡스톤(졸업 프로젝트)을 위해 개발 중인 백엔드 애플리케이션으로,
+</br>다중 광고 플랫폼 통합과 안정적인 API 설계, 확장 가능한 도메인 아키텍처를 목표로 합니다.
+
+&nbsp;
+
+## 프로젝트 개요
+
+- **프로젝트명**: WhereYouAd
+- **목적**: 광고 및 워크스페이스 관리 서비스의 백엔드 구현
+- **성격**: 2026 캡스톤 디자인 · 졸업 프로젝트
+
+### 주요 기능
+
+- **소셜 로그인 & JWT 인증** — Naver / Google / Kakao OAuth2 로그인 및 JWT 세션 관리
+- **광고 플랫폼 연동** — Google Ads, Meta Marketing, Naver Ads API와 OAuth2 토큰 기반 연결
+- **캠페인 / 광고 관리** — 다중 플랫폼 데이터를 통합 모델로 정규화하여 제공
+- **광고 성과 대시보드** — 플랫폼별·기간별 지표 집계 및 커서 기반 페이지네이션
+- **클릭 이벤트 수집** — Kafka를 통한 비동기 클릭 이벤트 처리
+- **AI 인사이트** — OpenAI 연동을 통한 광고 성과 분석 및 제안
+- **워크스페이스 / 프로젝트 관리** — 다중 사용자·팀 단위로 광고 자산을 분리 관리
+- **이미지 업로드** — AWS S3를 통한 광고 소재 저장
+
+
+### 기술 방향성
+- 도메인 계층형 아키텍처로 관심사 분리 및 유지보수성 확보
+- 외부 API(광고 플랫폼, AI)의 변경에 유연하게 대응할 수 있는 추상화 설계
+- 팀 협업을 고려한 컨벤션 및 일관된 응답/예외 처리 구조
+
+&nbsp;
+
+## 팀 구성 (Backend)
+
+| <div align="center">[김지민](https://github.com/jinnieusLab)</div> | <div align="center">[김민규](https://github.com/kingmingyu)</div> | <div align="center">[오준영](https://github.com/ojy0903)</div>                                       |
+| --- | --- |---------------------------------------------------------------------------------------------------|
+| <div align="center"><img src="https://avatars.githubusercontent.com/jinnieusLab" width="160" /></div> | <div align="center"><img src="https://avatars.githubusercontent.com/kingmingyu" width="160" /></div> | <div align="center"><img src="https://avatars.githubusercontent.com/ojy0903" width="160" /></div> |
+| <div align="center">백엔드</div> | <div align="center">백엔드</div> | <div align="center">백엔드</div>                                                                     |
+
+&nbsp;
+
+## 기술 스택
+
+### Core
+- **Language**: Java 17
+- **Framework**: Spring Boot 3.5.9, Spring Cloud 2024.0.1
+- **Build**: Gradle
+
+### Security
+- **Auth**: Spring Security, OAuth2 Client
+- **Token**: JWT (jjwt 0.11.5)
+- **Encryption**: AES 
+
+### DB / Cache
+- **RDBMS**: MySQL 8.0
+- **ORM**: Spring Data JPA (Hibernate)
+- **Cache**: Redis
+
+### Messaging
+- **Event Streaming**: Apache Kafka 3.7.0
+
+### External API
+- **Ad Platforms**: Google Ads SDK, Meta Marketing API, Naver Ads API
+- **AI**: OpenAI API
+- **HTTP Client**: OpenFeign, WebClient
+
+### Cloud & Infra
+- **Storage**: AWS S3 (Spring Cloud AWS)
+- **Notification**: Gmail SMTP, CoolSMS
+- **Container**: Docker, Docker Compose
+
+### Docs
+- **API 문서**: Springdoc OpenAPI (Swagger UI)
+
+&nbsp;
+
+## 개발 환경
+
+- **JDK**: 17 (LTS 권장)
+- **빌드 도구**: Gradle
+- **인프라**: Docker / Docker Compose (MySQL 8.0 · Redis · Kafka 로컬 구동)
+
+팀 내 개발 환경 차이를 최소화하기 위해 **JDK 17 기준**으로 개발합니다.
+로컬 실행 전에 `.env.example`을 복사하여 `.env` 파일을 생성하고 값을 채워야 합니다.
+
+```bash
+cp .env.example .env
+```
+
+필요한 환경 변수 그룹:
+- DB / Redis / Kafka 접속 정보
+- OAuth2 클라이언트 자격증명 (Naver / Google / Kakao)
+- 광고 플랫폼 자격증명 (Meta, Google Ads)
+- JWT / AES 시크릿
+- AWS S3, OpenAI, CoolSMS, Gmail 자격증명
+
+&nbsp;
+
+## 주요 스크립트
+
+| Script | 설명 |
+| --- | --- |
+| `./gradlew build` | 테스트 포함 전체 빌드 |
+| `./gradlew clean build -x test` | 테스트 제외 빌드 |
+| `./gradlew test` | 테스트만 실행 (MySQL + Redis 필요) |
+| `./gradlew bootRun` | 로컬 서버 실행 (`.env` 필요) |
+| `docker-compose up -d` | 전체 스택 실행 (App + MySQL + Redis + Kafka) |
+
+앱이 뜨면 `http://localhost:8080/swagger-ui/index.html` 에서 API 문서를 확인할 수 있습니다.
+
+&nbsp;
+
+## 프로젝트 구조
+
+현재 프로젝트는 **도메인 단위** 및 **계층형 패턴**을 중심으로 구성되어 있습니다.
+
+```bash
+src/main/java/com/whereyouad/WhereYouAd/
+├── domains/              # 핵심 비즈니스 도메인
+│   └── {domain}/
+│       ├── application/  # Service 계층 (DTO, Mapper 포함)
+│       ├── domain/       # 비즈니스 로직 (Service, Constant)
+│       ├── persistence/  # JPA Entity, Repository
+│       ├── presentation/ # Controller + Swagger 문서 인터페이스
+│       └── exception/    # 도메인 예외 + ErrorCode
+├── global/               # 전역 공통 설정 및 유틸
+│   ├── security/         # JWT, OAuth2 필터/핸들러
+│   ├── config/           # Feign, Redis, Kafka 설정
+│   ├── response/         # 응답 래퍼 (BaseResponse, DataResponse)
+│   ├── exception/        # 전역 예외 핸들러
+│   └── util/             # AESUtil, RedisUtil, CursorUtil 등
+└── infrastructure/       # 외부 시스템 연동
+    ├── meta/             # Meta Marketing API Feign 클라이언트
+    ├── naver/            # Naver Ads API 클라이언트
+    ├── openai/           # OpenAI Feign 클라이언트
+    ├── s3/               # AWS S3 이미지 업로드
+    ├── kafka/            # Kafka Producer / Consumer
+    └── notification/     # Gmail SMTP, CoolSMS
+```
+
+**핵심 도메인**: `user` · `advertisement` · `project` · `organization` · `platform` · `dashboard` · `image` · `click` · `ai`
+
+&nbsp;
+
+## CI / CD
+
+- **CI** — `.github/workflows/ci.yml`: `main`, `develop` 브랜치에 push / PR 시 MySQL · Redis 서비스 컨테이너를 띄우고 `./gradlew build` 실행
+- **CD** — `.github/workflows/cd.yml`: `develop` 브랜치 push 시 Docker 이미지 빌드 → Docker Hub 푸시 → Bastion host 경유 EC2 SSH 배포
+
+&nbsp;
+
+## 협업 컨벤션
+
+### 1. Branch Strategy
+- **develop**: 배포 가능한 상태의 브랜치 (Production)
+- **feature/#[이슈번호]**: 새로운 기능 개발 브랜치 (예: `feature/#1`)
+
+&nbsp;
+
+### 2. Commit Convention
+Angular Commit Convention을 따릅니다.
+
+`type: subject`
+
+| Type | 설명 |
+| --- | --- |
+| `feat` | 새로운 기능 추가 |
+| `fix` | 버그 수정 |
+| `docs` | 문서 수정 (README 등) |
+| `style` | 코드 포맷팅, 세미콜론 누락, 공백 등 (코드 변경 없음) |
+| `refactor` | 코드 리팩토링 (기능 변화 없음) |
+| `test` | 테스트 코드 추가/수정 |
+| `chore` | 빌드, 설정, 패키지 매니저 등 기타 변경사항 |
+| `ci` | CI 관련 설정 변경 |
+| `setting` | 프로젝트 환경 설정 변경 |
+
+&nbsp;
+
+### 3. Code Style
+
+팀 전체의 코드 스타일 일관성을 위해 다음 규칙을 적용합니다.
+
+- **패키지 구조**: 도메인 단위 계층형 패키지 (`application` / `domain` / `persistence` / `presentation` / `exception`)
+- **응답 형식**: 모든 API 응답은 `BaseResponse` 계열 래퍼(`DataResponse<T>`, `ErrorResponse`)로 통일
+- **에러 처리**: 도메인별 `BaseErrorCode` 구현체로 에러 코드 정의 → 도메인 예외 throw → 전역 핸들러 매핑
+- **API 문서**: Controller 코드와 Swagger 어노테이션을 `presentation/docs/` 인터페이스로 분리
+
+&nbsp;
+
+### 4. PR Process
+PR 템플릿에 따라 작성하며, **리뷰어 가이드**를 준수합니다.
+
+- **Title**: `[Type/#이슈번호] 작업 요약` (예: `[Feat/#1] 소셜 로그인 API 구현`)
+- **Review Labels**:
+  - `P1`: **필수 반영 (Critical)** - 버그/컨벤션 위반 (머지 불가)
+  - `P2`: **적극 권장 (Recommended)** - 더 나은 대안 (반영 권장)
+  - `P3`: **제안 (Suggestion)** - 아이디어 공유 (자율)
+  - `P4`: **단순 확인 (Nit)** - 오타/칭찬 등

--- a/README.md
+++ b/README.md
@@ -162,19 +162,19 @@ src/main/java/com/whereyouad/WhereYouAd/
 ### 2. Commit Convention
 Angular Commit Convention을 따릅니다.
 
-`type: subject`
+`:gitmoji: type: subject`
 
-| Type | 설명 |
-| --- | --- |
-| `feat` | 새로운 기능 추가 |
-| `fix` | 버그 수정 |
-| `docs` | 문서 수정 (README 등) |
-| `style` | 코드 포맷팅, 세미콜론 누락, 공백 등 (코드 변경 없음) |
-| `refactor` | 코드 리팩토링 (기능 변화 없음) |
-| `test` | 테스트 코드 추가/수정 |
-| `chore` | 빌드, 설정, 패키지 매니저 등 기타 변경사항 |
-| `ci` | CI 관련 설정 변경 |
-| `setting` | 프로젝트 환경 설정 변경 |
+| Gitmoji                | Type       | 설명                                         |
+|------------------------|------------|--------------------------------------------|
+| ✨ `:sparkles:`         | `feat`     | 새로운 기능 추가                                  |
+| 🐛 `:bug:`             | `fix`      | 버그 수정                                      |
+| 📝 `:memo:`            | `docs`     | 문서 수정 (README, Swagger Docs 등)             |
+| 🎨 `:art:`             | `style`    | 코드 포맷팅, 세미콜론 누락, 공백 등 (코드 변경 없음)           |
+| ♻️ `:recycle:`         | `refactor` | 코드 리팩토링 (기능 변화 없음)                         |
+| ✅ `:white_check_mark:` | `test`     | 테스트 코드 추가/수정                               |
+| 🔧 `:wrench:`          | `chore`    | 빌드, 설정, 패키지 매니저 등 기타 변경사항                  |
+| 💚 `:green_heart:`     | `ci`       | CI 관련 설정 변경                                |
+| 🚀 `:rocket:`     | `deploy`   | 배포 관련 수정(Dockerfile, docker-compose.yml 등) |
 
 &nbsp;
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/application/dto/request/PlatformRequest.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/application/dto/request/PlatformRequest.java
@@ -7,4 +7,11 @@ public class PlatformRequest {
             String apiKey,       // API 키 (AES 암호화됨) → PlatformConnection.authIdentifier
             String secretKey     // Secret (AES 암호화됨) → PlatformConnection.authCredential
     ) {}
+
+    // 네이버 광고 API 수정에 사용
+    public record UpdateNaverApiRequest(
+            String customerId, // 만약 customerId 가 같다면 그대로 유지, 다르면 계정 정보 자체를 교체
+            String apiKey,
+            String secretKey
+    ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/application/dto/request/PlatformRequest.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/application/dto/request/PlatformRequest.java
@@ -1,17 +1,19 @@
 package com.whereyouad.WhereYouAd.domains.platform.application.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public class PlatformRequest {
 
     public record PlatformAccount(
-            String customerId,   // 네이버 고객 ID (X-Customer) → PlatformAccount.externalAccountId
-            String apiKey,       // API 키 (AES 암호화됨) → PlatformConnection.authIdentifier
-            String secretKey     // Secret (AES 암호화됨) → PlatformConnection.authCredential
+            @NotBlank String customerId,   // 네이버 고객 ID (X-Customer) → PlatformAccount.externalAccountId
+            @NotBlank String apiKey,       // API 키 (AES 암호화됨) → PlatformConnection.authIdentifier
+            @NotBlank String secretKey     // Secret (AES 암호화됨) → PlatformConnection.authCredential
     ) {}
 
     // 네이버 광고 API 수정에 사용
     public record UpdateNaverApiRequest(
-            String customerId, // 만약 customerId 가 같다면 그대로 유지, 다르면 계정 정보 자체를 교체
-            String apiKey,
-            String secretKey
+            @NotBlank String customerId, // 만약 customerId 가 같다면 그대로 유지, 다르면 계정 정보 자체를 교체
+            @NotBlank String apiKey,
+            @NotBlank String secretKey
     ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/application/dto/request/PlatformRequest.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/application/dto/request/PlatformRequest.java
@@ -9,11 +9,4 @@ public class PlatformRequest {
             @NotBlank String apiKey,       // API 키 (AES 암호화됨) → PlatformConnection.authIdentifier
             @NotBlank String secretKey     // Secret (AES 암호화됨) → PlatformConnection.authCredential
     ) {}
-
-    // 네이버 광고 API 수정에 사용
-    public record UpdateNaverApiRequest(
-            @NotBlank String customerId, // 만약 customerId 가 같다면 그대로 유지, 다르면 계정 정보 자체를 교체
-            @NotBlank String apiKey,
-            @NotBlank String secretKey
-    ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/application/dto/response/PlatformResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/application/dto/response/PlatformResponse.java
@@ -1,7 +1,11 @@
 package com.whereyouad.WhereYouAd.domains.platform.application.dto.response;
 
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
+import com.whereyouad.WhereYouAd.domains.platform.domain.constant.AuthType;
 import com.whereyouad.WhereYouAd.domains.platform.domain.constant.PlatformStatus;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public class PlatformResponse {
 
@@ -10,5 +14,19 @@ public class PlatformResponse {
             String externalAccountId,
             Provider provider,
             PlatformStatus status
+    ) {}
+
+    public record PlatformKeyResponse(
+            Long platformAccountId,
+            String externalAccountId,
+            Provider provider,
+            AuthType authType,
+            PlatformStatus status,
+            LocalDate tokenExpireAt,
+            LocalDate syncedAt
+    ) {}
+
+    public record PlatformAccountListResponse(
+            List<PlatformKeyResponse> platformAccounts
     ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/application/mapper/PlatformConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/application/mapper/PlatformConverter.java
@@ -12,6 +12,10 @@ import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformAcc
 import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformConnection;
 import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
 public class PlatformConverter {
 
     // dto -> entity
@@ -55,5 +59,29 @@ public class PlatformConverter {
                 platformAccount.getProvider(),
                 platformAccount.getStatus()
         );
+    }
+
+    public static PlatformResponse.PlatformKeyResponse toPlatformKeyResponse(PlatformConnection connection) {
+        return new PlatformResponse.PlatformKeyResponse(
+                connection.getPlatformAccount().getId(),
+                connection.getPlatformAccount().getExternalAccountId(),
+                connection.getPlatformAccount().getProvider(),
+                connection.getAuthType(),
+                connection.getPlatformAccount().getStatus(),
+                connection.getTokenExpireAt() != null ? LocalDate.from(connection.getTokenExpireAt()) : null,
+                connection.getUpdatedAt() != null ? LocalDate.from(connection.getUpdatedAt()) : null
+                // TODO : 마지막 연동일자? 를 나타내는 것에 대해 논의 필요
+                // -> PlatformConnection 에 lastSyncedAt 로 필드를 추가하는게 나을지? 지금처럼 updatedAt 를 가져다 쓰는게 나을지?
+        );
+    }
+
+    public static PlatformResponse.PlatformAccountListResponse toPlatformAccountListResponse(List<PlatformConnection> connections) {
+        List<PlatformResponse.PlatformKeyResponse> responseList = new ArrayList<>();
+        for (PlatformConnection connection : connections) {
+            PlatformResponse.PlatformKeyResponse response = toPlatformKeyResponse(connection);
+            responseList.add(response);
+        }
+
+        return new PlatformResponse.PlatformAccountListResponse(responseList);
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/application/mapper/PlatformConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/application/mapper/PlatformConverter.java
@@ -69,9 +69,8 @@ public class PlatformConverter {
                 connection.getAuthType(),
                 connection.getPlatformAccount().getStatus(),
                 connection.getTokenExpireAt() != null ? LocalDate.from(connection.getTokenExpireAt()) : null,
-                connection.getUpdatedAt() != null ? LocalDate.from(connection.getUpdatedAt()) : null
-                // TODO : 마지막 연동일자? 를 나타내는 것에 대해 논의 필요
-                // -> PlatformConnection 에 lastSyncedAt 로 필드를 추가하는게 나을지? 지금처럼 updatedAt 를 가져다 쓰는게 나을지?
+                connection.getCreatedAt() != null ? LocalDate.from(connection.getCreatedAt()) : null
+                // 연동 시각은 PlatformConnection 에 createdAt 로
         );
     }
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/domain/service/PlatformService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/domain/service/PlatformService.java
@@ -8,5 +8,5 @@ public interface PlatformService {
 
     PlatformResponse.PlatformAccountListResponse getPlatformSyncInfos(Long userId, Long orgId);
 
-    PlatformResponse.PlatformAccount updateNaverAdAccount(Long userId, Long orgId, PlatformRequest.UpdateNaverApiRequest request);
+    PlatformResponse.PlatformAccount updateNaverAdAccount(Long userId, Long orgId, PlatformRequest.PlatformAccount request);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/domain/service/PlatformService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/domain/service/PlatformService.java
@@ -5,4 +5,8 @@ import com.whereyouad.WhereYouAd.domains.platform.application.dto.response.Platf
 
 public interface PlatformService {
     PlatformResponse.PlatformAccount addNaverAdAccount(Long userId, Long orgId, PlatformRequest.PlatformAccount dto);
+
+    PlatformResponse.PlatformAccountListResponse getPlatformSyncInfos(Long userId, Long orgId);
+
+    PlatformResponse.PlatformAccount updateNaverAdAccount(Long userId, Long orgId, PlatformRequest.UpdateNaverApiRequest request);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/domain/service/PlatformServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/domain/service/PlatformServiceImpl.java
@@ -14,6 +14,8 @@ import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformAcc
 import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformConnection;
 import com.whereyouad.WhereYouAd.domains.platform.persistence.repository.PlatformAccountRepository;
 import com.whereyouad.WhereYouAd.domains.platform.persistence.repository.PlatformConnectionRepository;
+import com.whereyouad.WhereYouAd.domains.user.exception.code.UserErrorCode;
+import com.whereyouad.WhereYouAd.domains.user.exception.handler.UserHandler;
 import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
 import com.whereyouad.WhereYouAd.domains.user.persistence.repository.UserRepository;
 import com.whereyouad.WhereYouAd.global.adapi.dto.AdAuthRequest;
@@ -27,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -78,6 +81,65 @@ public class PlatformServiceImpl implements PlatformService {
         platformConnectionRepository.save(
                 PlatformConverter.toPlatformConnection(dto, user, platformAccount)
         );
+
+        return PlatformConverter.toPlatformAccountResponse(platformAccount);
+    }
+
+    // 사용자의 특정 조직에 대한 광고 플랫폼 연동 정보 조회
+    // ADMIN 만 요청 가능 & 실제 연동한 광고 플랫폼 계정 주인만 조회 가능(ADMIN 인데 계정 주인 아닌 경우 빈 리스트 반환)
+    @Override
+    public PlatformResponse.PlatformAccountListResponse getPlatformSyncInfos(Long userId, Long orgId) {
+        // 회원 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(UserErrorCode.USER_NOT_FOUND));
+
+        // 조직 회원 검증
+        OrgMember orgMember = orgMemberRepository.findByUserIdAndOrgId(userId, orgId)
+                .orElseThrow(() -> new PlatformHandler(PlatformErrorCode.PLATFORM_ORG_MEMBER_NOT_FOUND));
+
+        // ADMIN 아닐 시 요청 불가
+        if (orgMember.getRole() != OrgRole.ADMIN) {
+            throw new PlatformHandler(PlatformErrorCode.PLATFORM_FORBIDDEN);
+        }
+
+        // userId, orgId 기반 PlatformConnection 모두 조회
+        List<PlatformConnection> connections = platformConnectionRepository.findByUserIdAndOrgId(userId, orgId);
+
+        // DTO 로 변환 및 반환
+        return PlatformConverter.toPlatformAccountListResponse(connections);
+    }
+
+    @Override
+    public PlatformResponse.PlatformAccount updateNaverAdAccount(Long userId, Long orgId, PlatformRequest.UpdateNaverApiRequest request) {
+        // 유저 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(UserErrorCode.USER_NOT_FOUND));
+
+        // 조직 멤버 여부 검증
+        OrgMember orgMember = orgMemberRepository.findByUserIdAndOrgId(userId, orgId)
+                .orElseThrow(() -> new PlatformHandler(PlatformErrorCode.PLATFORM_ORG_MEMBER_NOT_FOUND));
+
+        // ADMIN 권한 검증
+        if (orgMember.getRole() != OrgRole.ADMIN) {
+            throw new PlatformHandler(PlatformErrorCode.PLATFORM_FORBIDDEN);
+        }
+
+        // 기존 PlatformAccount 조회
+        Organization organization = orgMember.getOrganization();
+        PlatformAccount platformAccount = platformAccountRepository
+                .findByExternalAccountIdAndProviderAndOrganization(request.customerId(), Provider.NAVER, organization)
+                .orElseThrow(() -> new PlatformHandler(PlatformErrorCode.PLATFORM_ACCOUNT_NOT_FOUND));
+
+        // 새 자격증명으로 네이버 광고 API 검증
+        validateNaverCredentials(request.customerId(), request.apiKey(), request.secretKey());
+
+        // 기존 PlatformConnection 조회
+        PlatformConnection connection = platformConnectionRepository
+                .findByUserIdAndPlatformAccountId(userId, platformAccount.getId())
+                .orElseThrow(() -> new PlatformHandler(PlatformErrorCode.PLATFORM_CONNECTION_NOT_FOUND));
+
+        // 키값 및 secret 값 갱신 (apiKey / secretKey)
+        connection.renewApiKey(request.apiKey(), request.secretKey());
 
         return PlatformConverter.toPlatformAccountResponse(platformAccount);
     }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/domain/service/PlatformServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/domain/service/PlatformServiceImpl.java
@@ -110,7 +110,7 @@ public class PlatformServiceImpl implements PlatformService {
     }
 
     @Override
-    public PlatformResponse.PlatformAccount updateNaverAdAccount(Long userId, Long orgId, PlatformRequest.UpdateNaverApiRequest request) {
+    public PlatformResponse.PlatformAccount updateNaverAdAccount(Long userId, Long orgId, PlatformRequest.PlatformAccount request) {
         // 유저 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(UserErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/exception/code/PlatformErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/exception/code/PlatformErrorCode.java
@@ -18,6 +18,7 @@ public enum PlatformErrorCode implements BaseErrorCode {
     // 404
     PLATFORM_CONNECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "PLATFORM_404_1", "조직과 연결된 인증 정보를 찾을 수 없습니다."),
     PLATFORM_ORG_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "PLATFORM_404_2", "해당 조직의 멤버가 아닙니다."),
+    PLATFORM_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "PLATFORM_404_3", "해당 광고 계정을 찾을 수 없습니다."),
 
     // 409
     PLATFORM_ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, "PLATFORM_409_1", "이미 등록된 광고 계정입니다."),

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/persistence/entity/PlatformConnection.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/persistence/entity/PlatformConnection.java
@@ -59,4 +59,10 @@ public class PlatformConnection extends BaseEntity {
         this.authCredential = authCredential;
         this.tokenExpireAt = tokenExpireAt;
     }
+
+    public void renewApiKey(String authIdentifier, String authCredential) {
+        this.authIdentifier = authIdentifier;
+        this.authCredential = authCredential;
+        this.revokedAt = null;
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/persistence/entity/PlatformConnection.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/persistence/entity/PlatformConnection.java
@@ -61,8 +61,10 @@ public class PlatformConnection extends BaseEntity {
     }
 
     public void renewApiKey(String authIdentifier, String authCredential) {
+        this.authType = AuthType.API_KEY;
         this.authIdentifier = authIdentifier;
         this.authCredential = authCredential;
+        this.tokenExpireAt = null;
         this.revokedAt = null;
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/persistence/repository/PlatformConnectionRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/persistence/repository/PlatformConnectionRepository.java
@@ -35,4 +35,7 @@ public interface PlatformConnectionRepository extends JpaRepository<PlatformConn
 
     @Query("SELECT c FROM PlatformConnection c WHERE c.user.id = :userId " + "AND c.platformAccount.id = :platformAccountId")
     Optional<PlatformConnection> findByUserIdAndPlatformAccountId(@Param("userId") Long userId, @Param("platformAccountId") Long platformAccountId);
+
+    @Query("SELECT c FROM PlatformConnection c  WHERE c.user.id = :userId AND c.platformAccount.organization.id = :orgId")
+    List<PlatformConnection> findByUserIdAndOrgId(@Param("userId") Long userId, @Param("orgId") Long orgId);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/persistence/repository/PlatformConnectionRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/persistence/repository/PlatformConnectionRepository.java
@@ -36,6 +36,8 @@ public interface PlatformConnectionRepository extends JpaRepository<PlatformConn
     @Query("SELECT c FROM PlatformConnection c WHERE c.user.id = :userId " + "AND c.platformAccount.id = :platformAccountId")
     Optional<PlatformConnection> findByUserIdAndPlatformAccountId(@Param("userId") Long userId, @Param("platformAccountId") Long platformAccountId);
 
-    @Query("SELECT c FROM PlatformConnection c  WHERE c.user.id = :userId AND c.platformAccount.organization.id = :orgId")
+    @Query("SELECT c FROM PlatformConnection c " +
+            "JOIN FETCH c.platformAccount pa " +
+            "WHERE c.user.id = :userId AND pa.organization.id = :orgId")
     List<PlatformConnection> findByUserIdAndOrgId(@Param("userId") Long userId, @Param("orgId") Long orgId);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/presentation/PlatformController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/presentation/PlatformController.java
@@ -10,11 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,6 +19,7 @@ public class PlatformController implements PlatformControllerDocs {
 
     private final PlatformService platformService;
 
+    //네이버 광고 API 최초 등록 시 사용 (기존 코드 유지)
     @PostMapping("/{orgId}/accounts/naver")
     public ResponseEntity<DataResponse<PlatformResponse.PlatformAccount>> addNaverAdAccount(
             @AuthenticationPrincipal(expression = "userId") Long userId,
@@ -34,4 +31,33 @@ public class PlatformController implements PlatformControllerDocs {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(DataResponse.created(response));
     }
+
+    @GetMapping("/{orgId}/accounts")
+    public ResponseEntity<DataResponse<PlatformResponse.PlatformAccountListResponse>> getPlatformSyncInfos(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId
+    )
+    {
+        PlatformResponse.PlatformAccountListResponse response = platformService.getPlatformSyncInfos(userId, orgId);
+
+        return ResponseEntity.ok(
+                DataResponse.from(response)
+        );
+    }
+
+    // 네이버 광고 API 수정 시 사용
+    // 네이버 제외 구글, 메타의 경우 기존 OAuth 로그인 API 를 재호출 하도록 하여 수정 진행
+    @PatchMapping("/{orgId}/accounts/naver")
+    public ResponseEntity<DataResponse<PlatformResponse.PlatformAccount>> updateNaverAdAccount(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId,
+            @Valid @RequestBody PlatformRequest.UpdateNaverApiRequest request
+    )
+    {
+        PlatformResponse.PlatformAccount response = platformService.updateNaverAdAccount(userId, orgId, request);
+        return ResponseEntity.ok(
+                DataResponse.from(response)
+        );
+    }
+
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/presentation/PlatformController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/presentation/PlatformController.java
@@ -51,7 +51,7 @@ public class PlatformController implements PlatformControllerDocs {
     public ResponseEntity<DataResponse<PlatformResponse.PlatformAccount>> updateNaverAdAccount(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
-            @Valid @RequestBody PlatformRequest.UpdateNaverApiRequest request
+            @Valid @RequestBody PlatformRequest.PlatformAccount request
     )
     {
         PlatformResponse.PlatformAccount response = platformService.updateNaverAdAccount(userId, orgId, request);

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/presentation/docs/PlatformControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/presentation/docs/PlatformControllerDocs.java
@@ -30,4 +30,40 @@ public interface PlatformControllerDocs {
             @PathVariable Long orgId,
             @RequestBody PlatformRequest.PlatformAccount dto
     );
+
+    @Operation(
+            summary = "조직별 광고 플랫폼 연동 정보 조회 API",
+            description = "로그인한 사용자가 특정 조직에 직접 연동한 광고 플랫폼(Naver/Meta/Google) 계정 목록을 조회합니다. \n\n"
+                    +"ADMIN 권한을 가진 조직 멤버만 호출 가능하며, ADMIN이라도 본인이 연동한 계정만 조회됩니다 (본인 연동 계정이 없으면 빈 리스트 반환)."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403_1", description = "ADMIN 권한 없음"),
+            @ApiResponse(responseCode = "404_2", description = "해당 조직의 멤버가 아님")
+    })
+    ResponseEntity<DataResponse<PlatformResponse.PlatformAccountListResponse>> getPlatformSyncInfos(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId
+    );
+
+    @Operation(
+            summary = "네이버 광고 계정 자격증명 수정 API",
+            description = "기존에 연동된 네이버 광고 계정의 API 키(AES 암호화) 및 Secret 키(AES 암호화)를 갱신합니다. " +
+                    "요청 본문의 customerId(외부 고객 ID)로 기존 계정을 조회하며, 조회되지 않으면 404를 반환합니다. \n\n" +
+                    "새 자격증명은 실제 네이버 광고 API 호출로 검증한 뒤 관련 키 값과 secret 값만 갱신합니다. " +
+                    "ADMIN 권한을 가진 조직 멤버만 호출할 수 있습니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400_1", description = "네이버 광고 API 인증 실패"),
+            @ApiResponse(responseCode = "403_1", description = "ADMIN 권한 없음"),
+            @ApiResponse(responseCode = "404_1", description = "해당 계정에 대한 연동 정보를 찾을 수 없음"),
+            @ApiResponse(responseCode = "404_2", description = "해당 조직의 회원이 아님"),
+            @ApiResponse(responseCode = "404_3", description = "해당 customerId로 등록된 광고 계정을 찾을 수 없음")
+    })
+    ResponseEntity<DataResponse<PlatformResponse.PlatformAccount>> updateNaverAdAccount(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId,
+            @RequestBody PlatformRequest.UpdateNaverApiRequest request
+    );
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/presentation/docs/PlatformControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/presentation/docs/PlatformControllerDocs.java
@@ -64,6 +64,6 @@ public interface PlatformControllerDocs {
     ResponseEntity<DataResponse<PlatformResponse.PlatformAccount>> updateNaverAdAccount(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
-            @RequestBody PlatformRequest.UpdateNaverApiRequest request
+            @RequestBody PlatformRequest.PlatformAccount request
     );
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #119 

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

사용자가 특정 조직에 연동한 광고 플랫폼 조회 API, 네이버 플랫폼의 authIdentifier, authCredential 수정 API 추가

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- 사용자가 특정 조직에 연동한 광고 플랫폼 조회 API 추가
- 네이버 플랫폼 authIdentifier, authCredential 수정 API 추가
- 번외 : 백엔드 README.md 내용 추가

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.

=== 특정 조직에 연동한 광고 플랫폼 조회 API 테스팅 ===
org_id = 1 인 조직에서 user_id =1 인 회원이 연동한 플랫폼 조회 API 결과(Meta, Naver 연동 상태)
<img width="2094" height="1263" alt="image" src="https://github.com/user-attachments/assets/d01df490-7faf-4ed7-a7cc-002af965d22e" />

===네이버 플랫폼 authIdentifier, authCredential 수정 API 테스팅 ===
기존 PlatformConnection 값 (두번째가 Naver)
<img width="1627" height="300" alt="image" src="https://github.com/user-attachments/assets/aa78d367-e461-4051-b74b-f5cd7b0b5346" />

네이버 광고 API 에서 값 재발급
<img width="2559" height="1394" alt="image" src="https://github.com/user-attachments/assets/645fd4e3-dfc4-44a5-bea8-08926586fe35" />

이후, AES 암호화한 액세스 라이선스, 비밀키 값으로 수정 API 호출
<img width="2107" height="1027" alt="image" src="https://github.com/user-attachments/assets/9d2cf298-7940-4d8d-8727-311ae51259c5" />

바뀐 PlatformConnection 값
<img width="1635" height="318" alt="image" src="https://github.com/user-attachments/assets/76c98e6a-1909-4345-899c-08920e59f498" />


## ✅ 체크리스트
- [✅] 브랜치 전략(GitHub Flow)을 준수했나요?
- [✅] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [✅] 테스트 통과 확인
- [✅] 서버 실행 확인
- [✅] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- 현재 플랫폼들 중 네이버만 직접 API 관련 키값을 입력받는 구조라서 네이버 플랫폼에 대한 값 수정 API 만 추가하고, 만약 사용자가 메타나 구글 플랫폼 연동을 수정하기를 원한다면 프론트측에서 각각의 구글, 메타의 OAuth 로그인 API 를 다시 호출하는걸로 생각하고 구현해봤는데 이 구조가 괜찮을까요?
- 네이버 광고 API 최초 등록의 경우에는 민규님이 이미 만들어놓은 API (POST /api/platform/{orgId}/accounts/naver) 가 잘 구현되어 있는 것 같아 이걸 그대로 활용해도 괜찮을듯 해서 일단 그대로 둬봤습니다...
- 광고 API 연동 현황 조회 (GET /api/platform/{orgId}/accounts ) 에서 syncedAt 로 마지막 플랫폼 연동날짜를 보여주는데, 이 값을 현재는 PlatformConnection 의 updatedAt 값을 받아 쓰고 있는데 이대로가 괜찮을까요? 아니면 따로 필드를 PlatformConnection 에 추가하는게 좋을까요...? (PlatformConverter 내부 TODO 주석 참고)

- 번외로 저희 백엔드 README.md 를 프론트 리드미 참조해서 클로드 돌려봤는데 가볍게 확인해보시고 괜찮으면 이것도 반영하면 좋을 것 같아요...!!
<img width="2559" height="1393" alt="image" src="https://github.com/user-attachments/assets/3895fef0-4fc0-4127-a771-cce3d5ad430b" />
<img width="2559" height="1398" alt="image" src="https://github.com/user-attachments/assets/ff0b0455-e384-4f44-99c3-e56a30829a48" />


> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 플랫폼 광고 계정 동기화 정보 조회 API 추가
  * 기존 네이버 광고 계정의 API 자격증명 갱신(업데이트) API 추가
  * 플랫폼 응답 포맷에 계정 리스트와 키 정보 포함

* **Bug Fixes**
  * 계정 조회/권한 경계 검증 및 관련 오류 코드 추가

* **Documentation**
  * 프로젝트 README 대폭 확장(개요, 개발/배포 가이드, 협업 규칙 등)
  * 새 엔드포인트 Swagger 문서 추가

* **Validation**
  * 플랫폼 요청 필드에 필수 입력 검증 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhereYouAd/WhereYouAd-Backend/pull/124)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->