### PR TITLE
Feat/#125 타임라인 내 성과 상태 판별 구현

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/MetricFactRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/MetricFactRepository.java
@@ -60,6 +60,26 @@ public interface MetricFactRepository extends JpaRepository<MetricFact, Long> {
             @Param("status") Status status
             );
 
+    // orgId에 속한 모든 프로젝트의 지표중 해당 MetricFact 가 속한 AdCampaign 지표를 지정된 기간 범위 합산 (status 고려 x)
+    @Query("SELECT " +
+            "COALESCE(SUM(m.impressions), 0) AS totalImpressions, " +
+            "COALESCE(SUM(m.clicks), 0) AS totalClicks, " +
+            "COALESCE(SUM(m.conversions), 0) AS totalConversions, " +
+            "COALESCE(SUM(m.spend), 0) AS totalSpend, " +
+            "COALESCE(SUM(m.revenue), 0) AS totalRevenue " +
+            "FROM MetricFact m " +
+            "JOIN m.project p " +
+            "WHERE p.organization.id = :orgId " +
+            "AND p.organization.status = :orgStatus " +
+            "AND m.timeBucket >= :startDate AND m.timeBucket < :endDate "
+    )
+    MetricSumProjection findMetricsSumByOrgIdAndDateRange(
+            @Param("orgId") Long orgId,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate,
+            @Param("orgStatus") OrgStatus orgStatus
+    );
+
     //orgId 와 provider 가 일치하고 해당 MetricFact 가 속한 AdCampaign 의 status 가 ON_GOING 인 지표에 대해 지정된 기간 범위 합산
     @Query("SELECT " +
             "COALESCE(SUM(m.impressions), 0) AS totalImpressions, " +

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/timeline/domain/service/TimelineServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/timeline/domain/service/TimelineServiceImpl.java
@@ -1,6 +1,8 @@
 package com.whereyouad.WhereYouAd.domains.timeline.domain.service;
 
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.projection.MetricSumProjection;
 import com.whereyouad.WhereYouAd.domains.organization.domain.constant.OrgRole;
+import com.whereyouad.WhereYouAd.domains.organization.domain.constant.OrgStatus;
 import com.whereyouad.WhereYouAd.domains.organization.exception.code.OrgErrorCode;
 import com.whereyouad.WhereYouAd.domains.organization.exception.handler.OrgHandler;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMember;
@@ -18,6 +20,7 @@ import com.whereyouad.WhereYouAd.domains.timeline.exception.TimelineException;
 import com.whereyouad.WhereYouAd.domains.timeline.exception.code.TimelineErrorCode;
 import com.whereyouad.WhereYouAd.domains.timeline.persistence.entity.Timeline;
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Grain;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.MetricFact;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.MetricFactRepository;
 import com.whereyouad.WhereYouAd.domains.timeline.persistence.repository.TimelineRepository;
@@ -72,15 +75,33 @@ public class TimelineServiceImpl implements TimelineService {
                 comparisonDates.end().atTime(LocalTime.MAX),
                 orgId
         );
+
         if (!hasComparisonData) {
             throw new TimelineException(TimelineErrorCode.TIMELINE_NO_COMPARISON_DATA);
         }
 
+        // 현재 기간 및 비교 기간 성과 합계 조회 (Projection 사용)
+        MetricSumProjection currentFacts = metricFactRepository.findMetricsSumByOrgIdAndDateRange(
+                orgId,
+                dto.startDate().atStartOfDay(),
+                dto.endDate().plusDays(1).atStartOfDay(),
+                OrgStatus.ACTIVE,
+                Status.ON_GOING
+        );
+
+        MetricSumProjection pastFacts = metricFactRepository.findMetricsSumByOrgIdAndDateRange(
+                orgId,
+                comparisonDates.start().atStartOfDay(),
+                comparisonDates.end().plusDays(1).atStartOfDay(),
+                OrgStatus.ACTIVE,
+                Status.ON_GOING
+        );
+
         // 입력받은 DTO를 타임라인 엔티티로 변환
         Timeline timeline = TimelineConverter.toTimeline(dto, organization, userId, comparisonDates.start(), comparisonDates.end());
 
-        // PerformanceStatus 계산 및 판별 로직 호출 및 저장
-        PerformanceStatus status = timelineUtil.calculatePerformanceStatus(timeline);
+        // 성과 상태 - PerformanceStatus 계산 및 판별 로직 호출 및 저장 (초안)
+        PerformanceStatus status = timelineUtil.calculatePerformanceStatus(timeline, currentFacts, pastFacts);
         timeline.updatePerformanceStatus(status);
 
         // 엔티티 저장 및 반환
@@ -127,6 +148,23 @@ public class TimelineServiceImpl implements TimelineService {
             throw new TimelineException(TimelineErrorCode.TIMELINE_NO_COMPARISON_DATA);
         }
 
+        // 현재 기간 및 비교 기간 성과 합계 조회 (Projection 사용)
+        MetricSumProjection currentFacts = metricFactRepository.findMetricsSumByOrgIdAndDateRange(
+                orgId,
+                dto.startDate().atStartOfDay(),
+                dto.endDate().plusDays(1).atStartOfDay(),
+                OrgStatus.ACTIVE,
+                Status.ON_GOING
+        );
+
+        MetricSumProjection pastFacts = metricFactRepository.findMetricsSumByOrgIdAndDateRange(
+                orgId,
+                comparisonDates.start().atStartOfDay(),
+                comparisonDates.end().plusDays(1).atStartOfDay(),
+                OrgStatus.ACTIVE,
+                Status.ON_GOING
+        );
+
         // 8. 성과 리스트 -> boolean 플래그 변환
         boolean useClick = dto.metrics().contains(MetricType.CLICK);
         boolean useConversion = dto.metrics().contains(MetricType.CONVERSION);
@@ -141,7 +179,7 @@ public class TimelineServiceImpl implements TimelineService {
         timeline.updateSummary(null);
 
         // 10. PerformanceStatus 재계산
-        PerformanceStatus status = timelineUtil.calculatePerformanceStatus(timeline);
+        PerformanceStatus status = timelineUtil.calculatePerformanceStatus(timeline, currentFacts, pastFacts);
         timeline.updatePerformanceStatus(status);
 
         // 11. 변환 후 반환

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/timeline/domain/service/TimelineServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/timeline/domain/service/TimelineServiceImpl.java
@@ -69,30 +69,25 @@ public class TimelineServiceImpl implements TimelineService {
         // 비교 기준 날짜(지난 주, 지난 달, 지난 년도와 비교)
         ComparisonDateRange comparisonDates = calculateComparisonDates(dto.startDate(), dto.endDate(), dto.comparisonPeriodType());
 
-        // 비교 기간에 성과 데이터가 없으면 타임라인 생성 불가
-        boolean hasComparisonData = metricFactRepository.existsByTimeBucketBetweenAndOrg(
-                comparisonDates.start().atStartOfDay(),
-                comparisonDates.end().atTime(LocalTime.MAX),
-                orgId
-        );
-
-        if (!hasComparisonData) {
-            throw new TimelineException(TimelineErrorCode.TIMELINE_NO_COMPARISON_DATA);
-        }
-
-        // 현재 기간 및 비교 기간 성과 합계 조회 (Projection 사용)
-        MetricSumProjection currentFacts = metricFactRepository.findMetricsSumByOrgIdAndDateRange(
-                orgId,
-                dto.startDate().atStartOfDay(),
-                dto.endDate().plusDays(1).atStartOfDay(),
-                OrgStatus.ACTIVE,
-                Status.ON_GOING
-        );
-
+        // 비교 기간 성과 합계 조회 (Projection 사용)
         MetricSumProjection pastFacts = metricFactRepository.findMetricsSumByOrgIdAndDateRange(
                 orgId,
                 comparisonDates.start().atStartOfDay(),
                 comparisonDates.end().plusDays(1).atStartOfDay(),
+                OrgStatus.ACTIVE,
+                Status.ON_GOING
+        );
+
+        // 비교 기간에 성과 데이터가 없거나 모두 0이면 타임라인 생성 불가
+        if (isProjectionEmpty(pastFacts)) {
+            throw new TimelineException(TimelineErrorCode.TIMELINE_NO_COMPARISON_DATA);
+        }
+
+        // 현재 기간 성과 합계 조회 (Projection 사용)
+        MetricSumProjection currentFacts = metricFactRepository.findMetricsSumByOrgIdAndDateRange(
+                orgId,
+                dto.startDate().atStartOfDay(),
+                dto.endDate().plusDays(1).atStartOfDay(),
                 OrgStatus.ACTIVE,
                 Status.ON_GOING
         );
@@ -138,29 +133,25 @@ public class TimelineServiceImpl implements TimelineService {
         // 6. 비교 기준 날짜 재계산
         ComparisonDateRange comparisonDates = calculateComparisonDates(dto.startDate(), dto.endDate(), dto.comparisonPeriodType());
 
-        // 7. 비교 기간 성과 데이터 존재 검증
-        boolean hasComparisonData = metricFactRepository.existsByTimeBucketBetweenAndOrg(
-                comparisonDates.start().atStartOfDay(),
-                comparisonDates.end().atTime(LocalTime.MAX),
-                orgId
-        );
-        if (!hasComparisonData) {
-            throw new TimelineException(TimelineErrorCode.TIMELINE_NO_COMPARISON_DATA);
-        }
-
-        // 현재 기간 및 비교 기간 성과 합계 조회 (Projection 사용)
-        MetricSumProjection currentFacts = metricFactRepository.findMetricsSumByOrgIdAndDateRange(
-                orgId,
-                dto.startDate().atStartOfDay(),
-                dto.endDate().plusDays(1).atStartOfDay(),
-                OrgStatus.ACTIVE,
-                Status.ON_GOING
-        );
-
+        // 7. 비교 기간 성과 합계 조회 (Projection 사용)
         MetricSumProjection pastFacts = metricFactRepository.findMetricsSumByOrgIdAndDateRange(
                 orgId,
                 comparisonDates.start().atStartOfDay(),
                 comparisonDates.end().plusDays(1).atStartOfDay(),
+                OrgStatus.ACTIVE,
+                Status.ON_GOING
+        );
+
+        // 비교 기간에 성과 데이터가 없거나 모두 0이면 예외 처리
+        if (isProjectionEmpty(pastFacts)) {
+            throw new TimelineException(TimelineErrorCode.TIMELINE_NO_COMPARISON_DATA);
+        }
+
+        // 현재 기간 성과 합계 조회
+        MetricSumProjection currentFacts = metricFactRepository.findMetricsSumByOrgIdAndDateRange(
+                orgId,
+                dto.startDate().atStartOfDay(),
+                dto.endDate().plusDays(1).atStartOfDay(),
                 OrgStatus.ACTIVE,
                 Status.ON_GOING
         );
@@ -388,5 +379,15 @@ public class TimelineServiceImpl implements TimelineService {
             }
             case LAST_YEAR -> new ComparisonDateRange(startDate.minusYears(1), endDate.minusYears(1));
         };
+    }
+
+    // Projection 결과가 비어있는지(또는 모든 수치가 0인지) 확인하는 헬퍼 메서드
+    private boolean isProjectionEmpty(MetricSumProjection projection) {
+        if (projection == null) return true;
+        return (projection.getTotalImpressions() == null || projection.getTotalImpressions() == 0L) &&
+               (projection.getTotalClicks() == null || projection.getTotalClicks() == 0L) &&
+               (projection.getTotalConversions() == null || projection.getTotalConversions() == 0L) &&
+               (projection.getTotalSpend() == null || projection.getTotalSpend().compareTo(BigDecimal.ZERO) == 0) &&
+               (projection.getTotalRevenue() == null || projection.getTotalRevenue().compareTo(BigDecimal.ZERO) == 0);
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/timeline/domain/service/TimelineServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/timeline/domain/service/TimelineServiceImpl.java
@@ -74,8 +74,7 @@ public class TimelineServiceImpl implements TimelineService {
                 orgId,
                 comparisonDates.start().atStartOfDay(),
                 comparisonDates.end().plusDays(1).atStartOfDay(),
-                OrgStatus.ACTIVE,
-                Status.ON_GOING
+                OrgStatus.ACTIVE
         );
 
         // 비교 기간에 성과 데이터가 없거나 모두 0이면 타임라인 생성 불가
@@ -138,8 +137,7 @@ public class TimelineServiceImpl implements TimelineService {
                 orgId,
                 comparisonDates.start().atStartOfDay(),
                 comparisonDates.end().plusDays(1).atStartOfDay(),
-                OrgStatus.ACTIVE,
-                Status.ON_GOING
+                OrgStatus.ACTIVE
         );
 
         // 비교 기간에 성과 데이터가 없거나 모두 0이면 예외 처리

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/timeline/domain/util/TimelineUtil.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/timeline/domain/util/TimelineUtil.java
@@ -1,13 +1,90 @@
 package com.whereyouad.WhereYouAd.domains.timeline.domain.util;
 
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.projection.MetricSumProjection;
 import com.whereyouad.WhereYouAd.domains.timeline.domain.constant.PerformanceStatus;
 import com.whereyouad.WhereYouAd.domains.timeline.persistence.entity.Timeline;
 import org.springframework.stereotype.Component;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 @Component
 public class TimelineUtil {
-    // TODO: PerformanceStatus 판별 로직 추가
-    public PerformanceStatus calculatePerformanceStatus(Timeline timeline) {
-        return null;
+
+    // 성과 상태 판별 로직 초안
+    public PerformanceStatus calculatePerformanceStatus(Timeline timeline, MetricSumProjection currentFacts, MetricSumProjection pastFacts) {
+        
+        // 데이터가 아예 없는 경우 방어 로직 (Projection은 SUM이 없으면 0을 반환하도록 COALESCE 되어있음)
+        if (currentFacts == null || pastFacts == null) {
+            return PerformanceStatus.ON_TRACK;
+        }
+
+        double totalRate = 0.0;
+        int activeMetricCount = 0;
+
+        // 1. 클릭수 비교
+        if (timeline.isUseClick()) {
+            long currentClicks = currentFacts.getTotalClicks() != null ? currentFacts.getTotalClicks() : 0L;
+            long pastClicks = pastFacts.getTotalClicks() != null ? pastFacts.getTotalClicks() : 0L;
+            
+            if (pastClicks > 0) {
+                totalRate += (double) currentClicks / pastClicks;
+                activeMetricCount++;
+            }
+        }
+
+        // 2. 전환수 비교
+        if (timeline.isUseConversion()) {
+            long currentConv = currentFacts.getTotalConversions() != null ? currentFacts.getTotalConversions() : 0L;
+            long pastConv = pastFacts.getTotalConversions() != null ? pastFacts.getTotalConversions() : 0L;
+            
+            if (pastConv > 0) {
+                totalRate += (double) currentConv / pastConv;
+                activeMetricCount++;
+            }
+        }
+
+        // 3. 노출수 비교
+        if (timeline.isUseImpression()) {
+            long currentImp = currentFacts.getTotalImpressions() != null ? currentFacts.getTotalImpressions() : 0L;
+            long pastImp = pastFacts.getTotalImpressions() != null ? pastFacts.getTotalImpressions() : 0L;
+            
+            if (pastImp > 0) {
+                totalRate += (double) currentImp / pastImp;
+                activeMetricCount++;
+            }
+        }
+
+        // 4. ROAS 비교
+        if (timeline.isUseRoas()) {
+            BigDecimal currentSpend = currentFacts.getTotalSpend() != null ? currentFacts.getTotalSpend() : BigDecimal.ZERO;
+            BigDecimal currentRev = currentFacts.getTotalRevenue() != null ? currentFacts.getTotalRevenue() : BigDecimal.ZERO;
+            BigDecimal currentRoas = currentSpend.compareTo(BigDecimal.ZERO) > 0 ? currentRev.divide(currentSpend, 4, RoundingMode.HALF_UP) : BigDecimal.ZERO;
+
+            BigDecimal pastSpend = pastFacts.getTotalSpend() != null ? pastFacts.getTotalSpend() : BigDecimal.ZERO;
+            BigDecimal pastRev = pastFacts.getTotalRevenue() != null ? pastFacts.getTotalRevenue() : BigDecimal.ZERO;
+            BigDecimal pastRoas = pastSpend.compareTo(BigDecimal.ZERO) > 0 ? pastRev.divide(pastSpend, 4, RoundingMode.HALF_UP) : BigDecimal.ZERO;
+
+            if (pastRoas.compareTo(BigDecimal.ZERO) > 0) {
+                totalRate += currentRoas.divide(pastRoas, 4, RoundingMode.HALF_UP).doubleValue();
+                activeMetricCount++;
+            }
+        }
+
+        // 비교할 유효 지표가 없는 경우
+        if (activeMetricCount == 0) {
+            return PerformanceStatus.ON_TRACK;
+        }
+
+        double avgRate = totalRate / activeMetricCount;
+
+        // 초안: 10% 이상 상승하면 ABOVE_AVG, 10% 이상 하락하면 UNDERPERFORM, 그 외 ON_TRACK
+        if (avgRate >= 1.1) {
+            return PerformanceStatus.ABOVE_AVG;
+        } else if (avgRate <= 0.9) {
+            return PerformanceStatus.UNDERPERFORM;
+        } else {
+            return PerformanceStatus.ON_TRACK;
+        }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #125

## 🚀 개요
Timeline 생성 및 수정 시 사용자가 선택한 지표값들에 대해 비교 기준 기간과 비교하여, 성과 상태를 평균 이상/이하인지 판별하는 로직을 구현하였습니다.

## 📄 작업 내용
- Timeline 생성 및 수정 시 PerformaceStatus 반영
- TimelineUtil 내에 클릭수/전환수/노출수/ROAS를 기준 기간과 비교하는 로직 (calculatePerformanceStatus) 구현

## 📸 스크린샷 / 테스트 결과 (선택)
<img width="1038" height="662" alt="image" src="https://github.com/user-attachments/assets/25e25277-9b1e-4da3-b271-d81e2b61e43c" />

> Timeline 생성 api 테스트

<img width="994" height="712" alt="image" src="https://github.com/user-attachments/assets/60b5e21f-f13c-4431-a644-30e07d68d9e2" />

> Timeline 생성 api 테스트 결과


## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
성과 상태 (PerformanceStatus) 판단 시 사용자가 선택한 지표들(ex. 클릭수, ROAS...)에서 전체 평균을 내서 기준 기간(ex. 지난주, 지난달 등..)과 비교해 10% 이상, 이하로 차이가 나는지 확인하도록 하였는데 이 로직이 괜찮을지 확인해주시면 감사하겠습니다!

``` Java
if (avgRate >= 1.1) {
            return PerformanceStatus.ABOVE_AVG;
        } else if (avgRate <= 0.9) {
            return PerformanceStatus.UNDERPERFORM;
        } else {
            return PerformanceStatus.ON_TRACK;
        }
```

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 타임라인 생성/수정 시 현재 및 과거 기간의 집계 성과를 비교해 클릭·전환·노출·ROAS 기준으로 성과 상태를 정확히 재계산하여 반영합니다.
  * 기간별 성과 집계 로직을 확장해 필요한 합계 데이터가 정확히 조회되도록 개선했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhereYouAd/WhereYouAd-Backend/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->