### PR TITLE
Feat/#132 플랫폼 대시보드 내 MetricFact 조회 구현

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/MetricFactRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/MetricFactRepository.java
@@ -168,6 +168,20 @@ public interface MetricFactRepository extends JpaRepository<MetricFact, Long> {
             @Param("provider") Provider provider
     );
 
+    // FETCH JOIN 없이 MetricFact 정보만 빠르게 가져오는 쿼리 (대시보드 지표 합산용)
+    @Query("SELECT m FROM MetricFact m " +
+           "WHERE m.project.organization.id = :orgId " +
+           "AND m.provider = :provider " +
+           "AND m.timeBucket >= :start " +
+           "AND m.timeBucket <= :end " +
+           "ORDER BY m.timeBucket ASC")
+    List<MetricFact> findMetricFactsByOrgAndProviderAndPeriod(
+            @Param("orgId") Long orgId,
+            @Param("provider") Provider provider,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
+
     // adContent + timeBucket + provider 으로 기존 지표 조회 (Meta UPSERT 중복 방지)
     Optional<MetricFact> findByAdContentAndTimeBucketAndProvider(AdContent adContent, LocalDateTime timeBucket, Provider provider);
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/application/dto/response/DashboardResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/application/dto/response/DashboardResponse.java
@@ -75,4 +75,26 @@ public class DashboardResponse {
             String adName,
             String message
     ) {}
+
+    // 일자별 및 합계 지표를 담을 레코드
+    public record DailyMetricFactResponse(
+            LocalDate date,        // 일자 (합계인 경우 null 또는 특정 값)
+            Long impressions,      // 노출수
+            Long clicks,           // 클릭수
+            Long spend,            // 광고비
+            Long conversions,      // 전환수
+            Long revenue,          // 매출 (ROAS 계산용)
+            Double ctr,            // 클릭률 (%)
+            Double cpa,            // 전환단가
+            Double roas            // 광고수익률 (%)
+    ) {}
+
+    // 플랫폼별 대시보드 메트릭 리스트 래퍼 응답
+    public record PlatformMetricFactSummaryResponse(
+            String providerType,
+            LocalDate startDate,
+            LocalDate endDate,
+            DailyMetricFactResponse total,              // 기간 전체 합계 지표
+            List<DailyMetricFactResponse> dailyMetrics  // 일자별 지표 리스트
+    ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/domain/service/DashboardService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/domain/service/DashboardService.java
@@ -16,4 +16,8 @@ public interface DashboardService {
     // 지정된 날짜(startDate ~ endDate)동안의 진행 중(ON_GOING) 상태인 광고 개수를 찾는 메서드
     DashboardResponse.OngoingPlatformAdCountResponse getOngoingAdCountByProvider(
             Long userId, Long orgId, LocalDate startDate, LocalDate endDate);
+
+    // 플랫폼 대시보드의 일자별 지표(MetricFact) 조회
+    DashboardResponse.PlatformMetricFactSummaryResponse getPlatformMetricFacts(
+            Long userId, Long orgId, String providerType, Integer days);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/domain/service/DashboardServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/domain/service/DashboardServiceImpl.java
@@ -18,6 +18,8 @@ import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.Org
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgRepository;
 import com.whereyouad.WhereYouAd.domains.project.exception.code.ProjectErrorCode;
 import com.whereyouad.WhereYouAd.global.utils.BudgetCalculator;
+import com.whereyouad.WhereYouAd.global.utils.MetricCalculator;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.MetricFact;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,7 +27,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
-import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -43,6 +44,7 @@ public class DashboardServiceImpl implements DashboardService {
     private final OrgMemberRepository orgMemberRepository;
     private final OrgRepository orgRepository;
     private final BudgetCalculator budgetCalculator;
+    private final MetricCalculator metricCalculator;
 
     @Override
     @Transactional(readOnly = true)
@@ -141,18 +143,18 @@ public class DashboardServiceImpl implements DashboardService {
         }
 
         //최근 ~ 한달전 ROAS 값 계산하기 -> revenue / spend * 100
-        BigDecimal currTotalRevenue = toZeroIfNull(currentProjection.getTotalRevenue());
-        BigDecimal currTotalSpend = toZeroIfNull(currentProjection.getTotalSpend());
-        BigDecimal currentRoasBigDecimal = safePercent(currTotalRevenue, currTotalSpend);
+        BigDecimal currTotalRevenue = metricCalculator.toZeroIfNull(currentProjection.getTotalRevenue());
+        BigDecimal currTotalSpend = metricCalculator.toZeroIfNull(currentProjection.getTotalSpend());
+        BigDecimal currentRoasBigDecimal = metricCalculator.safePercent(currTotalRevenue, currTotalSpend);
 
         //한달전 ~ 두달전 ROAS 값 계산 -> revenue / spend * 100
-        BigDecimal pastTotalRevenue = toZeroIfNull(pastProjection.getTotalRevenue());
-        BigDecimal pastTotalSpend = toZeroIfNull(pastProjection.getTotalSpend());
-        BigDecimal pastRoas = safePercent(pastTotalRevenue, pastTotalSpend);
+        BigDecimal pastTotalRevenue = metricCalculator.toZeroIfNull(pastProjection.getTotalRevenue());
+        BigDecimal pastTotalSpend = metricCalculator.toZeroIfNull(pastProjection.getTotalSpend());
+        BigDecimal pastRoas = metricCalculator.safePercent(pastTotalRevenue, pastTotalSpend);
 
         //전환율(CVR) 계산 -> totalConversions(전환수 합계) / totalClicks(클릭수 합계) * 100
-        double rawCurrentCvr = safePercent(currentProjection.getTotalConversions(), currentProjection.getTotalClicks());
-        double rawPastCvr = safePercent(pastProjection.getTotalConversions(), pastProjection.getTotalClicks());
+        double rawCurrentCvr = metricCalculator.safePercent(currentProjection.getTotalConversions(), currentProjection.getTotalClicks());
+        double rawPastCvr = metricCalculator.safePercent(pastProjection.getTotalConversions(), pastProjection.getTotalClicks());
 
         //각각의 지표값 -> 클릭수(totalClicks), 노출수(totalImpressions), 전환율(currentCvr), 광고비 대비 매출(ROAS)
         Long totalClicks = currentProjection.getTotalClicks() != null ? currentProjection.getTotalClicks() : 0L;
@@ -161,10 +163,10 @@ public class DashboardServiceImpl implements DashboardService {
         double currentRoas = currentRoasBigDecimal.doubleValue(); //ROAS 소수점 2번째자리까지만 파싱된 BigDecimal -> double 로 형변환
 
         //각 지표값의 변화율 -> 클릭수 변화율, 노출수 변화율, 전환율 변화율, ROAS 변화율
-        Double clickChangeRate = calculateChangeRate(currentProjection.getTotalClicks(), pastProjection.getTotalClicks());
-        Double impressionChangeRate = calculateChangeRate(currentProjection.getTotalImpressions(), pastProjection.getTotalImpressions());
-        Double cvrChangeRate = calculateChangeRate(rawCurrentCvr, rawPastCvr);
-        Double roasChangeRate = calculateChangeRate(currentRoasBigDecimal, pastRoas);
+        Double clickChangeRate = metricCalculator.calculateChangeRate(currentProjection.getTotalClicks(), pastProjection.getTotalClicks());
+        Double impressionChangeRate = metricCalculator.calculateChangeRate(currentProjection.getTotalImpressions(), pastProjection.getTotalImpressions());
+        Double cvrChangeRate = metricCalculator.calculateChangeRate(rawCurrentCvr, rawPastCvr);
+        Double roasChangeRate = metricCalculator.calculateChangeRate(currentRoasBigDecimal, pastRoas);
 
         return DashboardConverter.toAggregatedSummary(
                 totalClicks,
@@ -232,12 +234,12 @@ public class DashboardServiceImpl implements DashboardService {
         Map<String, Double> prevRoasMap = previous.stream()
                 .collect(Collectors.toMap(
                         RoasProjection::getProvider,
-                        proj -> calculateRoas(proj.getTotalRevenue(), proj.getTotalSpend())));
+                        proj -> metricCalculator.calculateRoas(proj.getTotalRevenue(), proj.getTotalSpend())));
 
         // 8. 현재 기간 결과를 ROAS 기준 내림차순 정렬
         List<RoasProjection> sorted = current.stream()
                 .sorted(Comparator.comparingDouble(
-                        (RoasProjection p) -> calculateRoas(p.getTotalRevenue(), p.getTotalSpend())).reversed())
+                        (RoasProjection p) -> metricCalculator.calculateRoas(p.getTotalRevenue(), p.getTotalSpend())).reversed())
                 .toList();
 
         // 9. DTO 변환 + 순위(rank) + diffRate 계산
@@ -248,9 +250,9 @@ public class DashboardServiceImpl implements DashboardService {
             RoasProjection proj = sorted.get(i);
 
             // 해당 RoasProjection에 대한 값들
-            Double currentRoas = calculateRoas(proj.getTotalRevenue(), proj.getTotalSpend()); // 현재 roas
+            Double currentRoas = metricCalculator.calculateRoas(proj.getTotalRevenue(), proj.getTotalSpend()); // 현재 roas
             Double prevRoas = prevRoasMap.get(proj.getProvider()); // 이전 roas
-            Integer diffRate = computeDiffRate(currentRoas, prevRoas); // 변화율 계산
+            Integer diffRate = metricCalculator.computeDiffRate(currentRoas, prevRoas); // 변화율 계산
             Provider provider = Provider.valueOf(proj.getProvider()); // String -> Enum 변환
 
             rankings.add(DashboardConverter.toRankingROAS(
@@ -301,83 +303,105 @@ public class DashboardServiceImpl implements DashboardService {
 
 
 
-    //------------------- private 내부 계산 메서드 --------------------
+    @Override
+    @Transactional(readOnly = true)
+    public DashboardResponse.PlatformMetricFactSummaryResponse getPlatformMetricFacts(
+            Long userId, Long orgId, String providerType, Integer days) {
 
+        // 1. 조직 접근 권한 검증
+        orgRepository.findById(orgId)
+                .orElseThrow(() -> new DashboardException(OrgErrorCode.ORG_NOT_FOUND));
+        orgMemberRepository.findByUserIdAndOrgId(userId, orgId)
+                .orElseThrow(() -> new DashboardException(DashboardErrorCode.ACCESS_FORBIDDEN));
 
-    // ROAS = (revenue / spend) * 100
-    // spend가 null 또는 0이면 0.0 반환 (Division by Zero 방어)
-    private double calculateRoas(BigDecimal revenue, BigDecimal spend) {
-        // spend가 null이거나 0인 경우 -> 0.0 반환
-        if (spend == null || spend.compareTo(BigDecimal.ZERO) == 0)
-            return 0.0;
+        // 2. 파라미터 및 조회 기간 설정
+        Provider provider;
+        try {
+            provider = Provider.valueOf(providerType.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new DashboardException(DashboardErrorCode.PROVIDER_NOT_VALID);
+        }
 
-        // 매출이 없는 경우 -> 0.0 반환
-        if (revenue == null)
-            return 0.0;
+        int targetDays = (days != null && days > 0) ? days : 7;
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = endDate.minusDays(targetDays - 1); // targetDays가 7이면 당일 포함 7일
 
-        // ROAS 계산 후 반환
-        return revenue.divide(spend, 4, RoundingMode.HALF_UP) // 소수점 4째자리 까지 구하고 반올림
-                .multiply(BigDecimal.valueOf(100)) // * 100
-                .doubleValue(); // double로 형변환
-    }
+        // 3. MetricFact 조회
+        List<MetricFact> metricFacts = metricFactRepository.findMetricFactsByOrgAndProviderAndPeriod(
+                orgId,
+                provider,
+                startDate.atStartOfDay(),
+                endDate.atTime(23, 59, 59)
+        );
 
-    // 변화율 = ((current - prev) / prev) * 100 (반올림 정수)
-    // prevRoas가 null이거나 0이면 비교 불가 -> null 반환
-    private Integer computeDiffRate(double currentRoas, Double prevRoas) {
-        // 이전 데이터가 없거나 0인 경우 null 반환
-        if (prevRoas == null || prevRoas == 0.0)
-            return null;
+        // 4. 일자별 그룹화 및 합산
+        Map<LocalDate, List<MetricFact>> factsByDate = metricFacts.stream()
+                .collect(Collectors.groupingBy(mf -> mf.getTimeBucket().toLocalDate()));
 
-        // 변화율 계산 후 반환
-        double rate = ((currentRoas - prevRoas) / prevRoas) * 100.0;
-        return (int) Math.round(rate);
-    }
+        List<DashboardResponse.DailyMetricFactResponse> dailyMetrics = new ArrayList<>();
 
-    //변화율 계산 메서드
-    private Double calculateChangeRate(Number current, Number past) {
-        // null 방어 및 double 형변환
-        double currentVal = (current != null) ? current.doubleValue() : 0.0;
-        double pastVal = (past != null) ? past.doubleValue() : 0.0;
+        long sumImpressions = 0L;
+        long sumClicks = 0L;
+        long sumConversions = 0L;
+        BigDecimal sumSpend = BigDecimal.ZERO;
+        BigDecimal sumRevenue = BigDecimal.ZERO;
 
-        // Divide by Zero 방어 (과거 데이터가 0인 경우)
-        if (pastVal == 0.0) {
-            if (currentVal > 0.0) {
-                // 과거엔 0이었으나 현재 실적이 발생한 경우 (비즈니스 룰에 따라 100% 등으로 설정)
-                return 100.0;
+        for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+            List<MetricFact> dailyFacts = factsByDate.getOrDefault(date, List.of());
+
+            long dImpressions = 0L;
+            long dClicks = 0L;
+            long dConversions = 0L;
+            BigDecimal dSpend = BigDecimal.ZERO;
+            BigDecimal dRevenue = BigDecimal.ZERO;
+
+            for (MetricFact mf : dailyFacts) {
+                dImpressions += (mf.getImpressions() != null) ? mf.getImpressions() : 0L;
+                dClicks += (mf.getClicks() != null) ? mf.getClicks() : 0L;
+                dConversions += (mf.getConversions() != null) ? mf.getConversions() : 0L;
+                if (mf.getSpend() != null) dSpend = dSpend.add(mf.getSpend());
+                if (mf.getRevenue() != null) dRevenue = dRevenue.add(mf.getRevenue());
             }
-            // 둘 다 0이거나 데이터가 아예 없는 경우
-            return 0.0;
+
+            sumImpressions += dImpressions;
+            sumClicks += dClicks;
+            sumConversions += dConversions;
+            sumSpend = sumSpend.add(dSpend);
+            sumRevenue = sumRevenue.add(dRevenue);
+
+            dailyMetrics.add(new DashboardResponse.DailyMetricFactResponse(
+                    date,
+                    dImpressions,
+                    dClicks,
+                    dSpend.longValue(),
+                    dConversions,
+                    dRevenue.longValue(),
+                    metricCalculator.calculateCtr(dClicks, dImpressions),
+                    metricCalculator.calculateCpa(dSpend, dConversions),
+                    metricCalculator.calculateRoas(dRevenue, dSpend)
+            ));
         }
 
-        // 변화율 계산
-        double changeRate = ((currentVal - pastVal) / pastVal) * 100.0;
+        // 5. 합계 지표 객체 생성
+        DashboardResponse.DailyMetricFactResponse totalMetric = new DashboardResponse.DailyMetricFactResponse(
+                null,
+                sumImpressions,
+                sumClicks,
+                sumSpend.longValue(),
+                sumConversions,
+                sumRevenue.longValue(),
+                metricCalculator.calculateCtr(sumClicks, sumImpressions),
+                metricCalculator.calculateCpa(sumSpend, sumConversions),
+                metricCalculator.calculateRoas(sumRevenue, sumSpend)
+        );
 
-        // 소수점 둘째 자리까지 버림 처리
-        return BigDecimal.valueOf(changeRate)
-                .setScale(2, RoundingMode.DOWN)
-                .doubleValue();
-    }
-
-    //지표 값이 null 일 경우 BigDecimal 의 0 으로 바꿔주는 메서드
-    private BigDecimal toZeroIfNull(BigDecimal value) {
-        return value == null ? BigDecimal.ZERO : value;
-    }
-
-    //나눗셈 계산시 분모가 0 일 경우 나눗셈 시행하지 않고 0.00 반환
-    private BigDecimal safePercent(BigDecimal numerator, BigDecimal denominator) {
-        if (denominator == null || denominator.signum() == 0 || numerator == null) {
-            return BigDecimal.ZERO.setScale(2, RoundingMode.DOWN);
-        }
-        return numerator.divide(denominator, 4, RoundingMode.DOWN)
-                .multiply(BigDecimal.valueOf(100))
-                .setScale(2, RoundingMode.DOWN);
-    }
-
-    //나눗셈 계산시 분모가 0 일 경우 나눗셈 시행하지 않고 0.00 반환
-    private double safePercent(Number numerator, Number denominator) {
-        double n = numerator == null ? 0.0 : numerator.doubleValue();
-        double d = denominator == null ? 0.0 : denominator.doubleValue();
-        if (d == 0.0) return 0.0;
-        return (n / d) * 100.0;
+        // 6. 결과 반환
+        return new DashboardResponse.PlatformMetricFactSummaryResponse(
+                provider.name(),
+                startDate,
+                endDate,
+                totalMetric,
+                dailyMetrics
+        );
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/presentation/DashboardController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/presentation/DashboardController.java
@@ -83,6 +83,19 @@ public class DashboardController implements DashboardControllerDocs {
         return ResponseEntity.ok(DataResponse.from(response));
     }
 
+    @GetMapping("/{orgId}/metric-facts")
+    public ResponseEntity<DataResponse<DashboardResponse.PlatformMetricFactSummaryResponse>> getPlatformMetricFacts(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId,
+            @RequestParam(name = "providerType") String providerType,
+            @RequestParam(required = false, defaultValue = "7") Integer days
+    ) {
+        DashboardResponse.PlatformMetricFactSummaryResponse response =
+                dashboardService.getPlatformMetricFacts(userId, orgId, providerType, days);
+
+        return ResponseEntity.ok(DataResponse.from(response));
+    }
+
     @GetMapping(value = "/{orgId}/clicks/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public ResponseEntity<SseEmitter> streamRealClicks(
             @AuthenticationPrincipal(expression = "userId") Long userId,

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/presentation/docs/DashboardControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/presentation/docs/DashboardControllerDocs.java
@@ -98,6 +98,24 @@ public interface DashboardControllerDocs {
 
 
     @Operation(
+            summary = "대시보드 - 플랫폼별 기간 단위 지표(MetricFact) 조회 API",
+            description = "특정 플랫폼에 대하여 특정 기간 동안의 일자별 광고 지표(노출수, 클릭수, 광고비, 전환수, 매출 등) 및 비율 지표(CTR, CPA, ROAS), 그리고 기간 전체의 합계 데이터를 조회합니다.\n\n" +
+                          "조회 기간은 파라미터 `days`로 결정되며(기본값 7), 합계 데이터(`total`)와 일자별 데이터(`dailyMetrics`) 리스트가 포함된 형식으로 반환됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 플랫폼(providerType) 입력 값"),
+            @ApiResponse(responseCode = "403", description = "해당 조직에 대한 접근 권한이 없는 경우"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 조직")
+    })
+    ResponseEntity<DataResponse<DashboardResponse.PlatformMetricFactSummaryResponse>> getPlatformMetricFacts(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @Parameter(description = "조직 ID", required = true, example = "1") @PathVariable Long orgId,
+            @Parameter(description = "광고 플랫폼 (GOOGLE, META, NAVER)", required = true, example = "GOOGLE") @RequestParam(name = "providerType") String providerType,
+            @Parameter(description = "조회 기간(일 단위, 기본값 7)", example = "7") @RequestParam(required = false, defaultValue = "7") Integer days
+    );
+
+    @Operation(
             summary = "대시보드 - 실시간 클릭수 스트림 출력 API",
             description = "해당 조직의 최근 60분간 실시간 클릭수 추이와 이상 징후(봇) 감지 여부를 스트림으로 보내주는 API입니다.\n\n" +
                     "파라미터로 `mode`를 받아 `dummy`이면 서버 내에서 생성하는 가상 트래픽을, `real`일 경우 실제 수집된 클릭 데이터를 기반으로 반환합니다.\n\n" +

--- a/src/main/java/com/whereyouad/WhereYouAd/global/utils/MetricCalculator.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/utils/MetricCalculator.java
@@ -67,7 +67,7 @@ public class MetricCalculator {
     // 변화율 = ((current - past) / past) * 100 (반올림 정수)
     public Integer computeDiffRate(double currentVal, Double pastVal) {
         if (pastVal == null || pastVal == 0.0)
-            return null;
+            return 0;
 
         double rate = ((currentVal - pastVal) / pastVal) * 100.0;
         return (int) Math.round(rate);

--- a/src/main/java/com/whereyouad/WhereYouAd/global/utils/MetricCalculator.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/utils/MetricCalculator.java
@@ -1,0 +1,98 @@
+package com.whereyouad.WhereYouAd.global.utils;
+
+import org.springframework.stereotype.Component;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+@Component
+public class MetricCalculator {
+
+    // ROAS = (revenue / spend) * 100
+    // spend가 null 또는 0이면 0.0 반환 (Division by Zero 방어)
+    public double calculateRoas(BigDecimal revenue, BigDecimal spend) {
+        if (spend == null || spend.compareTo(BigDecimal.ZERO) == 0)
+            return 0.0;
+        if (revenue == null)
+            return 0.0;
+
+        return revenue.divide(spend, 4, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100))
+                .doubleValue();
+    }
+
+    // CTR = (clicks / impressions) * 100
+    public double calculateCtr(Long clicks, Long impressions) {
+        if (impressions == null || impressions == 0)
+            return 0.0;
+        if (clicks == null)
+            return 0.0;
+
+        return BigDecimal.valueOf(clicks)
+                .divide(BigDecimal.valueOf(impressions), 4, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100))
+                .doubleValue();
+    }
+
+    // CPA = (spend / conversions)
+    public double calculateCpa(BigDecimal spend, Long conversions) {
+        if (conversions == null || conversions == 0)
+            return 0.0;
+        if (spend == null)
+            return 0.0;
+
+        return spend.divide(BigDecimal.valueOf(conversions), 2, RoundingMode.HALF_UP)
+                .doubleValue();
+    }
+
+    // 변화율 = ((current - past) / past) * 100
+    // past가 null이거나 0일 경우의 방어 로직 포함
+    public Double calculateChangeRate(Number current, Number past) {
+        double currentVal = (current != null) ? current.doubleValue() : 0.0;
+        double pastVal = (past != null) ? past.doubleValue() : 0.0;
+
+        if (pastVal == 0.0) {
+            if (currentVal > 0.0) {
+                return 100.0;
+            }
+            return 0.0;
+        }
+
+        double changeRate = ((currentVal - pastVal) / pastVal) * 100.0;
+
+        return BigDecimal.valueOf(changeRate)
+                .setScale(2, RoundingMode.DOWN)
+                .doubleValue();
+    }
+
+    // 변화율 = ((current - past) / past) * 100 (반올림 정수)
+    public Integer computeDiffRate(double currentVal, Double pastVal) {
+        if (pastVal == null || pastVal == 0.0)
+            return null;
+
+        double rate = ((currentVal - pastVal) / pastVal) * 100.0;
+        return (int) Math.round(rate);
+    }
+
+    // 분모가 0일 경우 나눗셈 시행하지 않고 0.0 반환 (BigDecimal 반환)
+    public BigDecimal safePercent(BigDecimal numerator, BigDecimal denominator) {
+        if (denominator == null || denominator.signum() == 0 || numerator == null) {
+            return BigDecimal.ZERO.setScale(2, RoundingMode.DOWN);
+        }
+        return numerator.divide(denominator, 4, RoundingMode.DOWN)
+                .multiply(BigDecimal.valueOf(100))
+                .setScale(2, RoundingMode.DOWN);
+    }
+
+    // 분모가 0일 경우 나눗셈 시행하지 않고 0.0 반환 (double 반환)
+    public double safePercent(Number numerator, Number denominator) {
+        double n = numerator == null ? 0.0 : numerator.doubleValue();
+        double d = denominator == null ? 0.0 : denominator.doubleValue();
+        if (d == 0.0) return 0.0;
+        return (n / d) * 100.0;
+    }
+
+    // 지표 값이 null 일 경우 BigDecimal 의 0 으로 바꿔주는 메서드
+    public BigDecimal toZeroIfNull(BigDecimal value) {
+        return value == null ? BigDecimal.ZERO : value;
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/global/utils/MetricCalculator.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/utils/MetricCalculator.java
@@ -76,11 +76,11 @@ public class MetricCalculator {
     // 분모가 0일 경우 나눗셈 시행하지 않고 0.0 반환 (BigDecimal 반환)
     public BigDecimal safePercent(BigDecimal numerator, BigDecimal denominator) {
         if (denominator == null || denominator.signum() == 0 || numerator == null) {
-            return BigDecimal.ZERO.setScale(2, RoundingMode.DOWN);
+            return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
         }
-        return numerator.divide(denominator, 4, RoundingMode.DOWN)
+        return numerator.divide(denominator, 4, RoundingMode.HALF_UP)
                 .multiply(BigDecimal.valueOf(100))
-                .setScale(2, RoundingMode.DOWN);
+                .setScale(2, RoundingMode.HALF_UP);
     }
 
     // 분모가 0일 경우 나눗셈 시행하지 않고 0.0 반환 (double 반환)


### PR DESCRIPTION
## 📌 관련 이슈
- Close #132 

## 🚀 개요
플랫폼 대시보드에서 특정 플랫폼의 MetricFact를 7일/30일만큼 조회하는 API를 구현하였습니다.

## 📄 작업 내용
- 기존 DashboardServiceImpl 내 MetricFact 지표값 계산(ex. ROAS 등) 로직을 utils로 분리
   - 30일치 계산 -> 반복 되어 공통 클래스로 분리
- 특정 플랫폼의 MetricFact 원하는 날짜만큼 조회하는 API 구현

## 📸 스크린샷 / 테스트 결과 (선택)
<img width="1402" height="838" alt="image" src="https://github.com/user-attachments/assets/9b30b338-ad58-498f-8041-b3b4841742c0" />

<img width="490" height="363" alt="image" src="https://github.com/user-attachments/assets/5430beef-fb2c-4c32-bf10-a22090d3960c" />

<img width="332" height="413" alt="image" src="https://github.com/user-attachments/assets/982bc23c-8fb1-45da-806f-c9024b996164" />

> 해당 구간에 대한 합산값과, 그 아래에는 배열 안에 날짜별로 MetricFact가 쭉 이어져서 나옵니다. (7일이면 7일치..)

## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
플랫폼 대시보드 아래에 해당하는 부분(사진)에 대한 응답(날짜별 MetricFact)을 내려주는 API가 없었네요... 프론트 연동 요청에 따라 빠르게 만들어봤는데 지표들 합산하는 로직이 중복 되는 느낌이라 분리해서 재활용할 수 있게 하였는데, 해당 로직이 잘 맞는지 확인해주시면 감사하겠습니다!

그리고 7일/30일 날짜 수도 일단은 두 개로만 구분하지 않고, 쿼리 파라미터로 원하는 일수만큼 받을 수 있게 해두었는데 이게 괜찮을지도 고민입니다..!

+ 프론트 연동 시 이해를 위한 플랫폼별 연동(ex.  로그인/key 입력 후 최초 연동 이후 광고 데이터 수동 연동 api 호출 등..  각 플랫폼별로 순차적으로 이뤄져야하는 호출 등...) 관련한 API 명세 노션 작성도 필요할 듯 합니다!

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 플랫폼별 일자별 메트릭 조회 API 추가(기본 최근 7일, providerType 파라미터 지원)
  * 기간 합계 및 일별 리스트 형태의 응답 제공(노출·클릭·광고비·전환·매출 포함)

* **Enhancements**
  * 경량 조회 옵션으로 대시보드 지표를 빠르게 조회 가능

* **Refactor**
  * 메트릭 계산 로직을 공통 유틸로 통합해 계산 일관성 및 유지보수성 향상

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhereYouAd/WhereYouAd-Backend/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->