### PR TITLE
Feat/#127 회원 탈퇴 - User 엔티티 삭제 기능 추가

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/ai/persistence/repository/AIInsightReportRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/ai/persistence/repository/AIInsightReportRepository.java
@@ -2,10 +2,18 @@ package com.whereyouad.WhereYouAd.domains.ai.persistence.repository;
 
 import com.whereyouad.WhereYouAd.domains.ai.persistence.entity.AIInsightReport;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface AIInsightReportRepository extends JpaRepository<AIInsightReport, Long> {
 
     Optional<AIInsightReport> findByAccessToken(String accessToken);
+
+    // 조직 ID 기준 일괄 삭제 (회원 탈퇴 정리용)
+    @Modifying
+    @Query("DELETE FROM AIInsightReport r WHERE r.organization.id = :orgId")
+    void deleteByOrganizationId(@Param("orgId") Long orgId);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/request/OrgRequest.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/application/dto/request/OrgRequest.java
@@ -35,4 +35,10 @@ public class OrgRequest {
             @Email(message = "이메일 형식이 올바르지 않습니다.")
             String email
     ) {}
+
+    public record ChangeOwner(
+            @Schema(description = "워크스페이스 새 소유자로 지정할 사용자의 DB Id", example = "1")
+            @NotNull(message = "새 소유자 Id 는 필수입니다.")
+            Long newOwnerUserId
+    ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
@@ -24,6 +24,9 @@ public interface OrgService {
 
     void removeOrganizationSoft(Long userId, Long orgId);
 
+    // User Hard Delete 정리용 - 특정 User 가 owner 인 Soft Deleted Organization 들을 관련 엔티티와 함께 Hard Delete
+    void removeOrganizationsOwnedBySoftDeletedUser(Long userId);
+
     OrgResponse.Delete restoreOrganization(Long userId, Long orgId);
 
     // orgId 조직에서 memberId에 해당하는 맴버 제거

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgService.java
@@ -35,4 +35,6 @@ public interface OrgService {
     OrgResponse.OrgInvitationResponse sendOrgInvitation(Long userId, Long orgId, String email);
 
     OrgResponse.OrgInvitationResponse acceptOrgInvitation(Long userId, String token);
+
+    void changeOwner(Long userId, Long orgId, OrgRequest.ChangeOwner request);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -477,4 +477,33 @@ public class OrgServiceImpl implements OrgService {
 
         return new OrgResponse.OrgInvitationResponse(organization.getId(), "조직 멤버 초대 이메일을 수락하였습니다.", email);
     }
+
+    // 조직 생성자(ownerUserId) 양도 메서드
+    public void changeOwner(Long userId, Long orgId, OrgRequest.ChangeOwner request) {
+
+        // 생성자 양도를 요청한 기존 조직 생성자(userId)와, 새로운 생성자(request.newOwnerUserId()) 가 동일할 경우 오류
+        if (Objects.equals(userId, request.newOwnerUserId())) {
+            throw new OrgHandler(OrgErrorCode.ORG_OWNER_SAME_AS_BEFORE);
+        }
+
+        Organization organization = orgRepository.findById(orgId)
+                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
+
+        // 만약 생성자 양도를 요청한 회원이 해당 조직의 생성자 아닐 경우 오류
+        if (!Objects.equals(organization.getOwnerUserId(), userId)) {
+            throw new OrgHandler(OrgErrorCode.ORG_FORBIDDEN);
+        }
+
+        // 새로운 생성자가 될 회원의 OrgMember 조회
+        OrgMember newOwner = orgMemberRepository.findByUserIdAndOrgId(request.newOwnerUserId(), orgId)
+                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_MEMBER_NOT_FOUND));
+
+        // 새로운 생성자는 ADMIN 만 가능
+        if (newOwner.getRole() != OrgRole.ADMIN) {
+            throw new OrgHandler(OrgErrorCode.ORG_MEMBER_FORBIDDEN);
+        }
+
+        // 생성자 양도 진행
+        organization.changeOwner(request.newOwnerUserId());
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -498,17 +498,17 @@ public class OrgServiceImpl implements OrgService {
     // 조직 생성자(ownerUserId) 양도 메서드
     public void changeOwner(Long userId, Long orgId, OrgRequest.ChangeOwner request) {
 
-        // 생성자 양도를 요청한 기존 조직 생성자(userId)와, 새로운 생성자(request.newOwnerUserId()) 가 동일할 경우 오류
-        if (Objects.equals(userId, request.newOwnerUserId())) {
-            throw new OrgHandler(OrgErrorCode.ORG_OWNER_SAME_AS_BEFORE);
-        }
-
         Organization organization = orgRepository.findById(orgId)
                 .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_NOT_FOUND));
 
         // 만약 생성자 양도를 요청한 회원이 해당 조직의 생성자 아닐 경우 오류
         if (!Objects.equals(organization.getOwnerUserId(), userId)) {
             throw new OrgHandler(OrgErrorCode.ORG_FORBIDDEN);
+        }
+
+        // 생성자 양도를 요청한 기존 조직 생성자(userId)와, 새로운 생성자(request.newOwnerUserId()) 가 동일할 경우 오류
+        if (Objects.equals(userId, request.newOwnerUserId())) {
+            throw new OrgHandler(OrgErrorCode.ORG_OWNER_SAME_AS_BEFORE);
         }
 
         // 새로운 생성자가 될 회원의 OrgMember 조회

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -1,5 +1,6 @@
 package com.whereyouad.WhereYouAd.domains.organization.domain.service;
 
+import com.whereyouad.WhereYouAd.domains.ai.persistence.repository.AIInsightReportRepository;
 import com.whereyouad.WhereYouAd.domains.organization.application.dto.request.OrgRequest;
 import com.whereyouad.WhereYouAd.domains.organization.application.dto.response.OrgResponse;
 import com.whereyouad.WhereYouAd.domains.organization.application.mapper.OrgConverter;
@@ -11,10 +12,10 @@ import com.whereyouad.WhereYouAd.domains.organization.exception.handler.OrgHandl
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgInvitation;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMember;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
-import com.whereyouad.WhereYouAd.domains.ai.persistence.repository.AIInsightReportRepository;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgInvitationRepository;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgRepository;
+import com.whereyouad.WhereYouAd.domains.platform.persistence.repository.PlatformConnectionRepository;
 import com.whereyouad.WhereYouAd.domains.timeline.persistence.repository.TimelineRepository;
 import com.whereyouad.WhereYouAd.domains.user.domain.service.EmailService;
 import com.whereyouad.WhereYouAd.domains.user.exception.code.UserErrorCode;
@@ -45,10 +46,12 @@ public class OrgServiceImpl implements OrgService {
     private final TimelineRepository timelineRepository;
     private final AIInsightReportRepository aiInsightReportRepository;
     private final UserRepository userRepository;
+    private final PlatformConnectionRepository platformConnectionRepository;
 
     private final RedisUtil redisUtil;
     private final EmailService emailService;
     private final S3UploadService s3UploadService;
+
 
     // 조직(워크스페이스) 생성 메서드
     public OrgResponse.Create createOrganization(Long userId, OrgRequest.Create request, MultipartFile imageFile) {
@@ -256,6 +259,15 @@ public class OrgServiceImpl implements OrgService {
             throw new OrgHandler(OrgErrorCode.ORG_FORBIDDEN); // 예외처리
         }
 
+        // 조직에 연동된 플랫폼 계정이 존재할 경우 오류
+        // 별도 API 를 통해 사용자가 명시적 삭제 진행해야함
+        if (!platformConnectionRepository.findByUserIdAndOrgId(userId, orgId).isEmpty()) {
+            throw new OrgHandler(OrgErrorCode.ORG_PLATFORM_CONNECTED);
+        }
+
+        timelineRepository.deleteByOrganizationId(orgId);
+        aiInsightReportRepository.deleteByOrganizationId(orgId);
+
         String logoUrl = organization.getLogoUrl();
 
         // 해당 조직에 가입된 모든 회원들의 가입 정보 삭제
@@ -269,9 +281,6 @@ public class OrgServiceImpl implements OrgService {
         }
 
         orgMemberRepository.deleteAll(orgMembers);
-
-        // 조직에 종속된 부수 데이터 정리 (OrgInvitation / Timeline / AIInsightReport)
-        cleanupOrganizationRelatedData(orgId);
 
         // 조직 실제 삭제
         orgRepository.delete(organization);
@@ -298,6 +307,14 @@ public class OrgServiceImpl implements OrgService {
             throw new OrgHandler(OrgErrorCode.ORG_FORBIDDEN);
         }
 
+        // 조직에 연동된 플랫폼 계정이 존재할 경우 오류
+        // 별도 API 를 통해 사용자가 명시적 삭제 진행해야함
+        if (!platformConnectionRepository.findByUserIdAndOrgId(userId, orgId).isEmpty()) {
+            throw new OrgHandler(OrgErrorCode.ORG_PLATFORM_CONNECTED);
+        }
+
+        timelineRepository.deleteByOrganizationId(orgId);
+
         // 현재 워크스페이스가 삭제되는 조직인 멤버들의 currentOrgId를 null로 초기화
         List<OrgMember> orgMembers = orgMemberRepository.findOrgMemberByOrg(organization);
         for (OrgMember member : orgMembers) {
@@ -308,16 +325,38 @@ public class OrgServiceImpl implements OrgService {
 
         // 조직 status 만 DELETED 로 변경
         organization.softDelete();
-
-        // 멤버 없이 의미가 사라지는 부수 데이터(OrgInvitation, Timeline, AIInsightReport) 정리
-        cleanupOrganizationRelatedData(orgId);
     }
 
-    // 조직 삭제 시 함께 제거할 부수 데이터 일괄 정리
-    private void cleanupOrganizationRelatedData(Long orgId) {
-        orgInvitationRepository.deleteByOrganizationId(orgId);
-        timelineRepository.deleteByOrganizationId(orgId);
-        aiInsightReportRepository.deleteByOrganizationId(orgId);
+    // User Hard Delete 정리용 - 해당 User 가 owner 인 Soft Deleted Organization 들을 Hard Delete
+    // (Soft Delete 시 'owner + 다른 멤버 존재' 케이스는 차단되므로, 여기서는 본인 1명만 속한 조직만 존재)
+    @Override
+    public void removeOrganizationsOwnedBySoftDeletedUser(Long userId) {
+        List<Organization> targetOrganizations =
+                orgRepository.findAllByOwnerUserIdAndStatus(userId, OrgStatus.DELETED);
+
+        for (Organization organization : targetOrganizations) {
+            Long orgId = organization.getId();
+            String logoUrl = organization.getLogoUrl();
+
+            // 조직 소속 OrgMember 전부 Hard Delete (탈퇴 회원 본인의 OrgMember 포함)
+            List<OrgMember> orgMembers = orgMemberRepository.findOrgMemberByOrg(organization);
+            orgMemberRepository.deleteAll(orgMembers);
+
+            timelineRepository.deleteByOrganizationId(orgId);
+            aiInsightReportRepository.deleteByOrganizationId(orgId);
+
+            // 조직 Hard Delete
+            orgRepository.delete(organization);
+
+            // 로고 이미지 S3 삭제 (실패 시 로그만 남기고 진행)
+            if (logoUrl != null) {
+                try {
+                    s3UploadService.deleteImageFromUrl(logoUrl);
+                } catch (Exception e) {
+                    log.warn("탈퇴 회원 조직 Hard Delete - S3 로고 이미지 삭제 실패: {}", logoUrl, e);
+                }
+            }
+        }
     }
 
     public void removeMemberFromOrg(Long userId, Long orgId, Long memberId) {

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -11,9 +11,11 @@ import com.whereyouad.WhereYouAd.domains.organization.exception.handler.OrgHandl
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgInvitation;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMember;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
+import com.whereyouad.WhereYouAd.domains.ai.persistence.repository.AIInsightReportRepository;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgInvitationRepository;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgRepository;
+import com.whereyouad.WhereYouAd.domains.timeline.persistence.repository.TimelineRepository;
 import com.whereyouad.WhereYouAd.domains.user.domain.service.EmailService;
 import com.whereyouad.WhereYouAd.domains.user.exception.code.UserErrorCode;
 import com.whereyouad.WhereYouAd.domains.user.exception.handler.UserHandler;
@@ -40,6 +42,8 @@ public class OrgServiceImpl implements OrgService {
     private final OrgRepository orgRepository;
     private final OrgMemberRepository orgMemberRepository;
     private final OrgInvitationRepository orgInvitationRepository;
+    private final TimelineRepository timelineRepository;
+    private final AIInsightReportRepository aiInsightReportRepository;
     private final UserRepository userRepository;
 
     private final RedisUtil redisUtil;
@@ -266,6 +270,9 @@ public class OrgServiceImpl implements OrgService {
 
         orgMemberRepository.deleteAll(orgMembers);
 
+        // 조직에 종속된 부수 데이터 정리 (OrgInvitation / Timeline / AIInsightReport)
+        cleanupOrganizationRelatedData(orgId);
+
         // 조직 실제 삭제
         orgRepository.delete(organization);
 
@@ -299,8 +306,18 @@ public class OrgServiceImpl implements OrgService {
             }
         }
 
-        // 조직 status 만 DELETED 로 변경 후 종료
+        // 조직 status 만 DELETED 로 변경
         organization.softDelete();
+
+        // 멤버 없이 의미가 사라지는 부수 데이터(OrgInvitation, Timeline, AIInsightReport) 정리
+        cleanupOrganizationRelatedData(orgId);
+    }
+
+    // 조직 삭제 시 함께 제거할 부수 데이터 일괄 정리
+    private void cleanupOrganizationRelatedData(Long orgId) {
+        orgInvitationRepository.deleteByOrganizationId(orgId);
+        timelineRepository.deleteByOrganizationId(orgId);
+        aiInsightReportRepository.deleteByOrganizationId(orgId);
     }
 
     public void removeMemberFromOrg(Long userId, Long orgId, Long memberId) {

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -267,6 +267,7 @@ public class OrgServiceImpl implements OrgService {
 
         timelineRepository.deleteByOrganizationId(orgId);
         aiInsightReportRepository.deleteByOrganizationId(orgId);
+        orgInvitationRepository.deleteByOrganizationId(orgId);
 
         String logoUrl = organization.getLogoUrl();
 
@@ -312,8 +313,6 @@ public class OrgServiceImpl implements OrgService {
         if (!platformConnectionRepository.findByUserIdAndOrgId(userId, orgId).isEmpty()) {
             throw new OrgHandler(OrgErrorCode.ORG_PLATFORM_CONNECTED);
         }
-
-        timelineRepository.deleteByOrganizationId(orgId);
 
         // 현재 워크스페이스가 삭제되는 조직인 멤버들의 currentOrgId를 null로 초기화
         List<OrgMember> orgMembers = orgMemberRepository.findOrgMemberByOrg(organization);

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/domain/service/OrgServiceImpl.java
@@ -343,6 +343,7 @@ public class OrgServiceImpl implements OrgService {
 
             timelineRepository.deleteByOrganizationId(orgId);
             aiInsightReportRepository.deleteByOrganizationId(orgId);
+            orgInvitationRepository.deleteByOrganizationId(orgId);
 
             // 조직 Hard Delete
             orgRepository.delete(organization);

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
@@ -15,6 +15,7 @@ public enum OrgErrorCode implements BaseErrorCode {
     ORG_CANNOT_ROLE_CHANGE_SELF(HttpStatus.BAD_REQUEST, "ORG_400_4", "본인의 역할은 변경할 수 없습니다."),
     ORG_LAST_ADMIN(HttpStatus.BAD_REQUEST, "ORG_400_5", "마지막 ADMIN은 강등할 수 없습니다."),
     ORG_OWNER_SAME_AS_BEFORE(HttpStatus.BAD_REQUEST, "ORG_400_6", "자기 자신으로 조직 소유자를 변경할 수 없습니다."),
+    ORG_PLATFORM_CONNECTED(HttpStatus.BAD_REQUEST, "ORG_400_7", "조직 내 연동된 광고 플랫폼 연동을 먼저 해제해주세요."),
 
     // 403
     ORG_FORBIDDEN(HttpStatus.FORBIDDEN, "ORG_403_1", "해당 요청은 조직 생성자만 요청 가능합니다."),

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/exception/code/OrgErrorCode.java
@@ -14,6 +14,7 @@ public enum OrgErrorCode implements BaseErrorCode {
     ORG_CANNOT_KICK_ADMIN(HttpStatus.BAD_REQUEST, "ORG_400_3", "ADMIN은 추방할 수 없습니다."),
     ORG_CANNOT_ROLE_CHANGE_SELF(HttpStatus.BAD_REQUEST, "ORG_400_4", "본인의 역할은 변경할 수 없습니다."),
     ORG_LAST_ADMIN(HttpStatus.BAD_REQUEST, "ORG_400_5", "마지막 ADMIN은 강등할 수 없습니다."),
+    ORG_OWNER_SAME_AS_BEFORE(HttpStatus.BAD_REQUEST, "ORG_400_6", "자기 자신으로 조직 소유자를 변경할 수 없습니다."),
 
     // 403
     ORG_FORBIDDEN(HttpStatus.FORBIDDEN, "ORG_403_1", "해당 요청은 조직 생성자만 요청 가능합니다."),

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/entity/Organization.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/entity/Organization.java
@@ -4,6 +4,7 @@ import com.whereyouad.WhereYouAd.domains.organization.application.dto.request.Or
 import com.whereyouad.WhereYouAd.domains.organization.domain.constant.OrgStatus;
 import com.whereyouad.WhereYouAd.global.common.BaseEntity;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
@@ -52,5 +53,9 @@ public class Organization extends BaseEntity {
 
     public void restoreDelete() {
         this.status = OrgStatus.ACTIVE;
+    }
+
+    public void changeOwner(Long newOwnerUserId) {
+        this.ownerUserId = newOwnerUserId;
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/entity/Organization.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/entity/Organization.java
@@ -4,7 +4,6 @@ import com.whereyouad.WhereYouAd.domains.organization.application.dto.request.Or
 import com.whereyouad.WhereYouAd.domains.organization.domain.constant.OrgStatus;
 import com.whereyouad.WhereYouAd.global.common.BaseEntity;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgInvitationRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgInvitationRepository.java
@@ -23,4 +23,9 @@ public interface OrgInvitationRepository extends JpaRepository<OrgInvitation, Lo
     @Modifying
     @Query("DELETE FROM OrgInvitation ov WHERE ov.expireAt < :now")
     void deleteByExpireAtBefore(@Param("now") LocalDateTime now);
+
+    // 조직 ID 기준 일괄 삭제 (회원 탈퇴 정리용)
+    @Modifying
+    @Query("DELETE FROM OrgInvitation ov WHERE ov.organization.id = :orgId")
+    void deleteByOrganizationId(@Param("orgId") Long orgId);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgInvitationRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgInvitationRepository.java
@@ -28,4 +28,9 @@ public interface OrgInvitationRepository extends JpaRepository<OrgInvitation, Lo
     @Modifying
     @Query("DELETE FROM OrgInvitation ov WHERE ov.organization.id = :orgId")
     void deleteByOrganizationId(@Param("orgId") Long orgId);
+
+    // 이메일 기준 일괄 삭제 (탈퇴 회원 앞으로 발송된 pending 초대 정리용)
+    @Modifying
+    @Query("DELETE FROM OrgInvitation ov WHERE ov.email = :email")
+    void deleteByEmail(@Param("email") String email);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
@@ -69,4 +69,6 @@ public interface OrgMemberRepository extends JpaRepository<OrgMember, Long> {
 
     // 유저가 조직에 속하는지 확인
     boolean existsByUserIdAndOrganizationId(Long userId, Long orgId);
+
+    long countByOrganizationId(Long orgId);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
@@ -8,6 +8,7 @@ import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -18,6 +19,11 @@ public interface OrgMemberRepository extends JpaRepository<OrgMember, Long> {
 
     //User 가 가진 OrgMember 모두 추출하는 메서드
     List<OrgMember> findOrgMemberByUser(User user);
+
+    // userId 기준 OrgMember 일괄 Hard Delete (User Hard Delete 정리용)
+    @Modifying
+    @Query("DELETE FROM OrgMember om WHERE om.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
     
     //userId 를 통해 OrgMember 추출 -> Organization 의 status 가 ACTIVE 인 경우에만 조회
     @Query(value = "select om from OrgMember om join fetch om.organization o where om.user.id = :userId and o.status = 'ACTIVE'")

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgMemberRepository.java
@@ -75,6 +75,4 @@ public interface OrgMemberRepository extends JpaRepository<OrgMember, Long> {
 
     // 유저가 조직에 속하는지 확인
     boolean existsByUserIdAndOrganizationId(Long userId, Long orgId);
-
-    long countByOrganizationId(Long orgId);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/persistence/repository/OrgRepository.java
@@ -1,7 +1,17 @@
 package com.whereyouad.WhereYouAd.domains.organization.persistence.repository;
 
+import com.whereyouad.WhereYouAd.domains.organization.domain.constant.OrgStatus;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface OrgRepository extends JpaRepository<Organization, Long> {
+
+    // 특정 User 가 owner 이고, 지정된 상태인 Organization 모두 조회 (User Hard Delete 정리용)
+    @Query("SELECT o FROM Organization o WHERE o.ownerUserId = :ownerUserId AND o.status = :status")
+    List<Organization> findAllByOwnerUserIdAndStatus(@Param("ownerUserId") Long ownerUserId,
+                                                     @Param("status") OrgStatus status);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/OrgController.java
@@ -26,8 +26,7 @@ public class OrgController implements OrgControllerDocs {
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @RequestPart(value = "request") @Valid OrgRequest.Create request,
             @RequestPart(value = "image", required = false) MultipartFile image
-    )
-    {
+    ) {
         OrgResponse.Create response = orgService.createOrganization(userId, request, image);
         return ResponseEntity.ok(
                 DataResponse.created(response)
@@ -37,8 +36,7 @@ public class OrgController implements OrgControllerDocs {
     @GetMapping("/my")
     public ResponseEntity<DataResponse<OrgResponse.MyOrganizations>> getMyOrganizations(
             @AuthenticationPrincipal(expression = "userId") Long userId
-    )
-    {
+    ) {
         OrgResponse.MyOrganizations response = orgService.getMyOrganizations(userId);
 
         return ResponseEntity.ok(
@@ -49,8 +47,7 @@ public class OrgController implements OrgControllerDocs {
     @PostMapping("/{orgId}/workspace")
     public ResponseEntity<DataResponse<OrgResponse.CurrentWorkspace>> setCurrentWorkspace(
             @AuthenticationPrincipal(expression = "userId") Long userId,
-            @PathVariable Long orgId)
-    {
+            @PathVariable Long orgId) {
         OrgResponse.CurrentWorkspace response = orgService.setCurrentWorkspace(userId, orgId);
 
         return ResponseEntity.ok(
@@ -60,8 +57,7 @@ public class OrgController implements OrgControllerDocs {
 
     @GetMapping("/my/workspace")
     public ResponseEntity<DataResponse<OrgResponse.CurrentWorkspace>> getCurrentWorkspace(
-            @AuthenticationPrincipal(expression = "userId") Long userId)
-    {
+            @AuthenticationPrincipal(expression = "userId") Long userId) {
         OrgResponse.CurrentWorkspace response = orgService.getCurrentWorkspace(userId);
 
         return ResponseEntity.ok(
@@ -70,8 +66,7 @@ public class OrgController implements OrgControllerDocs {
     }
 
     @GetMapping("/{orgId}")
-    public ResponseEntity<DataResponse<OrgResponse.OrgDetail>> getOrganizationDetail(@PathVariable Long orgId)
-    {
+    public ResponseEntity<DataResponse<OrgResponse.OrgDetail>> getOrganizationDetail(@PathVariable Long orgId) {
         OrgResponse.OrgDetail response = orgService.getOrganizationDetail(orgId);
 
         return ResponseEntity.ok(
@@ -82,8 +77,7 @@ public class OrgController implements OrgControllerDocs {
     @GetMapping("/deleted")
     public ResponseEntity<DataResponse<OrgResponse.MyOrganizations>> getSoftDeletedOrganizations(
             @AuthenticationPrincipal(expression = "userId") Long userId
-    )
-    {
+    ) {
         OrgResponse.MyOrganizations response = orgService.getSoftDeletedOrgs(userId);
 
         return ResponseEntity.ok(
@@ -98,8 +92,7 @@ public class OrgController implements OrgControllerDocs {
             @PathVariable Long orgId,
             @RequestPart(value = "request") @Valid OrgRequest.Update request,
             @RequestPart(value = "image", required = false) MultipartFile imageFile
-    )
-    {
+    ) {
         OrgResponse.Update response = orgService.modifyOrganization(userId, orgId, request, imageFile);
         return ResponseEntity.ok(
                 DataResponse.from(response)
@@ -110,8 +103,7 @@ public class OrgController implements OrgControllerDocs {
     public ResponseEntity<DataResponse<OrgResponse.Delete>> restoreOrganization(
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId
-    )
-    {
+    ) {
         OrgResponse.Delete response = orgService.restoreOrganization(userId, orgId);
 
         return ResponseEntity.ok(
@@ -124,8 +116,7 @@ public class OrgController implements OrgControllerDocs {
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId,
             @RequestParam(defaultValue = "false") boolean isHard
-    )
-    {
+    ) {
         if (isHard) { //true 로 하여 Hard Delete 시
             orgService.removeOrganization(userId, orgId); //Hard Delete
         } else { //기본값(false) 이면
@@ -199,5 +190,19 @@ public class OrgController implements OrgControllerDocs {
             @AuthenticationPrincipal(expression = "userId") Long userId, @PathVariable String token) {
         OrgResponse.OrgInvitationResponse orgInvitationResponse = orgService.acceptOrgInvitation(userId, token);
         return ResponseEntity.ok(DataResponse.from(orgInvitationResponse));
+    }
+
+    @PatchMapping("/{orgId}/changeOwner")
+    public ResponseEntity<DataResponse<String>> changeOrgOwner(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId,
+            @RequestBody @Valid OrgRequest.ChangeOwner request
+    )
+    {
+        orgService.changeOwner(userId, orgId, request);
+
+        return ResponseEntity.ok(
+                DataResponse.from("워크스페이스 소유자가 Id=" + request.newOwnerUserId()  + " 인 사용자로 변경되었습니다.")
+        );
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/organization/presentation/docs/OrgControllerDocs.java
@@ -241,4 +241,26 @@ public interface OrgControllerDocs {
             @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable String token
     );
+
+    @Operation(
+            summary = "조직 소유자(생성자) 양도 API",
+            description = "현재 조직 생성자(owner)가 새로운 생성자로 지정할 회원의 userId 를 RequestBody 로 전달하여 소유권을 양도하는 API.\n\n" +
+                    "- 요청자(로그인한 회원)는 해당 조직의 현재 생성자여야 합니다.\n\n" +
+                    "- 새로운 생성자로 지정할 회원은 해당 조직의 멤버여야 하며, 역할이 ADMIN 이어야 합니다.\n\n" +
+                    "- 본인에게 소유권을 위임할 수 없습니다.\n\n" +
+                    "회원 탈퇴 시점에 본인이 소유자인 조직이 남아있고 해당 조직에 다른 멤버가 존재할 경우 탈퇴가 차단되므로, 그 전에 이 API 로 소유권을 위임해야 합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "400_6", description = "ORG_400_6 : 자기 자신으로 조직 소유자를 변경할 수 없음"),
+            @ApiResponse(responseCode = "403_1", description = "ORG_403_1 : 허가되지 않은 회원의 요청 (조직 생성자 X)"),
+            @ApiResponse(responseCode = "403_2", description = "ORG_403_2 : 새로운 생성자로 지정한 회원이 ADMIN 권한을 가지고 있지 않음"),
+            @ApiResponse(responseCode = "404_1", description = "ORG_404_1 : 해당 id 조직 존재 X"),
+            @ApiResponse(responseCode = "404_2", description = "ORG_404_2 : 새로운 생성자로 지정한 회원이 해당 조직에 속해있지 않음")
+    })
+    ResponseEntity<DataResponse<String>> changeOrgOwner(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId,
+            @RequestBody @Valid OrgRequest.ChangeOwner request
+    );
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/domain/service/PlatformService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/domain/service/PlatformService.java
@@ -9,4 +9,7 @@ public interface PlatformService {
     PlatformResponse.PlatformAccountListResponse getPlatformSyncInfos(Long userId, Long orgId);
 
     PlatformResponse.PlatformAccount updateNaverAdAccount(Long userId, Long orgId, PlatformRequest.PlatformAccount request);
+
+    void disconnectPlatform(Long userId, Long orgId, Long accountId);
+
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/domain/service/PlatformServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/domain/service/PlatformServiceImpl.java
@@ -144,6 +144,12 @@ public class PlatformServiceImpl implements PlatformService {
         return PlatformConverter.toPlatformAccountResponse(platformAccount);
     }
 
+    @Override
+    public void disconnectPlatform(Long userId, Long orgId, Long accountId) {
+        // TODO: 관련된 PlatformConnection, PlatformAccount, 광고 도메인 엔티티 제거 로직 개발
+        return;
+    }
+
     private void validateNaverCredentials(String customerId, String encryptedApiKey, String encryptedSecretKey) {
         try {
             PlatformConnection tempConnection = PlatformConverter.toTempPlatformConnection(customerId, encryptedApiKey, encryptedSecretKey);

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/persistence/repository/PlatformConnectionRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/persistence/repository/PlatformConnectionRepository.java
@@ -24,6 +24,9 @@ public interface PlatformConnectionRepository extends JpaRepository<PlatformConn
     // 조직 ID와 플랫폼으로 등록된 연동 정보(Account/Connection) 목록 조회
     List<PlatformConnection> findByPlatformAccount_Organization_IdAndPlatformAccount_Provider(Long orgId, Provider provider);
 
+    // 사용자 ID로 등록된 연동 정보 목록 조회 (회원 탈퇴 시 정리용)
+    List<PlatformConnection> findByUser_Id(Long userId);
+
     // 사용자 ID와 플랫폼으로 등록된 연동 정보 목록 조회
     List<PlatformConnection> findByUser_IdAndPlatformAccount_Provider(Long userId, Provider provider);
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/presentation/PlatformController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/presentation/PlatformController.java
@@ -60,4 +60,17 @@ public class PlatformController implements PlatformControllerDocs {
         );
     }
 
+
+    @DeleteMapping("/{orgId}/accounts/{accountId}")
+    public ResponseEntity<DataResponse<String>> disconnectPlatform(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable(value = "orgId") Long orgId,
+            @PathVariable(value = "accountId") Long accountId
+    )
+    {
+        platformService.disconnectPlatform(userId, orgId, accountId);
+
+        return ResponseEntity.ok(DataResponse.from("광고 플랫폼 연동 정보와 연관된 광고 정보가 정상적으로 삭제되었습니다."));
+    }
+
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/platform/presentation/PlatformController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/platform/presentation/PlatformController.java
@@ -5,6 +5,7 @@ import com.whereyouad.WhereYouAd.domains.platform.application.dto.response.Platf
 import com.whereyouad.WhereYouAd.domains.platform.domain.service.PlatformService;
 import com.whereyouad.WhereYouAd.domains.platform.presentation.docs.PlatformControllerDocs;
 import com.whereyouad.WhereYouAd.global.response.DataResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -61,6 +62,7 @@ public class PlatformController implements PlatformControllerDocs {
     }
 
 
+    @Hidden
     @DeleteMapping("/{orgId}/accounts/{accountId}")
     public ResponseEntity<DataResponse<String>> disconnectPlatform(
             @AuthenticationPrincipal(expression = "userId") Long userId,

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/timeline/persistence/repository/TimelineRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/timeline/persistence/repository/TimelineRepository.java
@@ -2,6 +2,14 @@ package com.whereyouad.WhereYouAd.domains.timeline.persistence.repository;
 
 import com.whereyouad.WhereYouAd.domains.timeline.persistence.entity.Timeline;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TimelineRepository extends JpaRepository<Timeline, Long> {
+
+    // 조직 ID 기준 일괄 삭제 (회원 탈퇴 정리용)
+    @Modifying
+    @Query("DELETE FROM Timeline t WHERE t.organization.id = :orgId")
+    void deleteByOrganizationId(@Param("orgId") Long orgId);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
@@ -1,6 +1,7 @@
 package com.whereyouad.WhereYouAd.domains.user.domain.service;
 
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMember;
+import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
 import com.whereyouad.WhereYouAd.domains.user.application.dto.request.UserInfoModifyRequest;
 import com.whereyouad.WhereYouAd.domains.user.application.dto.response.MyOrgResponse;
@@ -18,13 +19,16 @@ import com.whereyouad.WhereYouAd.domains.user.persistence.repository.UserReposit
 import com.whereyouad.WhereYouAd.global.utils.RedisUtil;
 import com.whereyouad.WhereYouAd.infrastructure.client.aws.s3.S3UploadService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Objects;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -194,5 +198,50 @@ public class UserService {
         user.modifyInfo(finalName, finalImageUrl, finalEncodedPassword);
 
         return UserConverter.toUserInfoResponse(user.getId(), user.getName(), user.getProfileImageUrl());
+    }
+
+    // 회원 탈퇴
+    // 만약 탈퇴하려는 회원이 Organization 의 owner (organization.getOwnerUserId()) 면 탈퇴 불가 -> 양도 먼저 진행 필요
+    public void deleteUser(Long userId) {
+        // 회원 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(UserErrorCode.USER_NOT_FOUND));
+
+        // 회원 프로필 이미지 S3 URL 추출
+        String profileImageUrl = user.getProfileImageUrl();
+
+        // 회원이 속한 조직 List 조회
+        List<OrgMember> orgMembers = orgMemberRepository.findOrgMemberByUserId(userId);
+
+        List<Organization> organizations = orgMembers.stream()
+                .map(OrgMember::getOrganization)
+                .toList();
+
+        // 회원이 속한 모든 조직 중에서
+        for (Organization organization : organizations) {
+            if (Objects.equals(organization.getOwnerUserId(), userId)) { // 만약 회원이 생성자인 조직이 있으면
+                // 해당 조직의 회원 수를 조회
+                long memberCount = orgMemberRepository.countByOrganizationId(organization.getId());
+
+                if (memberCount > 1) { // 회원 수가 1 초과이면 (본인 제외 다른 회원이 조직에 속해있으면)
+                    // 탈퇴 불가(조직 생성자 양도부터 먼저 진행해야한다.)
+                    throw new UserHandler(UserErrorCode.USER_OWNS_ORGANIZATION);
+                }
+
+                // 회원 수가 1 이면 본인만 속한 조직(별도 회원이 없는 조직) 이므로 Soft Delete 진행
+                organization.softDelete();
+            }
+        }
+
+        // 회원 삭제
+        userRepository.deleteById(userId);
+
+        // 회원 삭제 이후 S3 에서 이미지 삭제 진행
+        try {
+            s3UploadService.deleteImageFromUrl(profileImageUrl);
+        } catch (Exception e) {
+            // 이미지 삭제에 실패하더라도 로그 처리만 하고 탈퇴는 정상 진행
+            log.error("회원 탈퇴 과정에서 S3 이미지 삭제 오류 발생");
+        }
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
@@ -28,6 +28,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -281,10 +283,17 @@ public class UserService {
         if (profileImageUrl == null) {
             return;
         }
-        try {
-            s3UploadService.deleteImageFromUrl(profileImageUrl);
-        } catch (Exception e) {
-            log.error("회원 탈퇴 과정에서 S3 이미지 삭제 오류 발생", e);
-        }
+        
+        // S3 이미지 삭제를 afterCommit 에 수행하도록 수정
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                try {
+                    s3UploadService.deleteImageFromUrl(profileImageUrl);
+                } catch (Exception e) {
+                    log.error("회원 탈퇴 과정에서 S3 이미지 삭제 오류 발생", e);
+                }
+            }
+        });
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
@@ -3,7 +3,6 @@ package com.whereyouad.WhereYouAd.domains.user.domain.service;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMember;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
-import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformAccount;
 import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformConnection;
 import com.whereyouad.WhereYouAd.domains.platform.persistence.repository.PlatformAccountRepository;
 import com.whereyouad.WhereYouAd.domains.platform.persistence.repository.PlatformConnectionRepository;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
@@ -18,9 +18,7 @@ import com.whereyouad.WhereYouAd.domains.user.domain.constant.UserStatus;
 import com.whereyouad.WhereYouAd.domains.user.application.mapper.UserConverter;
 import com.whereyouad.WhereYouAd.domains.user.application.dto.request.SignUpRequest;
 import com.whereyouad.WhereYouAd.domains.user.application.dto.response.SignUpResponse;
-import com.whereyouad.WhereYouAd.domains.user.persistence.entity.AuthProviderAccount;
 import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
-import com.whereyouad.WhereYouAd.domains.user.persistence.repository.AuthProviderAccountRepository;
 import com.whereyouad.WhereYouAd.domains.user.persistence.repository.RefreshTokenRepository;
 import com.whereyouad.WhereYouAd.domains.user.persistence.repository.UserRepository;
 import com.whereyouad.WhereYouAd.global.utils.RedisUtil;
@@ -30,8 +28,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -46,7 +42,6 @@ public class UserService {
     private final UserRepository userRepository;
     private final OrgMemberRepository orgMemberRepository;
     private final OrgInvitationRepository orgInvitationRepository;
-    private final AuthProviderAccountRepository authProviderAccountRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final PlatformConnectionRepository platformConnectionRepository;
     private final OrgService orgService;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
@@ -1,11 +1,10 @@
 package com.whereyouad.WhereYouAd.domains.user.domain.service;
 
+import com.whereyouad.WhereYouAd.domains.organization.domain.service.OrgService;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMember;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
-import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgRepository;
 import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformConnection;
-import com.whereyouad.WhereYouAd.domains.platform.persistence.repository.PlatformAccountRepository;
 import com.whereyouad.WhereYouAd.domains.platform.persistence.repository.PlatformConnectionRepository;
 import com.whereyouad.WhereYouAd.domains.user.application.dto.request.UserInfoModifyRequest;
 import com.whereyouad.WhereYouAd.domains.user.application.dto.response.MyOrgResponse;
@@ -44,10 +43,10 @@ public class UserService {
     private final OrgMemberRepository orgMemberRepository;
     private final AuthProviderAccountRepository authProviderAccountRepository;
     private final PlatformConnectionRepository platformConnectionRepository;
+    private final OrgService orgService;
     private final PasswordEncoder passwordEncoder;
     private final RedisUtil redisUtil;
     private final S3UploadService s3UploadService;
-    private final OrgRepository orgRepository;
 
     //회원가입 메서드
     public SignUpResponse signUpUser(SignUpRequest request) {
@@ -219,56 +218,73 @@ public class UserService {
         // 회원 프로필 이미지 S3 URL 추출
         String profileImageUrl = user.getProfileImageUrl();
 
-        // 회원이 속한 조직 List 조회
-        List<OrgMember> orgMembers = orgMemberRepository.findOrgMemberByUserId(userId);
+        // 1) 검증 단계
+        // PlatformConnection 이 연결되어있는가? -> 연결되어 있으면 오류
+        // 속한 Organization 중에 "해당 회원이 owner 인데 다른 회원이 멤버로 속한 Organization" 이 존재하는가? -> 존재 시 오류
+        validateNoPlatformConnections(userId);
+        handleOrganizationsOwnedByUser(userId);
 
-        List<Organization> organizations = orgMembers.stream()
-                .map(OrgMember::getOrganization)
-                .toList();
+        // 2) 정리 단계 - User 를 참조하는 자식 엔티티 제거
+        removeAllOrgMembers(user);
+        removeAuthProviderAccounts(user);
 
-        // 회원이 속한 모든 조직 중에서
-        for (Organization organization : organizations) {
-            if (Objects.equals(organization.getOwnerUserId(), userId)) { // 만약 회원이 생성자인 조직이 있으면
-                // 해당 조직의 회원 수를 조회
-                long memberCount = orgMemberRepository.countByOrganizationId(organization.getId());
+        // 3) 본인 삭제 + 프로필 이미지 삭제
+        userRepository.deleteById(userId);
+        deleteProfileImage(profileImageUrl);
+    }
 
-                if (memberCount > 1) { // 회원 수가 1 초과이면 (본인 제외 다른 회원이 조직에 속해있으면)
-                    // 탈퇴 불가(조직 생성자 양도부터 먼저 진행해야한다.)
-                    throw new UserHandler(UserErrorCode.USER_OWNS_ORGANIZATION);
-                }
-
-                // 회원 수가 1 이면 본인만 속한 조직(별도 회원이 없는 조직) 이므로 Soft Delete 진행
-                organization.softDelete();
-            }
-        }
-
-        // User 를 참조하는 OrgMember 제거 (Soft Delete 된 조직 멤버십까지 포함)
-        orgMemberRepository.deleteAll(orgMemberRepository.findOrgMemberByUser(user));
-
-        // 소셜 로그인 사용자라면 연결된 AuthProviderAccount 도 제거
-        // 논의점: 해당 회원의 이메일로 연동된 소셜로그인 정보 삭제를 어떻게 처리할지?
-        List<AuthProviderAccount> authProviderAccounts = authProviderAccountRepository.findByUserEmail(user.getEmail());
-        if (!authProviderAccounts.isEmpty()) {
-            authProviderAccountRepository.deleteAll(authProviderAccounts);
-        }
-
-        // 광고 플랫폼 연동(PlatformConnection) 및 함께 연관된 PlatformAccount 제거
-        // 광고 플랫폼 연동 정보 존재 시 예외처리
-        // TODO : 광고 플랫폼 연동 정보 삭제 & 관련된 광고 엔티티 (AdCampaign, AdGroup, AdContent, MetricFact) 삭제 API 추가
+    // 광고 플랫폼 연동 정보 존재 시 탈퇴 불가
+    // TODO : 광고 플랫폼 연동 정보 삭제 & 관련된 광고 엔티티 (Project ,AdCampaign, AdGroup, AdContent, MetricFact) 삭제 로직 추가 필요
+    private void validateNoPlatformConnections(Long userId) {
         List<PlatformConnection> platformConnections = platformConnectionRepository.findByUser_Id(userId);
         if (!platformConnections.isEmpty()) {
             throw new UserHandler(UserErrorCode.USER_HAS_PLATFORM_CONNECTION);
         }
+    }
 
-        // 회원 삭제
-        userRepository.deleteById(userId);
+    // 회원이 owner 인 조직 처리 - 다른 멤버가 있으면 탈퇴 거부, 본인만 있으면 Soft Delete
+    private void handleOrganizationsOwnedByUser(Long userId) {
+        List<OrgMember> orgMembers = orgMemberRepository.findOrgMemberByUserId(userId);
 
-        // 회원 삭제 이후 S3 에서 이미지 삭제 진행
+        for (OrgMember orgMember : orgMembers) {
+            Organization organization = orgMember.getOrganization();
+            if (!Objects.equals(organization.getOwnerUserId(), userId)) {
+                continue;
+            }
+
+            long memberCount = orgMemberRepository.countByOrganizationId(organization.getId());
+            if (memberCount > 1) {
+                // 다른 멤버가 남아있으면 소유권 양도부터 진행해야 함
+                throw new UserHandler(UserErrorCode.USER_OWNS_ORGANIZATION);
+            }
+
+            // 본인만 속한 조직은 OrgService 의 Soft Delete 로직 호출 (조직 연관된 엔티티 정리 포함)
+            orgService.removeOrganizationSoft(userId, organization.getId());
+        }
+    }
+
+    // User 를 참조하는 모든 OrgMember 제거 (Soft Delete 된 조직의 멤버십까지 포함)
+    private void removeAllOrgMembers(User user) {
+        orgMemberRepository.deleteAll(orgMemberRepository.findOrgMemberByUser(user));
+    }
+
+    // 소셜 로그인 연동 계정 제거
+    private void removeAuthProviderAccounts(User user) {
+        List<AuthProviderAccount> authProviderAccounts = authProviderAccountRepository.findByUserEmail(user.getEmail());
+        if (!authProviderAccounts.isEmpty()) {
+            authProviderAccountRepository.deleteAll(authProviderAccounts);
+        }
+    }
+
+    // S3 프로필 이미지 삭제 실패해도 탈퇴 트랜잭션은 정상 종료
+    private void deleteProfileImage(String profileImageUrl) {
+        if (profileImageUrl == null) {
+            return;
+        }
         try {
             s3UploadService.deleteImageFromUrl(profileImageUrl);
         } catch (Exception e) {
-            // 이미지 삭제에 실패하더라도 로그 처리만 하고 탈퇴는 정상 진행
-            log.error("회원 탈퇴 과정에서 S3 이미지 삭제 오류 발생");
+            log.error("회원 탈퇴 과정에서 S3 이미지 삭제 오류 발생", e);
         }
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
@@ -252,7 +252,7 @@ public class UserService {
                 continue;
             }
 
-            long memberCount = orgMemberRepository.countByOrganizationId(organization.getId());
+            int memberCount = orgMemberRepository.countByOrganizationIdAndUserStatus(organization.getId(), UserStatus.ACTIVE);
             if (memberCount > 1) {
                 // 다른 멤버가 남아있으면 소유권 양도부터 진행해야 함
                 throw new UserHandler(UserErrorCode.USER_OWNS_ORGANIZATION);

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
@@ -3,6 +3,7 @@ package com.whereyouad.WhereYouAd.domains.user.domain.service;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMember;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
+import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgRepository;
 import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformConnection;
 import com.whereyouad.WhereYouAd.domains.platform.persistence.repository.PlatformAccountRepository;
 import com.whereyouad.WhereYouAd.domains.platform.persistence.repository.PlatformConnectionRepository;
@@ -46,6 +47,7 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final RedisUtil redisUtil;
     private final S3UploadService s3UploadService;
+    private final OrgRepository orgRepository;
 
     //회원가입 메서드
     public SignUpResponse signUpUser(SignUpRequest request) {
@@ -240,8 +242,8 @@ public class UserService {
             }
         }
 
-        // User 를 참조하는 OrgMember 제거
-        orgMemberRepository.deleteAll(orgMembers);
+        // User 를 참조하는 OrgMember 제거 (Soft Delete 된 조직 멤버십까지 포함)
+        orgMemberRepository.deleteAll(orgMemberRepository.findOrgMemberByUser(user));
 
         // 소셜 로그인 사용자라면 연결된 AuthProviderAccount 도 제거
         // 논의점: 해당 회원의 이메일로 연동된 소셜로그인 정보 삭제를 어떻게 처리할지?

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
@@ -43,7 +43,6 @@ public class UserService {
     private final OrgMemberRepository orgMemberRepository;
     private final AuthProviderAccountRepository authProviderAccountRepository;
     private final PlatformConnectionRepository platformConnectionRepository;
-    private final PlatformAccountRepository platformAccountRepository;
     private final PasswordEncoder passwordEncoder;
     private final RedisUtil redisUtil;
     private final S3UploadService s3UploadService;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
@@ -233,7 +233,6 @@ public class UserService {
     }
 
     // 광고 플랫폼 연동 정보 존재 시 탈퇴 불가
-    // TODO : 광고 플랫폼 연동 정보 삭제 & 관련된 광고 엔티티 (Project ,AdCampaign, AdGroup, AdContent, MetricFact, ClickLog) 삭제 API 추가 필요
     private void validateNoPlatformConnections(Long userId) {
         List<PlatformConnection> platformConnections = platformConnectionRepository.findByUser_Id(userId);
         if (!platformConnections.isEmpty()) {

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
@@ -3,6 +3,10 @@ package com.whereyouad.WhereYouAd.domains.user.domain.service;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMember;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
+import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformAccount;
+import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformConnection;
+import com.whereyouad.WhereYouAd.domains.platform.persistence.repository.PlatformAccountRepository;
+import com.whereyouad.WhereYouAd.domains.platform.persistence.repository.PlatformConnectionRepository;
 import com.whereyouad.WhereYouAd.domains.user.application.dto.request.UserInfoModifyRequest;
 import com.whereyouad.WhereYouAd.domains.user.application.dto.response.MyOrgResponse;
 import com.whereyouad.WhereYouAd.domains.user.application.dto.response.MyPageResponse;
@@ -14,7 +18,9 @@ import com.whereyouad.WhereYouAd.domains.user.domain.constant.UserStatus;
 import com.whereyouad.WhereYouAd.domains.user.application.mapper.UserConverter;
 import com.whereyouad.WhereYouAd.domains.user.application.dto.request.SignUpRequest;
 import com.whereyouad.WhereYouAd.domains.user.application.dto.response.SignUpResponse;
+import com.whereyouad.WhereYouAd.domains.user.persistence.entity.AuthProviderAccount;
 import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
+import com.whereyouad.WhereYouAd.domains.user.persistence.repository.AuthProviderAccountRepository;
 import com.whereyouad.WhereYouAd.domains.user.persistence.repository.UserRepository;
 import com.whereyouad.WhereYouAd.global.utils.RedisUtil;
 import com.whereyouad.WhereYouAd.infrastructure.client.aws.s3.S3UploadService;
@@ -36,6 +42,9 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final OrgMemberRepository orgMemberRepository;
+    private final AuthProviderAccountRepository authProviderAccountRepository;
+    private final PlatformConnectionRepository platformConnectionRepository;
+    private final PlatformAccountRepository platformAccountRepository;
     private final PasswordEncoder passwordEncoder;
     private final RedisUtil redisUtil;
     private final S3UploadService s3UploadService;
@@ -231,6 +240,24 @@ public class UserService {
                 // 회원 수가 1 이면 본인만 속한 조직(별도 회원이 없는 조직) 이므로 Soft Delete 진행
                 organization.softDelete();
             }
+        }
+
+        // User 를 참조하는 OrgMember 제거
+        orgMemberRepository.deleteAll(orgMembers);
+
+        // 소셜 로그인 사용자라면 연결된 AuthProviderAccount 도 제거
+        // 논의점: 해당 회원의 이메일로 연동된 소셜로그인 정보 삭제를 어떻게 처리할지?
+        List<AuthProviderAccount> authProviderAccounts = authProviderAccountRepository.findByUserEmail(user.getEmail());
+        if (!authProviderAccounts.isEmpty()) {
+            authProviderAccountRepository.deleteAll(authProviderAccounts);
+        }
+
+        // 광고 플랫폼 연동(PlatformConnection) 및 함께 연관된 PlatformAccount 제거
+        // 광고 플랫폼 연동 정보 존재 시 예외처리
+        // TODO : 광고 플랫폼 연동 정보 삭제 & 관련된 광고 엔티티 (AdCampaign, AdGroup, AdContent, MetricFact) 삭제 API 추가
+        List<PlatformConnection> platformConnections = platformConnectionRepository.findByUser_Id(userId);
+        if (!platformConnections.isEmpty()) {
+            throw new UserHandler(UserErrorCode.USER_HAS_PLATFORM_CONNECTION);
         }
 
         // 회원 삭제

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/UserService.java
@@ -3,6 +3,7 @@ package com.whereyouad.WhereYouAd.domains.user.domain.service;
 import com.whereyouad.WhereYouAd.domains.organization.domain.service.OrgService;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMember;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
+import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgInvitationRepository;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
 import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformConnection;
 import com.whereyouad.WhereYouAd.domains.platform.persistence.repository.PlatformConnectionRepository;
@@ -20,6 +21,7 @@ import com.whereyouad.WhereYouAd.domains.user.application.dto.response.SignUpRes
 import com.whereyouad.WhereYouAd.domains.user.persistence.entity.AuthProviderAccount;
 import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
 import com.whereyouad.WhereYouAd.domains.user.persistence.repository.AuthProviderAccountRepository;
+import com.whereyouad.WhereYouAd.domains.user.persistence.repository.RefreshTokenRepository;
 import com.whereyouad.WhereYouAd.domains.user.persistence.repository.UserRepository;
 import com.whereyouad.WhereYouAd.global.utils.RedisUtil;
 import com.whereyouad.WhereYouAd.infrastructure.client.aws.s3.S3UploadService;
@@ -43,7 +45,9 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final OrgMemberRepository orgMemberRepository;
+    private final OrgInvitationRepository orgInvitationRepository;
     private final AuthProviderAccountRepository authProviderAccountRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
     private final PlatformConnectionRepository platformConnectionRepository;
     private final OrgService orgService;
     private final PasswordEncoder passwordEncoder;
@@ -217,26 +221,24 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(UserErrorCode.USER_NOT_FOUND));
 
-        // 회원 프로필 이미지 S3 URL 추출
-        String profileImageUrl = user.getProfileImageUrl();
-
         // 1) 검증 단계
         // PlatformConnection 이 연결되어있는가? -> 연결되어 있으면 오류
         // 속한 Organization 중에 "해당 회원이 owner 인데 다른 회원이 멤버로 속한 Organization" 이 존재하는가? -> 존재 시 오류
         validateNoPlatformConnections(userId);
         handleOrganizationsOwnedByUser(userId);
 
-        // 2) 정리 단계 - User 를 참조하는 자식 엔티티 제거
-        removeAllOrgMembers(user);
-        removeAuthProviderAccounts(user);
+        // 2) 즉시 정리 단계
+        // 해당 회원 이메일로 발송된 pending OrgInvitation 정리
+        orgInvitationRepository.deleteByEmail(user.getEmail());
+        // JWT RefreshToken 삭제
+        refreshTokenRepository.deleteById(user.getEmail());
 
-        // 3) 본인 삭제 + 프로필 이미지 삭제
-        userRepository.deleteById(userId);
-        deleteProfileImage(profileImageUrl);
+        // 3) 회원 삭제 -> Soft Delete 상태로 변경, 30일 지날 시 스케줄러에서 Hard Delete
+        user.softDeleteUser();
     }
 
     // 광고 플랫폼 연동 정보 존재 시 탈퇴 불가
-    // TODO : 광고 플랫폼 연동 정보 삭제 & 관련된 광고 엔티티 (Project ,AdCampaign, AdGroup, AdContent, MetricFact) 삭제 로직 추가 필요
+    // TODO : 광고 플랫폼 연동 정보 삭제 & 관련된 광고 엔티티 (Project ,AdCampaign, AdGroup, AdContent, MetricFact, ClickLog) 삭제 API 추가 필요
     private void validateNoPlatformConnections(Long userId) {
         List<PlatformConnection> platformConnections = platformConnectionRepository.findByUser_Id(userId);
         if (!platformConnections.isEmpty()) {
@@ -260,40 +262,10 @@ public class UserService {
                 throw new UserHandler(UserErrorCode.USER_OWNS_ORGANIZATION);
             }
 
-            // 본인만 속한 조직은 OrgService 의 Soft Delete 로직 호출 (조직 연관된 엔티티 정리 포함)
+            // 본인만 속한 조직은 OrgService 의 Soft Delete 로직 호출
+            // 추후 Scheduler 에서 해당 Organization 과 연관 엔티티 한번에 정리
             orgService.removeOrganizationSoft(userId, organization.getId());
         }
     }
 
-    // User 를 참조하는 모든 OrgMember 제거 (Soft Delete 된 조직의 멤버십까지 포함)
-    private void removeAllOrgMembers(User user) {
-        orgMemberRepository.deleteAll(orgMemberRepository.findOrgMemberByUser(user));
-    }
-
-    // 소셜 로그인 연동 계정 제거
-    private void removeAuthProviderAccounts(User user) {
-        List<AuthProviderAccount> authProviderAccounts = authProviderAccountRepository.findByUserEmail(user.getEmail());
-        if (!authProviderAccounts.isEmpty()) {
-            authProviderAccountRepository.deleteAll(authProviderAccounts);
-        }
-    }
-
-    // S3 프로필 이미지 삭제 실패해도 탈퇴 트랜잭션은 정상 종료
-    private void deleteProfileImage(String profileImageUrl) {
-        if (profileImageUrl == null) {
-            return;
-        }
-        
-        // S3 이미지 삭제를 afterCommit 에 수행하도록 수정
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-                try {
-                    s3UploadService.deleteImageFromUrl(profileImageUrl);
-                } catch (Exception e) {
-                    log.error("회원 탈퇴 과정에서 S3 이미지 삭제 오류 발생", e);
-                }
-            }
-        });
-    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/scheduler/UserDeleteExecutor.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/scheduler/UserDeleteExecutor.java
@@ -2,6 +2,8 @@ package com.whereyouad.WhereYouAd.domains.user.domain.service.scheduler;
 
 import com.whereyouad.WhereYouAd.domains.organization.domain.service.OrgService;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
+import com.whereyouad.WhereYouAd.domains.user.exception.code.UserErrorCode;
+import com.whereyouad.WhereYouAd.domains.user.exception.handler.UserHandler;
 import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
 import com.whereyouad.WhereYouAd.domains.user.persistence.repository.AuthProviderAccountRepository;
 import com.whereyouad.WhereYouAd.domains.user.persistence.repository.UserRepository;
@@ -29,8 +31,11 @@ public class UserDeleteExecutor {
     // (3) profileImageUrl S3 이미지 삭제
     // (4) User Hard Delete
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void hardDeleteSingleUser(User user) {
-        // 기존 hardDeleteSingleUser 로직 이동
+    public void hardDeleteSingleUser(Long userId) {
+        // 개선 : User 객체의 JPA 지연로딩 오류 방지를 위한 userId param 사용 & 메서드 내부에서 User 객체 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(UserErrorCode.USER_NOT_FOUND));
+
         orgService.removeOrganizationsOwnedBySoftDeletedUser(user.getId());
         orgMemberRepository.deleteByUserId(user.getId());
         authProviderAccountRepository.deleteByUserId(user.getId());

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/scheduler/UserDeleteExecutor.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/scheduler/UserDeleteExecutor.java
@@ -1,0 +1,48 @@
+package com.whereyouad.WhereYouAd.domains.user.domain.service.scheduler;
+
+import com.whereyouad.WhereYouAd.domains.organization.domain.service.OrgService;
+import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
+import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
+import com.whereyouad.WhereYouAd.domains.user.persistence.repository.AuthProviderAccountRepository;
+import com.whereyouad.WhereYouAd.domains.user.persistence.repository.UserRepository;
+import com.whereyouad.WhereYouAd.infrastructure.client.aws.s3.S3UploadService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserDeleteExecutor {
+
+    private final OrgService orgService;
+    private final OrgMemberRepository orgMemberRepository;
+    private final AuthProviderAccountRepository authProviderAccountRepository;
+    private final UserRepository userRepository;
+    private final S3UploadService s3UploadService;
+
+    // Soft Delete (status = DELETED) 상태이고 deletedAt 으로부터 30일 이상 지난 회원에 대해
+    // (1) 본인이 owner 인 Soft Deleted Organization 과 관련 엔티티 Hard Delete
+    // (2) 본인 소속 OrgMember Hard Delete
+    // (3) profileImageUrl S3 이미지 삭제
+    // (4) User Hard Delete
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void hardDeleteSingleUser(User user) {
+        // 기존 hardDeleteSingleUser 로직 이동
+        orgService.removeOrganizationsOwnedBySoftDeletedUser(user.getId());
+        orgMemberRepository.deleteByUserId(user.getId());
+        authProviderAccountRepository.deleteByUserId(user.getId());
+        userRepository.delete(user);
+
+        String profileImageUrl = user.getProfileImageUrl();
+        if (profileImageUrl != null) {
+            try {
+                s3UploadService.deleteImageFromUrl(profileImageUrl);
+            } catch (Exception e) {
+                log.warn("S3 프로필 이미지 삭제 실패 - userId: {}", user.getId(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/scheduler/UserDeleteScheduler.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/scheduler/UserDeleteScheduler.java
@@ -20,8 +20,8 @@ public class UserDeleteScheduler {
     private final UserRepository userRepository;
     private final UserDeleteExecutor userDeleteExecutor;
 
-    // 매주 토요일 → 일요일로 넘어가는 새벽 2시 (일요일 02:00)
-    @Scheduled(cron = "0 0 2 * * SUN")
+    // 매주 토요일 → 일요일로 넘어가는 새벽 3시 (일요일 03:00)
+    @Scheduled(cron = "0 0 3 * * SUN")
     public void hardDeleteUsers() {
         LocalDate threshold = LocalDate.now().minusDays(SOFT_DELETE_RETENTION_DAYS);
         log.info("Soft Delete 회원 Hard Delete 스케줄러 실행 - threshold: {}", threshold);

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/scheduler/UserDeleteScheduler.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/scheduler/UserDeleteScheduler.java
@@ -31,16 +31,16 @@ public class UserDeleteScheduler {
                 userRepository.findAllByStatusAndDeletedAtBefore(UserStatus.DELETED, threshold);
 
         int successCount = 0;
-        for (User user : targetUsers) {
+        for (Long userId : targetUserIds) {
             try {
-                userDeleteExecutor.hardDeleteSingleUser(user);
+                userDeleteExecutor.hardDeleteSingleUser(userId);
                 successCount++;
             } catch (Exception e) {
-                log.error("회원 Hard Delete 실패 - userId: {}", user.getId(), e);
+                log.error("회원 Hard Delete 실패 - userId: {}", userId, e);
             }
         }
 
         log.info("Soft Delete 회원 Hard Delete 완료 - 대상: {}, 성공: {}",
-                targetUsers.size(), successCount);
+                targetUserIds.size(), successCount);
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/scheduler/UserDeleteScheduler.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/scheduler/UserDeleteScheduler.java
@@ -1,7 +1,6 @@
 package com.whereyouad.WhereYouAd.domains.user.domain.service.scheduler;
 
 import com.whereyouad.WhereYouAd.domains.user.domain.constant.UserStatus;
-import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
 import com.whereyouad.WhereYouAd.domains.user.persistence.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,8 +26,9 @@ public class UserDeleteScheduler {
         LocalDate threshold = LocalDate.now().minusDays(SOFT_DELETE_RETENTION_DAYS);
         log.info("Soft Delete 회원 Hard Delete 스케줄러 실행 - threshold: {}", threshold);
 
-        List<User> targetUsers =
-                userRepository.findAllByStatusAndDeletedAtBefore(UserStatus.DELETED, threshold);
+        // 삭제 대상 User 엔티티의 Id 를 리스트 조회
+        List<Long> targetUserIds =
+                userRepository.findIdsByStatusAndDeletedAtBefore(UserStatus.DELETED, threshold);
 
         int successCount = 0;
         for (Long userId : targetUserIds) {

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/scheduler/UserDeleteScheduler.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/scheduler/UserDeleteScheduler.java
@@ -1,17 +1,12 @@
 package com.whereyouad.WhereYouAd.domains.user.domain.service.scheduler;
 
-import com.whereyouad.WhereYouAd.domains.organization.domain.service.OrgService;
-import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
 import com.whereyouad.WhereYouAd.domains.user.domain.constant.UserStatus;
 import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
-import com.whereyouad.WhereYouAd.domains.user.persistence.repository.AuthProviderAccountRepository;
 import com.whereyouad.WhereYouAd.domains.user.persistence.repository.UserRepository;
-import com.whereyouad.WhereYouAd.infrastructure.client.aws.s3.S3UploadService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -24,20 +19,10 @@ public class UserDeleteScheduler {
     private static final int SOFT_DELETE_RETENTION_DAYS = 30;
 
     private final UserRepository userRepository;
-    private final OrgMemberRepository orgMemberRepository;
-    private final AuthProviderAccountRepository authProviderAccountRepository;
-    private final OrgService orgService;
-    private final S3UploadService s3UploadService;
+    private final UserDeleteExecutor userDeleteExecutor;
 
     // 매주 토요일 → 일요일로 넘어가는 새벽 2시 (일요일 02:00)
-    // Soft Delete (status = DELETED) 상태이고 deletedAt 으로부터 30일 이상 지난 회원에 대해
-    // (1) 본인이 owner 인 Soft Deleted Organization 과 관련 엔티티 Hard Delete
-    // (2) 본인 소속 OrgMember Hard Delete
-    // (3) 본인 소속 AuthProviderAccount Hard Delete
-    // (4) profileImageUrl S3 이미지 삭제
-    // (5) User Hard Delete
     @Scheduled(cron = "0 0 2 * * SUN")
-    @Transactional
     public void hardDeleteUsers() {
         LocalDate threshold = LocalDate.now().minusDays(SOFT_DELETE_RETENTION_DAYS);
         log.info("Soft Delete 회원 Hard Delete 스케줄러 실행 - threshold: {}", threshold);
@@ -48,7 +33,7 @@ public class UserDeleteScheduler {
         int successCount = 0;
         for (User user : targetUsers) {
             try {
-                hardDeleteSingleUser(user);
+                userDeleteExecutor.hardDeleteSingleUser(user);
                 successCount++;
             } catch (Exception e) {
                 log.error("회원 Hard Delete 실패 - userId: {}", user.getId(), e);
@@ -57,33 +42,5 @@ public class UserDeleteScheduler {
 
         log.info("Soft Delete 회원 Hard Delete 완료 - 대상: {}, 성공: {}",
                 targetUsers.size(), successCount);
-    }
-
-    private void hardDeleteSingleUser(User user) {
-        Long userId = user.getId();
-        String profileImageUrl = user.getProfileImageUrl();
-
-        // 본인이 owner 이고 본인만 속한 Soft Deleted 조직 + 부수 데이터(OrgInvitation/Timeline/AIInsightReport) 정리
-        orgService.removeOrganizationsOwnedBySoftDeletedUser(userId);
-
-        // 본인이 속한 OrgMember 전부 제거
-        // 다른 회원이 owner 인 조직에서의 멤버십
-        orgMemberRepository.deleteByUserId(userId);
-
-        // 소셜 로그인 연동 정보 제거
-        authProviderAccountRepository.deleteByUserId(userId);
-
-        // User Hard Delete
-        userRepository.delete(user);
-
-        // 프로필 이미지 S3 삭제
-        if (profileImageUrl != null) {
-            try {
-                s3UploadService.deleteImageFromUrl(profileImageUrl);
-            } catch (Exception e) {
-                log.warn("회원 Hard Delete - S3 프로필 이미지 삭제 실패: userId={}, url={}",
-                        userId, profileImageUrl, e);
-            }
-        }
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/scheduler/UserDeleteScheduler.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/scheduler/UserDeleteScheduler.java
@@ -1,0 +1,89 @@
+package com.whereyouad.WhereYouAd.domains.user.domain.service.scheduler;
+
+import com.whereyouad.WhereYouAd.domains.organization.domain.service.OrgService;
+import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
+import com.whereyouad.WhereYouAd.domains.user.domain.constant.UserStatus;
+import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
+import com.whereyouad.WhereYouAd.domains.user.persistence.repository.AuthProviderAccountRepository;
+import com.whereyouad.WhereYouAd.domains.user.persistence.repository.UserRepository;
+import com.whereyouad.WhereYouAd.infrastructure.client.aws.s3.S3UploadService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserDeleteScheduler {
+
+    private static final int SOFT_DELETE_RETENTION_DAYS = 30;
+
+    private final UserRepository userRepository;
+    private final OrgMemberRepository orgMemberRepository;
+    private final AuthProviderAccountRepository authProviderAccountRepository;
+    private final OrgService orgService;
+    private final S3UploadService s3UploadService;
+
+    // 매주 토요일 → 일요일로 넘어가는 새벽 2시 (일요일 02:00)
+    // Soft Delete (status = DELETED) 상태이고 deletedAt 으로부터 30일 이상 지난 회원에 대해
+    // (1) 본인이 owner 인 Soft Deleted Organization 과 관련 엔티티 Hard Delete
+    // (2) 본인 소속 OrgMember Hard Delete
+    // (3) 본인 소속 AuthProviderAccount Hard Delete
+    // (4) profileImageUrl S3 이미지 삭제
+    // (5) User Hard Delete
+    @Scheduled(cron = "0 0 2 * * SUN")
+    @Transactional
+    public void hardDeleteUsers() {
+        LocalDate threshold = LocalDate.now().minusDays(SOFT_DELETE_RETENTION_DAYS);
+        log.info("Soft Delete 회원 Hard Delete 스케줄러 실행 - threshold: {}", threshold);
+
+        List<User> targetUsers =
+                userRepository.findAllByStatusAndDeletedAtBefore(UserStatus.DELETED, threshold);
+
+        int successCount = 0;
+        for (User user : targetUsers) {
+            try {
+                hardDeleteSingleUser(user);
+                successCount++;
+            } catch (Exception e) {
+                log.error("회원 Hard Delete 실패 - userId: {}", user.getId(), e);
+            }
+        }
+
+        log.info("Soft Delete 회원 Hard Delete 완료 - 대상: {}, 성공: {}",
+                targetUsers.size(), successCount);
+    }
+
+    private void hardDeleteSingleUser(User user) {
+        Long userId = user.getId();
+        String profileImageUrl = user.getProfileImageUrl();
+
+        // 본인이 owner 이고 본인만 속한 Soft Deleted 조직 + 부수 데이터(OrgInvitation/Timeline/AIInsightReport) 정리
+        orgService.removeOrganizationsOwnedBySoftDeletedUser(userId);
+
+        // 본인이 속한 OrgMember 전부 제거
+        // 다른 회원이 owner 인 조직에서의 멤버십
+        orgMemberRepository.deleteByUserId(userId);
+
+        // 소셜 로그인 연동 정보 제거
+        authProviderAccountRepository.deleteByUserId(userId);
+
+        // User Hard Delete
+        userRepository.delete(user);
+
+        // 프로필 이미지 S3 삭제
+        if (profileImageUrl != null) {
+            try {
+                s3UploadService.deleteImageFromUrl(profileImageUrl);
+            } catch (Exception e) {
+                log.warn("회원 Hard Delete - S3 프로필 이미지 삭제 실패: userId={}, url={}",
+                        userId, profileImageUrl, e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/scheduler/UserDeleteScheduler.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/domain/service/scheduler/UserDeleteScheduler.java
@@ -20,8 +20,8 @@ public class UserDeleteScheduler {
     private final UserRepository userRepository;
     private final UserDeleteExecutor userDeleteExecutor;
 
-    // 매주 토요일 → 일요일로 넘어가는 새벽 3시 (일요일 03:00)
-    @Scheduled(cron = "0 0 3 * * SUN")
+    // 매일 새벽 3시
+    @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
     public void hardDeleteUsers() {
         LocalDate threshold = LocalDate.now().minusDays(SOFT_DELETE_RETENTION_DAYS);
         log.info("Soft Delete 회원 Hard Delete 스케줄러 실행 - threshold: {}", threshold);

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/exception/code/UserErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/exception/code/UserErrorCode.java
@@ -17,6 +17,7 @@ public enum UserErrorCode implements BaseErrorCode {
     USER_PASSWORD_NOT_CORRECT(HttpStatus.BAD_REQUEST, "USER_400_6", "비밀번호가 일치하지 않습니다."),
     SOCIAL_USER_PASSWORD_CANNOT_MODIFY(HttpStatus.BAD_REQUEST, "USER_400_7", "소셜 로그인 회원은 비밀번호를 변경할 수 없습니다."),
     USER_OLD_PASSWORD_REQUIRED(HttpStatus.BAD_REQUEST, "USER_400_8", "비밀번호 변경을 위해선 이전 비밀번호 입력이 필요합니다."),
+    USER_OWNS_ORGANIZATION(HttpStatus.BAD_REQUEST, "USER_400_9", "다른 멤버가 속한 조직의 생성자는 탈퇴할 수 없습니다. 소유권을 위임한 뒤 다시 시도해 주세요."),
 
     // 401
     USER_EMAIL_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "USER_401_1", "이메일 인증이 진행되지 않았습니다."),

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/exception/code/UserErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/exception/code/UserErrorCode.java
@@ -18,6 +18,7 @@ public enum UserErrorCode implements BaseErrorCode {
     SOCIAL_USER_PASSWORD_CANNOT_MODIFY(HttpStatus.BAD_REQUEST, "USER_400_7", "소셜 로그인 회원은 비밀번호를 변경할 수 없습니다."),
     USER_OLD_PASSWORD_REQUIRED(HttpStatus.BAD_REQUEST, "USER_400_8", "비밀번호 변경을 위해선 이전 비밀번호 입력이 필요합니다."),
     USER_OWNS_ORGANIZATION(HttpStatus.BAD_REQUEST, "USER_400_9", "다른 멤버가 속한 조직의 생성자는 탈퇴할 수 없습니다. 소유권을 위임한 뒤 다시 시도해 주세요."),
+    USER_HAS_PLATFORM_CONNECTION(HttpStatus.BAD_REQUEST, "USER_400_10", "연동된 광고 플랫폼을 먼저 연동 해제한 뒤 재시도 해주세요."),
 
     // 401
     USER_EMAIL_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "USER_401_1", "이메일 인증이 진행되지 않았습니다."),

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/persistence/entity/User.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/persistence/entity/User.java
@@ -6,6 +6,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
+import java.time.LocalDate;
+
 @Entity
 @Table(name = "users")
 @Getter
@@ -43,6 +45,9 @@ public class User extends BaseEntity {
     @ColumnDefault("'ACTIVE'")  //기본값 ACTIVE
     private UserStatus status;  //ACTIVE, SUSPENDED, DELETED
 
+    @Column(nullable = true, name = "deleted_at")
+    private LocalDate deletedAt;
+
     @Column(name = "current_org_id")
     private Long currentOrgId;
 
@@ -63,5 +68,10 @@ public class User extends BaseEntity {
 
     public void setCurrentOrgId(Long currentOrgId) {
         this.currentOrgId = currentOrgId;
+    }
+
+    public void softDeleteUser() {
+        this.status = UserStatus.DELETED;
+        this.deletedAt = LocalDate.now();
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/persistence/repository/AuthProviderAccountRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/persistence/repository/AuthProviderAccountRepository.java
@@ -2,6 +2,7 @@ package com.whereyouad.WhereYouAd.domains.user.persistence.repository;
 
 import com.whereyouad.WhereYouAd.domains.user.persistence.entity.AuthProviderAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,4 +13,9 @@ public interface AuthProviderAccountRepository extends JpaRepository<AuthProvide
 
     @Query("select apa from AuthProviderAccount apa where apa.user.email = :email")
     List<AuthProviderAccount> findByUserEmail(@Param(value = "email") String email);
+
+    // userId 기준 AuthProviderAccount 일괄 Hard Delete (User Hard Delete 정리용)
+    @Modifying
+    @Query("DELETE FROM AuthProviderAccount apa WHERE apa.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/persistence/repository/UserRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/persistence/repository/UserRepository.java
@@ -22,8 +22,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // 이메일 중복 예외 처리를 위한 이메일로 조회 메서드
     boolean existsByEmail(String email);
 
-    // Soft Delete 후 일정 기간이 지난 회원 조회 (Hard Delete 대상)
-    @Query("SELECT u FROM User u WHERE u.status = :status AND u.deletedAt <= :threshold")
-    List<User> findAllByStatusAndDeletedAtBefore(@Param("status") UserStatus status,
-                                                 @Param("threshold") LocalDate threshold);
+    // Soft Delete 후 일정 기간이 지난 회원의 userId 리스트 조회 (Hard Delete 대상)
+    @Query("SELECT u.id FROM User u WHERE u.status = :status AND u.deletedAt <= :threshold")
+    List<Long> findIdsByStatusAndDeletedAtBefore(@Param("status") UserStatus status, @Param("threshold") LocalDate threshold);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/persistence/repository/UserRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/persistence/repository/UserRepository.java
@@ -1,10 +1,13 @@
 package com.whereyouad.WhereYouAd.domains.user.persistence.repository;
 
+import com.whereyouad.WhereYouAd.domains.user.domain.constant.UserStatus;
 import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -18,4 +21,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // 이메일 중복 예외 처리를 위한 이메일로 조회 메서드
     boolean existsByEmail(String email);
+
+    // Soft Delete 후 일정 기간이 지난 회원 조회 (Hard Delete 대상)
+    @Query("SELECT u FROM User u WHERE u.status = :status AND u.deletedAt <= :threshold")
+    List<User> findAllByStatusAndDeletedAtBefore(@Param("status") UserStatus status,
+                                                 @Param("threshold") LocalDate threshold);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/UserController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/UserController.java
@@ -109,4 +109,14 @@ public class UserController implements UserControllerDocs {
                 DataResponse.from(response)
         );
     }
+
+    @DeleteMapping("/my")
+    public ResponseEntity<DataResponse<String>> deleteUser(
+            @AuthenticationPrincipal(expression = "userId") Long userId
+    )
+    {
+        userService.deleteUser(userId);
+
+        return ResponseEntity.ok(DataResponse.from("탈퇴가 정상적으로 처리되었습니다"));
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/docs/UserControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/docs/UserControllerDocs.java
@@ -121,4 +121,22 @@ public interface UserControllerDocs {
             @RequestPart(value = "request") UserInfoModifyRequest request,
             @RequestPart(value = "image", required = false) MultipartFile image
     );
+
+    @Operation(
+            summary = "회원 탈퇴 API",
+            description = "AccessToken 을 헤더로 받아 현재 로그인한 회원을 탈퇴 처리합니다.\n\n" +
+                    "1. 회원의 프로필 이미지가 S3 에 존재할 경우 함께 삭제됩니다. S3 이미지 삭제에 실패하더라도 회원 탈퇴는 정상적으로 진행되며, 실패한 이미지 URL 은 서버 로그로만 기록됩니다.\n\n" +
+                    "2. 회원이 속한 워크스페이스(Organization) 처리 방식\n\n" +
+                    "- 단순 ADMIN / MEMBER 로만 속해있는 조직 → 해당 가입 정보만 제거됩니다.\n\n" +
+                    "- 회원이 생성자인 조직 → 본인 외 다른 멤버가 없는 경우 조직이 함께 Soft Delete 처리되며, 본인 외 다른 멤버가 존재하는 경우 탈퇴가 차단됩니다. 이 경우 먼저 `PATCH /api/org/{orgId}/changeOwner` API 로 소유권을 위임한 뒤 다시 탈퇴를 시도해야 합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "404_1", description = "USER_404_1 : 해당 사용자 존재하지 않음"),
+            @ApiResponse(responseCode = "400_9", description = "USER_400_9 : 다른 멤버가 속한 조직의 소유자는 탈퇴할 수 없음 (소유권 위임 후 재시도 필요)")
+    })
+    public ResponseEntity<DataResponse<String>> deleteUser(
+            @AuthenticationPrincipal(expression = "userId") Long userId
+    );
+
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/docs/UserControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/docs/UserControllerDocs.java
@@ -125,15 +125,22 @@ public interface UserControllerDocs {
     @Operation(
             summary = "회원 탈퇴 API",
             description = "AccessToken 을 헤더로 받아 현재 로그인한 회원을 탈퇴 처리합니다.\n\n" +
-                    "1. 회원의 프로필 이미지가 S3 에 존재할 경우 함께 삭제됩니다. S3 이미지 삭제에 실패하더라도 회원 탈퇴는 정상적으로 진행되며, 실패한 이미지 URL 은 서버 로그로만 기록됩니다.\n\n" +
-                    "2. 회원이 속한 워크스페이스(Organization) 처리 방식\n\n" +
-                    "- 단순 ADMIN / MEMBER 로만 속해있는 조직 → 해당 가입 정보만 제거됩니다.\n\n" +
-                    "- 회원이 생성자인 조직 → 본인 외 다른 멤버가 없는 경우 조직이 함께 Soft Delete 처리되며, 본인 외 다른 멤버가 존재하는 경우 탈퇴가 차단됩니다. 이 경우 먼저 `PATCH /api/org/{orgId}/changeOwner` API 로 소유권을 위임한 뒤 다시 탈퇴를 시도해야 합니다."
+                    "### 1. 사전 검증 (통과해야 탈퇴 가능)\n" +
+                    "- **광고 플랫폼 연동(PlatformConnection) 존재 여부**: 연동된 광고 플랫폼이 하나라도 남아 있으면 탈퇴가 차단됩니다. 먼저 모든 광고 플랫폼 연동을 해제한 뒤 다시 시도해야 합니다. -> 추후 삭제 API 추가 예정\n\n" +
+                    "- **본인이 소유자인 조직에 다른 멤버 존재**: 본인이 생성자(owner)인 조직에 본인 외 다른 멤버가 남아 있으면 탈퇴가 차단됩니다. `PATCH /api/org/{orgId}/changeOwner` API 로 소유권을 위임한 뒤 재시도해야 합니다.\n\n" +
+                    "### 2. 회원이 속한 워크스페이스(Organization) 처리\n" +
+                    "- **단순 ADMIN / MEMBER 로만 속해있는 조직** → 해당 가입 정보(OrgMember)만 제거됩니다. 조직 자체는 유지됩니다.\n\n" +
+                    "- **회원이 생성자(owner)이고 본인만 속한 조직** → 조직이 Soft Delete 처리되며, 해당 조직의 부수 데이터(보낸 초대장 / 활동 타임라인 / AI 인사이트 리포트)도 함께 정리됩니다. 조직 자체는 복구 가능한 상태(status = DELETED) 로 남습니다.\n\n" +
+                    "### 3. 회원 본인 데이터 정리\n" +
+                    "- 소유자가 아닌채로 속한 조직에서 탈퇴하는 회원 정보가 모두 제거됩니다.\n\n" +
+                    "- 소셜 로그인 사용자의 경우 연결된 소셜계정이 함께 제거됩니다.\n\n" +
+                    "- 회원 본인이 삭제된 후, 프로필 이미지가 S3 에서 삭제됩니다. S3 이미지 삭제 실패는 서버 로그로만 기록됩니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),
             @ApiResponse(responseCode = "404_1", description = "USER_404_1 : 해당 사용자 존재하지 않음"),
-            @ApiResponse(responseCode = "400_9", description = "USER_400_9 : 다른 멤버가 속한 조직의 소유자는 탈퇴할 수 없음 (소유권 위임 후 재시도 필요)")
+            @ApiResponse(responseCode = "400_9", description = "USER_400_9 : 다른 멤버가 속한 조직의 소유자는 탈퇴할 수 없음 (소유권 위임 후 재시도 필요)"),
+            @ApiResponse(responseCode = "400_10", description = "USER_400_10 : 연동된 광고 플랫폼이 존재하여 탈퇴할 수 없음 (모든 연동 해제 후 재시도 필요)")
     })
     public ResponseEntity<DataResponse<String>> deleteUser(
             @AuthenticationPrincipal(expression = "userId") Long userId

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/docs/UserControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/user/presentation/docs/UserControllerDocs.java
@@ -124,17 +124,23 @@ public interface UserControllerDocs {
 
     @Operation(
             summary = "회원 탈퇴 API",
-            description = "AccessToken 을 헤더로 받아 현재 로그인한 회원을 탈퇴 처리합니다.\n\n" +
+            description = "AccessToken 을 헤더로 받아 현재 로그인한 회원을 탈퇴 처리합니다. " +
+                    "Soft Delete 방식이며, 30일 유예 기간 이후 스케줄러가 Hard Delete 를 수행합니다.\n\n" +
                     "### 1. 사전 검증 (통과해야 탈퇴 가능)\n" +
                     "- **광고 플랫폼 연동(PlatformConnection) 존재 여부**: 연동된 광고 플랫폼이 하나라도 남아 있으면 탈퇴가 차단됩니다. 먼저 모든 광고 플랫폼 연동을 해제한 뒤 다시 시도해야 합니다. -> 추후 삭제 API 추가 예정\n\n" +
-                    "- **본인이 소유자인 조직에 다른 멤버 존재**: 본인이 생성자(owner)인 조직에 본인 외 다른 멤버가 남아 있으면 탈퇴가 차단됩니다. `PATCH /api/org/{orgId}/changeOwner` API 로 소유권을 위임한 뒤 재시도해야 합니다.\n\n" +
+                    "- **본인이 소유자인 조직에 다른 ACTIVE 멤버 존재**: 본인이 생성자(owner)인 조직에 본인 외 다른 ACTIVE 멤버가 남아 있으면 탈퇴가 차단됩니다. `PATCH /api/org/{orgId}/changeOwner` API 로 소유권을 위임한 뒤 재시도해야 합니다.\n\n" +
                     "### 2. 회원이 속한 워크스페이스(Organization) 처리\n" +
-                    "- **단순 ADMIN / MEMBER 로만 속해있는 조직** → 해당 가입 정보(OrgMember)만 제거됩니다. 조직 자체는 유지됩니다.\n\n" +
-                    "- **회원이 생성자(owner)이고 본인만 속한 조직** → 조직이 Soft Delete 처리되며, 해당 조직의 부수 데이터(보낸 초대장 / 활동 타임라인 / AI 인사이트 리포트)도 함께 정리됩니다. 조직 자체는 복구 가능한 상태(status = DELETED) 로 남습니다.\n\n" +
-                    "### 3. 회원 본인 데이터 정리\n" +
-                    "- 소유자가 아닌채로 속한 조직에서 탈퇴하는 회원 정보가 모두 제거됩니다.\n\n" +
-                    "- 소셜 로그인 사용자의 경우 연결된 소셜계정이 함께 제거됩니다.\n\n" +
-                    "- 회원 본인이 삭제된 후, 프로필 이미지가 S3 에서 삭제됩니다. S3 이미지 삭제 실패는 서버 로그로만 기록됩니다."
+                    "- **단순 ADMIN / MEMBER 로만 속해있는 조직** → 탈퇴 시점에는 별도 처리 없이 유지됩니다. 이후 Hard Delete 단계에서 일괄 삭제됩니다.\n\n" +
+                    "- **회원이 생성자(owner)이고 본인만 속한 조직** → 조직 status 가 DELETED 로 변경됩니다(Soft Delete). 조직 부수 데이터(보낸 초대장 / 활동 타임라인 / AI 인사이트 리포트 / 조직 로고 S3 이미지) 정리는 회원 Hard Delete 시점에 함께 진행됩니다.\n\n" +
+                    "### 3. 탈퇴 시점 즉시 정리 (Soft Delete)\n" +
+                    "- 회원 본인 이메일로 발송된 Pending 상태 조직 초대장 즉시 삭제.\n\n" +
+                    "- 회원 JWT RefreshToken 즉시 삭제.\n\n" +
+                    "- 회원 status : ACTIVE → DELETED 변경, deletedAt 기록 (Soft Delete).\n\n" +
+                    "### 4. 30일 후 Hard Delete (스케줄러 자동 실행, 매일 3:00 AM KST)\n" +
+                    "- deletedAt 으로부터 30일 경과한 Soft Deleted 회원이 대상입니다.\n\n" +
+                    "- 회원이 owner 인 Soft Deleted 조직과 관련 데이터(워크스페이스 소속 정보 / 활동 타임라인 / AI 인사이트 리포트 / 보낸 초대장 / 조직 로고 S3 이미지) Hard Delete.\n\n" +
+                    "- 회원이 속한 모든 워크스페이스에서 회원이 제외됨.\n\n" +
+                    "- 회원 본인 Hard Delete 후 프로필 이미지 S3 삭제. S3 이미지 삭제 실패는 서버 로그로만 기록됩니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "성공"),


### PR DESCRIPTION
## 📌 관련 이슈
- Close #127 

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

회원 탈퇴 기능과 함께 연관된 엔티티 제거 로직 추가

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- 회원 탈퇴 API 추가
- 관련 엔티티(Organization, AuthProviderAccount, 등) 제거 or 예외 처리 로직 추가

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.

탈퇴 API 테스팅을 위한 회원 가입 진행 (userId=14)
<img width="1052" height="502" alt="최초 회원가입" src="https://github.com/user-attachments/assets/3025ab3b-25c6-48f7-8005-7f5c7cad8d46" />
<br>
 userId=14 인 회원이 조직 생성(owner 가 userId=14 이고 다른 멤버 없는 상태)
<img width="1051" height="383" alt="삭제용 조직 생성" src="https://github.com/user-attachments/assets/806e3351-cc14-4c04-b7c9-17bebff2e09c" />
<img width="668" height="304" alt="조직 DB" src="https://github.com/user-attachments/assets/3348d7f0-8d84-44eb-a248-299accec0622" />
<br>
userId=14 의 조직 가입 상태 (org_id = 10 은 생성자, org_id = 1, 2, 3 은 MEMBER)
<img width="674" height="302" alt="회원 조직 가입 상태(org_id=10 은 생성자, 1,2,3 은 MEMBER)" src="https://github.com/user-attachments/assets/d5328a24-a5b0-46ff-972d-79929ebe9c91" />

<br>
회원 탈퇴 진행 결과 -> 회원 삭제, 조직 Soft Delete, OrgMember 관련 데이터들 모두 삭제
<img width="1048" height="454" alt="회원 탈퇴 진행 결과" src="https://github.com/user-attachments/assets/45154862-c66f-4940-b8dc-4d28495b9879" />
<img width="671" height="239" alt="삭제 후 회원 테이블" src="https://github.com/user-attachments/assets/43993fa7-2b1c-4047-a69c-24aa54c20e59" />
<img width="676" height="333" alt="삭제 후 조직 테이블" src="https://github.com/user-attachments/assets/e1ee3799-b677-40f3-94e8-b04b1c5ed8ca" />
<img width="672" height="305" alt="삭제 후 org_member 테이블" src="https://github.com/user-attachments/assets/f4b1e18d-4706-485b-b0eb-bb0fe3a53878" />

<br><br>
===오류 테스트 (다른 회원이 조직에 속한 경우)===

오류 테스트를 위해 회원, 조직 복구
<img width="672" height="292" alt="오류테스트 - 회원 복구" src="https://github.com/user-attachments/assets/d642a6dd-b207-4fa2-a45d-4d7a913364ff" />
<img width="674" height="284" alt="오류테스트 - 조직 복구" src="https://github.com/user-attachments/assets/eeefd472-2925-4135-b4c2-7a07924beb42" />

<br>
user_id = 3 이 탈퇴하려는 회원이 owner 인 조직에 MEMBER 로 속해있는 상태
<img width="675" height="354" alt="오류테스트 - orgMember userId=3 이 조직의 멤버" src="https://github.com/user-attachments/assets/823c71c2-71f5-478e-8a06-3b0318272921" />

<br>
탈퇴 시도 시 오류
<img width="1054" height="509" alt="다른멤버속한조직오류" src="https://github.com/user-attachments/assets/f1ff2573-bb33-47b0-920c-59c498d07579" />


## ✅ 체크리스트
- [✅] 브랜치 전략(GitHub Flow)을 준수했나요?
- [✅] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [✅] 테스트 통과 확인
- [✅] 서버 실행 확인
- [✅] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- 지금 로직에서는 회원이 속한 조직들 중에서 "회원이 owner 인 조직이 있는데 그 조직에 다른 멤버가 속해있을 경우" 오류가 발생하고, "회원이 연결한 PlatformConnection" 이 존재할 경우 오류가 발생합니다.
- 일단 구현을 하긴 했는데... 회원 탈퇴 외적으로 추가해야할 로직이 몇가지 더 생겨서 그것도 추가 작업으로 진행해야 할 것 같습니다.
- 1. 지금 회원탈퇴 로직에서는 탈퇴하려는 회원과 연관된 PlatformConnection 이 존재할 시 오류를 발생합니다. -> 조직 내에서 PlatformConnection 과 PlatformAccount 를 삭제하는 API 를 추가해야 할 듯 합니다...
- 2. 위 1번에서 PlatformConnection 과 PlatformAccount 을 삭제하면서 연관된 광고 관련 엔티티(Project ,AdCampaign, AdGroup, AdContent, MetricFact) 도 함께 삭제 진행하도록 해야할 것 같습니다.
- 3. 기존 OrgServiceImpl 에서 조직 삭제 진행 시 연관된 광고 엔티티와 PlatformConnection, PlatformAccount 를 같이 제거해주도록 수정해야 할 것 같습니다... 

===의논점===
- 지금 회원 탈퇴를 진행하게 되면 본인 혼자 속한 Organization 에 대해서는 Soft Delete, 나머지 연관된 Timeline, OrgMember, AIInsightReport, OrgInvitation 은 Hard Delete 되는 방식으로 진행했습니다. 추후 위에 1,2 번 API 가 개발되면 PlatformConnection 과 PlatformAccount Hard Delete 유도 -> 사용자가 해당 API 호출해 제거하고 나면 Organization Timeline, OrgMember, AIInsightReport, OrgInvitation 를 Hard Delete 하는 방식을 고려중입니다...
- 생각보다 User 엔티티 관련 연관관계 다뤄야 하는게 많아서 다른 API 개발이랑 엮으려면 오래 걸릴 수 있을 듯 합니다... 일단 이 PR 을 Draft 로 바꾸고 다른 API 완성한뒤에 다시 전환하는 것도 고려중입니다.

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 조직 소유자 양도 API 및 소유자 변경 기능 추가
  * 로그인 사용자의 계정 탈퇴(회원 탈퇴) 엔드포인트 추가
  * 광고 플랫폼 연동 해제(계정 삭제) 엔드포인트 추가
  * 소프트 삭제 후 일정 기간 경과 계정 자동 완전 삭제 스케줄러 추가

* **Behavior Changes**
  * 조직/사용자 삭제 시 초대, 타임라인, AI 인사이트 리포트 등 연관 데이터 일괄 정리 강화
  * 플랫폼 연동 존재 시 삭제 제한 검사 추가
  * 소프트 삭제 처리 흐름 간소화

* **Errors / Messages**
  * 소유자 변경·탈퇴 관련 신규 오류 코드 및 상세 메시지 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhereYouAd/WhereYouAd-Backend/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->