### PR TITLE
Feat/#141 예산 수정 - 네이버 광고 예산 수정 API 구현

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
@@ -1,5 +1,11 @@
 package com.whereyouad.WhereYouAd.domains.advertisement.domain.service;
 
+import com.whereyouad.WhereYouAd.domains.organization.domain.constant.OrgRole;
+import com.whereyouad.WhereYouAd.domains.organization.exception.handler.OrgHandler;
+import com.whereyouad.WhereYouAd.domains.organization.exception.code.OrgErrorCode;
+import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMember;
+import com.whereyouad.WhereYouAd.domains.organization.persistence.repository.OrgMemberRepository;
+import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformConnection;
 import com.whereyouad.WhereYouAd.domains.platform.persistence.repository.PlatformConnectionRepository;
 import com.whereyouad.WhereYouAd.global.utils.AdApiAuthUtil;
 import com.whereyouad.WhereYouAd.global.adapi.dto.AdAuthRequest;
@@ -25,6 +31,7 @@ import java.util.Map;
 public class NaverAdApiService {
 
     private final PlatformConnectionRepository connectionRepository;
+    private final OrgMemberRepository orgMemberRepository;
     private final AdApiAuthUtil adApiAuthUtil;
     private final NaverClient naverClient;
 
@@ -168,7 +175,17 @@ public class NaverAdApiService {
 
     // 캠페인 예산 수정
     @Transactional
-    public NaverDTO.CampaignResponse updateCampaignBudget(Long connectionId, String campaignId, NaverDTO.UpdateCampaignBudgetRequest request) {
+    public NaverDTO.CampaignResponse updateCampaignBudget(Long userId, Long connectionId, String campaignId, NaverDTO.UpdateCampaignBudgetRequest request) {
+
+        // 조직원 및 ADMIN 권한 검증
+        PlatformConnection connection = connectionRepository.findWithAccountAndOrgById(connectionId)
+                .orElseThrow(() -> new AdvertisementHandler(NaverAdErrorCode.NAVER_CAMPAIGN_BUDGET_UPDATE_FAILED));
+        Long orgId = connection.getPlatformAccount().getOrganization().getId();
+        OrgMember orgMember = orgMemberRepository.findByUserIdAndOrgId(userId, orgId)
+                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_MEMBER_NOT_FOUND));
+        if (orgMember.getRole() != OrgRole.ADMIN) {
+            throw new OrgHandler(OrgErrorCode.ORG_MEMBER_FORBIDDEN);
+        }
 
         // 예산이 10의 배수가 아닌 경우 오류(네이버 광고 예산 요청 값 검증)
         if (request.dailyBudget() != null && request.dailyBudget() % 10 != 0) {
@@ -192,7 +209,17 @@ public class NaverAdApiService {
 
     // 광고그룹 예산 수정
     @Transactional
-    public NaverDTO.AdGroupResponse updateAdGroupBudget(Long connectionId, String adgroupId, NaverDTO.UpdateAdGroupBudgetRequest request) {
+    public NaverDTO.AdGroupResponse updateAdGroupBudget(Long userId, Long connectionId, String adgroupId, NaverDTO.UpdateAdGroupBudgetRequest request) {
+
+        // 조직원 및 ADMIN 권한 검증
+        PlatformConnection connection = connectionRepository.findWithAccountAndOrgById(connectionId)
+                .orElseThrow(() -> new AdvertisementHandler(NaverAdErrorCode.NAVER_AD_GROUP_BUDGET_UPDATE_FAILED));
+        Long orgId = connection.getPlatformAccount().getOrganization().getId();
+        OrgMember orgMember = orgMemberRepository.findByUserIdAndOrgId(userId, orgId)
+                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_MEMBER_NOT_FOUND));
+        if (orgMember.getRole() != OrgRole.ADMIN) {
+            throw new OrgHandler(OrgErrorCode.ORG_MEMBER_FORBIDDEN);
+        }
 
         // 예산이 10의 배수가 아닌 경우 오류(네이버 광고 예산 요청 값 검증)
         if (request.dailyBudget() != null && request.dailyBudget() % 10 != 0) {

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
@@ -233,12 +233,17 @@ public class NaverAdApiService {
             // 헤더 제작
             Map<String, String> headers = adApiAuthUtil.generateAuthHeaders(
                     connectionId, AdAuthRequest.forMethodAndPath("PUT", "/ncc/adgroups/" + adgroupId));
-            String fields = request.bidAmt() != null ? "budget,bidAmt" : "budget";
-            // 요청 body 제작
-            NaverDTO.UpdateAdGroupBudgetBody body =
-                    new NaverDTO.UpdateAdGroupBudgetBody(adgroupId, request.useDailyBudget(), request.dailyBudget(), request.bidAmt());
-            // API 호출
-            return naverClient.updateAdGroupBudget(headers, adgroupId, fields, body);
+            // 네이버 API 제약: budget과 bidAmt는 fields에 함께 넣어도 bidAmt가 무시됨 → 각각 별도 호출 필요
+            NaverDTO.AdGroupResponse result = null;
+            if (request.dailyBudget() != null || request.useDailyBudget() != null) {
+                result = naverClient.updateAdGroupBudget(headers, adgroupId, "budget",
+                        new NaverDTO.UpdateAdGroupBudgetBody(adgroupId, request.useDailyBudget(), request.dailyBudget(), null));
+            }
+            if (request.bidAmt() != null) {
+                result = naverClient.updateAdGroupBudget(headers, adgroupId, "bidAmt",
+                        new NaverDTO.UpdateAdGroupBudgetBody(adgroupId, null, null, request.bidAmt()));
+            }
+            return result;
         } catch (Exception e) {
             log.error("[NAVER] 광고그룹 예산 수정 실패 - connectionId={}, adgroupId={}", connectionId, adgroupId, e);
             throw new AdvertisementHandler(NaverAdErrorCode.NAVER_AD_GROUP_BUDGET_UPDATE_FAILED);

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
@@ -176,7 +176,7 @@ public class NaverAdApiService {
     // 캠페인 예산 수정
     public NaverDTO.CampaignResponse updateCampaignBudget(Long userId, Long connectionId, String campaignId, NaverDTO.UpdateCampaignBudgetRequest request) {
         validateAdminOwnership(userId, connectionId);
-        if (request.dailyBudget() != null && request.dailyBudget() % 10 != 0) {
+        if (request.dailyBudget() != null && (request.dailyBudget() <= 0 || request.dailyBudget() % 10 != 0)) {
             throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BUDGET_VALUE);
         }
         try {
@@ -194,10 +194,10 @@ public class NaverAdApiService {
     // 광고그룹 예산 수정
     public NaverDTO.AdGroupResponse updateAdGroupBudget(Long userId, Long connectionId, String adgroupId, NaverDTO.UpdateAdGroupBudgetRequest request) {
         validateAdminOwnership(userId, connectionId);
-        if (request.dailyBudget() != null && request.dailyBudget() % 10 != 0) {
+        if (request.dailyBudget() != null && (request.dailyBudget() <= 0 || request.dailyBudget() % 10 != 0)) {
             throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BUDGET_VALUE);
         }
-        if (request.bidAmt() != null && request.bidAmt() % 10 != 0) {
+        if (request.bidAmt() != null && (request.bidAmt() <= 0 || request.bidAmt() % 10 != 0)) {
             throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BUDGET_VALUE);
         }
         try {

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
@@ -183,8 +183,13 @@ public class NaverAdApiService {
     @Transactional
     public NaverDTO.CampaignResponse updateCampaignBudget(Long userId, Long connectionId, String campaignId, NaverDTO.UpdateCampaignBudgetRequest request) {
         PlatformConnection connection = validateAdminOwnership(userId, connectionId);
-        if (request.dailyBudget() != null && (request.dailyBudget() <= 0 || request.dailyBudget() % 10 != 0)) {
-            throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BUDGET_VALUE);
+        if (request.dailyBudget() != null) {
+            if (request.dailyBudget() % 10 != 0) {
+                throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BUDGET_VALUE);
+            }
+            if (request.dailyBudget() < 50 || request.dailyBudget() > 1_000_000_000) {
+                throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BUDGET_RANGE);
+            }
         }
         try {
             Map<String, String> headers = adApiAuthUtil.generateAuthHeaders(
@@ -208,11 +213,21 @@ public class NaverAdApiService {
     @Transactional
     public NaverDTO.AdGroupResponse updateAdGroupBudget(Long userId, Long connectionId, String adgroupId, NaverDTO.UpdateAdGroupBudgetRequest request) {
         PlatformConnection connection = validateAdminOwnership(userId, connectionId);
-        if (request.dailyBudget() != null && (request.dailyBudget() <= 0 || request.dailyBudget() % 10 != 0)) {
-            throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BUDGET_VALUE);
+        if (request.dailyBudget() != null) {
+            if (request.dailyBudget() % 10 != 0) {
+                throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BUDGET_VALUE);
+            }
+            if (request.dailyBudget() < 50 || request.dailyBudget() > 1_000_000_000) {
+                throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BUDGET_RANGE);
+            }
         }
-        if (request.bidAmt() != null && (request.bidAmt() <= 0 || request.bidAmt() % 10 != 0)) {
-            throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BUDGET_VALUE);
+        if (request.bidAmt() != null) {
+            if (request.bidAmt() % 10 != 0) {
+                throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BUDGET_VALUE);
+            }
+            if (request.bidAmt() < 70 || request.bidAmt() > 100_000) {
+                throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BID_AMOUNT_RANGE);
+            }
         }
         try {
             Map<String, String> headers = adApiAuthUtil.generateAuthHeaders(

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
@@ -1,5 +1,9 @@
 package com.whereyouad.WhereYouAd.domains.advertisement.domain.service;
 
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdCampaign;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdGroup;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdCampaignRepository;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdGroupRepository;
 import com.whereyouad.WhereYouAd.domains.organization.domain.constant.OrgRole;
 import com.whereyouad.WhereYouAd.domains.organization.exception.handler.OrgHandler;
 import com.whereyouad.WhereYouAd.domains.organization.exception.code.OrgErrorCode;
@@ -34,6 +38,8 @@ public class NaverAdApiService {
     private final OrgMemberRepository orgMemberRepository;
     private final AdApiAuthUtil adApiAuthUtil;
     private final NaverClient naverClient;
+    private final AdGroupRepository adGroupRepository;
+    private final AdCampaignRepository adCampaignRepository;
 
     // 캠페인 목록 조회
     @Transactional(readOnly = true)
@@ -174,8 +180,9 @@ public class NaverAdApiService {
     }
 
     // 캠페인 예산 수정
+    @Transactional
     public NaverDTO.CampaignResponse updateCampaignBudget(Long userId, Long connectionId, String campaignId, NaverDTO.UpdateCampaignBudgetRequest request) {
-        validateAdminOwnership(userId, connectionId);
+        PlatformConnection connection = validateAdminOwnership(userId, connectionId);
         if (request.dailyBudget() != null && (request.dailyBudget() <= 0 || request.dailyBudget() % 10 != 0)) {
             throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BUDGET_VALUE);
         }
@@ -184,7 +191,13 @@ public class NaverAdApiService {
                     connectionId, AdAuthRequest.forMethodAndPath("PUT", "/ncc/campaigns/" + campaignId));
             NaverDTO.UpdateCampaignBudgetBody body =
                     new NaverDTO.UpdateCampaignBudgetBody(campaignId, request.useDailyBudget(), request.dailyBudget());
-            return naverClient.updateCampaignBudget(headers, campaignId, "budget", body);
+            NaverDTO.CampaignResponse result = naverClient.updateCampaignBudget(headers, campaignId, "budget", body);
+
+            adCampaignRepository
+                    .findByPlatformAccountAndExternalCampaignId(connection.getPlatformAccount(), campaignId)
+                    .ifPresent(campaign -> campaign.updateBudget(request.dailyBudget()));
+
+            return result;
         } catch (Exception e) {
             log.error("[NAVER] 캠페인 예산 수정 실패 - connectionId={}, campaignId={}", connectionId, campaignId, e);
             throw new AdvertisementHandler(NaverAdErrorCode.NAVER_CAMPAIGN_BUDGET_UPDATE_FAILED);
@@ -192,8 +205,9 @@ public class NaverAdApiService {
     }
 
     // 광고그룹 예산 수정
+    @Transactional
     public NaverDTO.AdGroupResponse updateAdGroupBudget(Long userId, Long connectionId, String adgroupId, NaverDTO.UpdateAdGroupBudgetRequest request) {
-        validateAdminOwnership(userId, connectionId);
+        PlatformConnection connection = validateAdminOwnership(userId, connectionId);
         if (request.dailyBudget() != null && (request.dailyBudget() <= 0 || request.dailyBudget() % 10 != 0)) {
             throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BUDGET_VALUE);
         }
@@ -213,6 +227,11 @@ public class NaverAdApiService {
                 result = naverClient.updateAdGroupBudget(headers, adgroupId, "bidAmt",
                         new NaverDTO.UpdateAdGroupBudgetBody(adgroupId, null, null, request.bidAmt()));
             }
+
+            adGroupRepository
+                    .findByAdCampaign_PlatformAccountAndExternalGroupId(connection.getPlatformAccount(), adgroupId)
+                    .ifPresent(adGroup -> adGroup.updateBudget(request.dailyBudget(), request.bidAmt()));
+
             return result;
         } catch (Exception e) {
             log.error("[NAVER] 광고그룹 예산 수정 실패 - connectionId={}, adgroupId={}", connectionId, adgroupId, e);
@@ -221,7 +240,7 @@ public class NaverAdApiService {
     }
 
     @Transactional(readOnly = true)
-    private void validateAdminOwnership(Long userId, Long connectionId) {
+    private PlatformConnection validateAdminOwnership(Long userId, Long connectionId) {
         PlatformConnection connection = connectionRepository.findWithAccountAndOrgById(connectionId)
                 .orElseThrow(() -> new AdvertisementHandler(NaverAdErrorCode.NAVER_CONNECTION_NOT_FOUND));
         Long orgId = connection.getPlatformAccount().getOrganization().getId();
@@ -230,6 +249,7 @@ public class NaverAdApiService {
         if (orgMember.getRole() != OrgRole.ADMIN) {
             throw new OrgHandler(OrgErrorCode.ORG_MEMBER_FORBIDDEN);
         }
+        return connection;
     }
 
     // 일별 기본 지표 조회 (/stats, 기본 일 단위)

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
@@ -174,32 +174,16 @@ public class NaverAdApiService {
     }
 
     // 캠페인 예산 수정
-    @Transactional
     public NaverDTO.CampaignResponse updateCampaignBudget(Long userId, Long connectionId, String campaignId, NaverDTO.UpdateCampaignBudgetRequest request) {
-
-        // 조직원 및 ADMIN 권한 검증
-        PlatformConnection connection = connectionRepository.findWithAccountAndOrgById(connectionId)
-                .orElseThrow(() -> new AdvertisementHandler(NaverAdErrorCode.NAVER_CAMPAIGN_BUDGET_UPDATE_FAILED));
-        Long orgId = connection.getPlatformAccount().getOrganization().getId();
-        OrgMember orgMember = orgMemberRepository.findByUserIdAndOrgId(userId, orgId)
-                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_MEMBER_NOT_FOUND));
-        if (orgMember.getRole() != OrgRole.ADMIN) {
-            throw new OrgHandler(OrgErrorCode.ORG_MEMBER_FORBIDDEN);
-        }
-
-        // 예산이 10의 배수가 아닌 경우 오류(네이버 광고 예산 요청 값 검증)
+        validateAdminOwnership(userId, connectionId);
         if (request.dailyBudget() != null && request.dailyBudget() % 10 != 0) {
             throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BUDGET_VALUE);
         }
-        // API 호출
         try {
-            // 헤더 제작
             Map<String, String> headers = adApiAuthUtil.generateAuthHeaders(
                     connectionId, AdAuthRequest.forMethodAndPath("PUT", "/ncc/campaigns/" + campaignId));
-            // 요청 body 제작
             NaverDTO.UpdateCampaignBudgetBody body =
                     new NaverDTO.UpdateCampaignBudgetBody(campaignId, request.useDailyBudget(), request.dailyBudget());
-            // API 호출
             return naverClient.updateCampaignBudget(headers, campaignId, "budget", body);
         } catch (Exception e) {
             log.error("[NAVER] 캠페인 예산 수정 실패 - connectionId={}, campaignId={}", connectionId, campaignId, e);
@@ -208,29 +192,15 @@ public class NaverAdApiService {
     }
 
     // 광고그룹 예산 수정
-    @Transactional
     public NaverDTO.AdGroupResponse updateAdGroupBudget(Long userId, Long connectionId, String adgroupId, NaverDTO.UpdateAdGroupBudgetRequest request) {
-
-        // 조직원 및 ADMIN 권한 검증
-        PlatformConnection connection = connectionRepository.findWithAccountAndOrgById(connectionId)
-                .orElseThrow(() -> new AdvertisementHandler(NaverAdErrorCode.NAVER_AD_GROUP_BUDGET_UPDATE_FAILED));
-        Long orgId = connection.getPlatformAccount().getOrganization().getId();
-        OrgMember orgMember = orgMemberRepository.findByUserIdAndOrgId(userId, orgId)
-                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_MEMBER_NOT_FOUND));
-        if (orgMember.getRole() != OrgRole.ADMIN) {
-            throw new OrgHandler(OrgErrorCode.ORG_MEMBER_FORBIDDEN);
-        }
-
-        // 예산이 10의 배수가 아닌 경우 오류(네이버 광고 예산 요청 값 검증)
+        validateAdminOwnership(userId, connectionId);
         if (request.dailyBudget() != null && request.dailyBudget() % 10 != 0) {
             throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BUDGET_VALUE);
         }
         if (request.bidAmt() != null && request.bidAmt() % 10 != 0) {
             throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BUDGET_VALUE);
         }
-        // API 호출
         try {
-            // 헤더 제작
             Map<String, String> headers = adApiAuthUtil.generateAuthHeaders(
                     connectionId, AdAuthRequest.forMethodAndPath("PUT", "/ncc/adgroups/" + adgroupId));
             // 네이버 API 제약: budget과 bidAmt는 fields에 함께 넣어도 bidAmt가 무시됨 → 각각 별도 호출 필요
@@ -247,6 +217,18 @@ public class NaverAdApiService {
         } catch (Exception e) {
             log.error("[NAVER] 광고그룹 예산 수정 실패 - connectionId={}, adgroupId={}", connectionId, adgroupId, e);
             throw new AdvertisementHandler(NaverAdErrorCode.NAVER_AD_GROUP_BUDGET_UPDATE_FAILED);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    private void validateAdminOwnership(Long userId, Long connectionId) {
+        PlatformConnection connection = connectionRepository.findWithAccountAndOrgById(connectionId)
+                .orElseThrow(() -> new AdvertisementHandler(NaverAdErrorCode.NAVER_CONNECTION_NOT_FOUND));
+        Long orgId = connection.getPlatformAccount().getOrganization().getId();
+        OrgMember orgMember = orgMemberRepository.findByUserIdAndOrgId(userId, orgId)
+                .orElseThrow(() -> new OrgHandler(OrgErrorCode.ORG_MEMBER_NOT_FOUND));
+        if (orgMember.getRole() != OrgRole.ADMIN) {
+            throw new OrgHandler(OrgErrorCode.ORG_MEMBER_FORBIDDEN);
         }
     }
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
@@ -166,6 +166,58 @@ public class NaverAdApiService {
         }
     }
 
+    // 캠페인 예산 수정
+    @Transactional
+    public NaverDTO.CampaignResponse updateCampaignBudget(Long connectionId, String campaignId, NaverDTO.UpdateCampaignBudgetRequest request) {
+
+        // 예산이 10의 배수가 아닌 경우 오류(네이버 광고 예산 요청 값 검증)
+        if (request.dailyBudget() != null && request.dailyBudget() % 10 != 0) {
+            throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BUDGET_VALUE);
+        }
+        // API 호출
+        try {
+            // 헤더 제작
+            Map<String, String> headers = adApiAuthUtil.generateAuthHeaders(
+                    connectionId, AdAuthRequest.forMethodAndPath("PUT", "/ncc/campaigns/" + campaignId));
+            // 요청 body 제작
+            NaverDTO.UpdateCampaignBudgetBody body =
+                    new NaverDTO.UpdateCampaignBudgetBody(campaignId, request.useDailyBudget(), request.dailyBudget());
+            // API 호출
+            return naverClient.updateCampaignBudget(headers, campaignId, "budget", body);
+        } catch (Exception e) {
+            log.error("[NAVER] 캠페인 예산 수정 실패 - connectionId={}, campaignId={}", connectionId, campaignId, e);
+            throw new AdvertisementHandler(NaverAdErrorCode.NAVER_CAMPAIGN_BUDGET_UPDATE_FAILED);
+        }
+    }
+
+    // 광고그룹 예산 수정
+    @Transactional
+    public NaverDTO.AdGroupResponse updateAdGroupBudget(Long connectionId, String adgroupId, NaverDTO.UpdateAdGroupBudgetRequest request) {
+
+        // 예산이 10의 배수가 아닌 경우 오류(네이버 광고 예산 요청 값 검증)
+        if (request.dailyBudget() != null && request.dailyBudget() % 10 != 0) {
+            throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BUDGET_VALUE);
+        }
+        if (request.bidAmt() != null && request.bidAmt() % 10 != 0) {
+            throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BUDGET_VALUE);
+        }
+        // API 호출
+        try {
+            // 헤더 제작
+            Map<String, String> headers = adApiAuthUtil.generateAuthHeaders(
+                    connectionId, AdAuthRequest.forMethodAndPath("PUT", "/ncc/adgroups/" + adgroupId));
+            String fields = request.bidAmt() != null ? "budget,bidAmt" : "budget";
+            // 요청 body 제작
+            NaverDTO.UpdateAdGroupBudgetBody body =
+                    new NaverDTO.UpdateAdGroupBudgetBody(adgroupId, request.useDailyBudget(), request.dailyBudget(), request.bidAmt());
+            // API 호출
+            return naverClient.updateAdGroupBudget(headers, adgroupId, fields, body);
+        } catch (Exception e) {
+            log.error("[NAVER] 광고그룹 예산 수정 실패 - connectionId={}, adgroupId={}", connectionId, adgroupId, e);
+            throw new AdvertisementHandler(NaverAdErrorCode.NAVER_AD_GROUP_BUDGET_UPDATE_FAILED);
+        }
+    }
+
     // 일별 기본 지표 조회 (/stats, 기본 일 단위)
     @Transactional(readOnly = true)
     public List<NaverDTO.StatResponse> getDailyStats(Long connectionId, String id, String since, String until) {

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/exception/code/NaverAdErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/exception/code/NaverAdErrorCode.java
@@ -11,7 +11,9 @@ public enum NaverAdErrorCode implements BaseErrorCode {
 
     // 400
     NAVER_INVALID_DOWNLOAD_URL(HttpStatus.BAD_REQUEST, "NAVER_400_1", "유효하지 않은 다운로드 URL입니다."),
-    NAVER_INVALID_BUDGET_VALUE(HttpStatus.BAD_REQUEST, "NAVER_400_2", "예산 및 입찰가는 10의 배수여야 합니다."),
+    NAVER_INVALID_BUDGET_VALUE(HttpStatus.BAD_REQUEST, "NAVER_400_2", "예산 및 입찰가는 10원 단위로 입력해야 합니다."),
+    NAVER_INVALID_BUDGET_RANGE(HttpStatus.BAD_REQUEST, "NAVER_400_3", "예산은 50원 이상 1,000,000,000원 이하로 입력해야 합니다."),
+    NAVER_INVALID_BID_AMOUNT_RANGE(HttpStatus.BAD_REQUEST, "NAVER_400_4", "입찰가는 70원 이상 100,000원 이하로 입력해야 합니다."),
 
     // 404
     NAVER_CONNECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "NAVER_404_1", "플랫폼 연결 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/exception/code/NaverAdErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/exception/code/NaverAdErrorCode.java
@@ -11,6 +11,7 @@ public enum NaverAdErrorCode implements BaseErrorCode {
 
     // 400
     NAVER_INVALID_DOWNLOAD_URL(HttpStatus.BAD_REQUEST, "NAVER_400_1", "유효하지 않은 다운로드 URL입니다."),
+    NAVER_INVALID_BUDGET_VALUE(HttpStatus.BAD_REQUEST, "NAVER_400_2", "예산 및 입찰가는 10의 배수여야 합니다."),
 
     // 500
     NAVER_CAMPAIGN_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "NAVER_500_1", "네이버 캠페인 목록 조회에 실패했습니다."),
@@ -21,6 +22,8 @@ public enum NaverAdErrorCode implements BaseErrorCode {
     NAVER_REPORT_STATUS_CHECK_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "NAVER_500_6", "네이버 성과 보고서 상태 조회에 실패했습니다."),
     NAVER_REPORT_DOWNLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "NAVER_500_7", "네이버 성과 보고서 원문 다운로드에 실패했습니다."),
     NAVER_HOURLY_STAT_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "NAVER_500_8", "네이버 시간대별 통계 조회에 실패했습니다."),
+    NAVER_CAMPAIGN_BUDGET_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "NAVER_500_9", "네이버 캠페인 예산 수정에 실패했습니다."),
+    NAVER_AD_GROUP_BUDGET_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "NAVER_500_10", "네이버 광고 그룹 예산 수정에 실패했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/exception/code/NaverAdErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/exception/code/NaverAdErrorCode.java
@@ -13,6 +13,9 @@ public enum NaverAdErrorCode implements BaseErrorCode {
     NAVER_INVALID_DOWNLOAD_URL(HttpStatus.BAD_REQUEST, "NAVER_400_1", "유효하지 않은 다운로드 URL입니다."),
     NAVER_INVALID_BUDGET_VALUE(HttpStatus.BAD_REQUEST, "NAVER_400_2", "예산 및 입찰가는 10의 배수여야 합니다."),
 
+    // 404
+    NAVER_CONNECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "NAVER_404_1", "플랫폼 연결 정보를 찾을 수 없습니다."),
+
     // 500
     NAVER_CAMPAIGN_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "NAVER_500_1", "네이버 캠페인 목록 조회에 실패했습니다."),
     NAVER_AD_GROUP_FETCH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "NAVER_500_2", "네이버 광고 그룹 목록 조회에 실패했습니다."),

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdCampaign.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdCampaign.java
@@ -94,4 +94,8 @@ public class AdCampaign extends BaseEntity {
             this.description = description;
         }
     }
+
+    public void updateBudget(Long budget) {
+        if (budget != null) this.budget = budget;
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdCampaign.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdCampaign.java
@@ -96,6 +96,6 @@ public class AdCampaign extends BaseEntity {
     }
 
     public void updateBudget(Long budget) {
-        if (budget != null) this.budget = budget;
+        this.budget = budget;
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdGroup.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdGroup.java
@@ -43,6 +43,12 @@ public class AdGroup extends BaseEntity {
     @OneToMany(mappedBy = "adGroup", cascade = CascadeType.ALL)
     private List<AdContent> adContents = new ArrayList<>();
 
+    @Column(name = "budget")
+    private Long budget;
+
+    @Column(name = "bid_amount")
+    private Long bidAmount;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ad_campaign_id")
     private AdCampaign adCampaign;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdGroup.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdGroup.java
@@ -61,4 +61,9 @@ public class AdGroup extends BaseEntity {
             this.targetingInfo = targetingInfo;
         }
     }
+
+    public void updateBudget(Long budget, Long bidAmount) {
+        if (budget != null) this.budget = budget;
+        if (bidAmount != null) this.bidAmount = bidAmount;
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/NaverAdApiController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/NaverAdApiController.java
@@ -10,6 +10,7 @@ import com.whereyouad.WhereYouAd.infrastructure.client.naver.dto.NaverDTO;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -143,22 +144,24 @@ public class NaverAdApiController implements NaverAdApiControllerDocs {
     // 캠페인 예산 수정
     @PutMapping("/campaigns/{campaignId}/budget")
     public ResponseEntity<DataResponse<NaverDTO.CampaignResponse>> updateCampaignBudget(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long connectionId,
             @PathVariable String campaignId,
             @RequestBody NaverDTO.UpdateCampaignBudgetRequest request
     ) {
         return ResponseEntity.ok(DataResponse.from(
-                naverAdApiService.updateCampaignBudget(connectionId, campaignId, request)));
+                naverAdApiService.updateCampaignBudget(userId, connectionId, campaignId, request)));
     }
 
     // 광고그룹 예산 수정
     @PutMapping("/adgroups/{adgroupId}/budget")
     public ResponseEntity<DataResponse<NaverDTO.AdGroupResponse>> updateAdGroupBudget(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long connectionId,
             @PathVariable String adgroupId,
             @RequestBody NaverDTO.UpdateAdGroupBudgetRequest request
     ) {
         return ResponseEntity.ok(DataResponse.from(
-                naverAdApiService.updateAdGroupBudget(connectionId, adgroupId, request)));
+                naverAdApiService.updateAdGroupBudget(userId, connectionId, adgroupId, request)));
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/NaverAdApiController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/NaverAdApiController.java
@@ -139,4 +139,26 @@ public class NaverAdApiController implements NaverAdApiControllerDocs {
     ) {
         return ResponseEntity.ok(DataResponse.from(naverAdSyncService.syncConversionReports(connectionId, statDate)));
     }
+
+    // 캠페인 예산 수정
+    @PutMapping("/campaigns/{campaignId}/budget")
+    public ResponseEntity<DataResponse<NaverDTO.CampaignResponse>> updateCampaignBudget(
+            @PathVariable Long connectionId,
+            @PathVariable String campaignId,
+            @RequestBody NaverDTO.UpdateCampaignBudgetRequest request
+    ) {
+        return ResponseEntity.ok(DataResponse.from(
+                naverAdApiService.updateCampaignBudget(connectionId, campaignId, request)));
+    }
+
+    // 광고그룹 예산 수정
+    @PutMapping("/adgroups/{adgroupId}/budget")
+    public ResponseEntity<DataResponse<NaverDTO.AdGroupResponse>> updateAdGroupBudget(
+            @PathVariable Long connectionId,
+            @PathVariable String adgroupId,
+            @RequestBody NaverDTO.UpdateAdGroupBudgetRequest request
+    ) {
+        return ResponseEntity.ok(DataResponse.from(
+                naverAdApiService.updateAdGroupBudget(connectionId, adgroupId, request)));
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/NaverAdApiControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/NaverAdApiControllerDocs.java
@@ -198,6 +198,7 @@ public interface NaverAdApiControllerDocs {
             @ApiResponse(responseCode = "200", description = "수정된 캠페인 정보 반환"),
             @ApiResponse(responseCode = "400", description = "예산이 10의 배수가 아님"),
             @ApiResponse(responseCode = "403", description = "조직 미가입 또는 ADMIN 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "플랫폼 연결 정보 없음"),
             @ApiResponse(responseCode = "500", description = "네이버 API 호출 실패")
     })
     ResponseEntity<DataResponse<NaverDTO.CampaignResponse>> updateCampaignBudget(
@@ -214,6 +215,7 @@ public interface NaverAdApiControllerDocs {
             @ApiResponse(responseCode = "200", description = "수정된 광고그룹 정보 반환"),
             @ApiResponse(responseCode = "400", description = "예산 또는 입찰가가 10의 배수가 아님"),
             @ApiResponse(responseCode = "403", description = "조직 미가입 또는 ADMIN 권한 없음"),
+            @ApiResponse(responseCode = "404", description = "플랫폼 연결 정보 없음"),
             @ApiResponse(responseCode = "500", description = "네이버 API 호출 실패")
     })
     ResponseEntity<DataResponse<NaverDTO.AdGroupResponse>> updateAdGroupBudget(

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/NaverAdApiControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/NaverAdApiControllerDocs.java
@@ -4,6 +4,7 @@ import com.whereyouad.WhereYouAd.domains.advertisement.application.dto.request.A
 import com.whereyouad.WhereYouAd.domains.advertisement.application.dto.response.AdvertisementResponse;
 import com.whereyouad.WhereYouAd.global.response.DataResponse;
 import com.whereyouad.WhereYouAd.infrastructure.client.naver.dto.NaverDTO;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -17,6 +18,7 @@ import java.util.List;
 
 public interface NaverAdApiControllerDocs {
 
+    @Hidden
     @Operation(summary = "api 통신 test용: 네이버 광고 캠페인 목록 조회", description = "연동된 네이버 광고 계정의 캠페인 목록을 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "캠페인 목록 반환"),
@@ -28,6 +30,7 @@ public interface NaverAdApiControllerDocs {
             @PathVariable Long connectionId
     );
 
+    @Hidden
     @Operation(summary = "api 통신 test용: 네이버 광고 그룹 목록 조회", description = "특정 캠페인의 광고 그룹 목록을 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "광고 그룹 목록 반환"),
@@ -41,6 +44,7 @@ public interface NaverAdApiControllerDocs {
             @RequestParam("nccCampaignId") String nccCampaignId
     );
 
+    @Hidden
     @Operation(summary = "api 통신 test용: 네이버 광고 소재 목록 조회", description = "특정 광고 그룹의 광고 소재 목록을 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "광고 소재 목록 반환"),
@@ -54,6 +58,7 @@ public interface NaverAdApiControllerDocs {
             @RequestParam("nccAdgroupId") String nccAdgroupId
     );
 
+    @Hidden
     @Operation(summary = "api 통신 test용: 네이버 키워드 원문 조회", description = "광고 그룹에 설정된 키워드 목록을 원문으로 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "키워드 목록 반환"),
@@ -66,6 +71,8 @@ public interface NaverAdApiControllerDocs {
             @Parameter(description = "네이버 광고 그룹 ID", required = true)
             @RequestParam("nccAdgroupId") String nccAdgroupId
     );
+
+    @Hidden
     @Operation(summary = "api 통신 test용: 네이버 AD 리포트 생성 요청", description = "특정 일자의 AD 리포트 생성을 네이버에 요청합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "리포트 생성 요청됨(상태 확인 필요)"),
@@ -78,6 +85,7 @@ public interface NaverAdApiControllerDocs {
             @RequestParam("statDt") String statDt
     );
 
+    @Hidden
     @Operation(summary = "api 통신 test용: 네이버 AD_CONVERSION 리포트 생성 요청", description = "특정 일자의 AD_CONVERSION 리포트 생성을 네이버에 요청합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "리포트 생성 요청됨(상태 확인 필요)"),
@@ -90,6 +98,7 @@ public interface NaverAdApiControllerDocs {
             @RequestParam("statDt") String statDt
     );
 
+    @Hidden
     @Operation(summary = "api 통신 test용: 대용량 보고서 상태 조회", description = "생성 요청한 보고서의 상태를 확인합니다. (BUILT 상태가 되면 다운로드 가능)")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "상태 및 다운로드 URL 반환"),
@@ -102,6 +111,7 @@ public interface NaverAdApiControllerDocs {
             @PathVariable String reportJobId
     );
 
+    @Hidden
     @Operation(summary = "api 통신 test용: 대용량 보고서 다운로드", description = "보고서 다운로드 URL을 통해 원문(TSV 등) 데이터를 가져옵니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "보고서 데이터 원문 반환"),
@@ -114,6 +124,7 @@ public interface NaverAdApiControllerDocs {
             @RequestParam("url") String downloadUrl
     );
 
+    @Hidden
     @Operation(summary = "api 통신 test용: 일별 통계 직접 조회", description = "/stats API를 이용하여 특정 대상의 일별 기본 지표를 가져옵니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "일별 통계 반환"),
@@ -130,6 +141,7 @@ public interface NaverAdApiControllerDocs {
             @RequestParam("until") String until
     );
 
+    @Hidden
     @Operation(summary = "api 통신 test용: 네이버 메타데이터 동기화", description = "연동된 네이버 계정의 캠페인/광고그룹/광고소재를 가져와 DB에 upsert합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "동기화 완료 - 처리된 캠페인/그룹/소재 수 반환"),
@@ -153,6 +165,7 @@ public interface NaverAdApiControllerDocs {
             @RequestBody AdvertisementRequest.ManualSyncRequest request
     );
 
+    @Hidden
     @Operation(summary = "api 통신 test용: 네이버 전체 통계 동기화", description = "일별(DAILY) 기본 지표와 전환 리포트를 동기화합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "동기화 완료 - 처리된 광고소재 수 반환"),
@@ -166,6 +179,7 @@ public interface NaverAdApiControllerDocs {
             @RequestParam("statDate") String statDate
     );
 
+    @Hidden
     @Operation(summary = "api 통신 test용: 네이버 전환 리포트만 동기화", description = "전환 데이터만 단독으로 동기화합니다. (기본 Stats 동기화 없이)")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "동기화 완료 - 처리된 전환 행 수 반환"),

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/NaverAdApiControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/NaverAdApiControllerDocs.java
@@ -178,4 +178,30 @@ public interface NaverAdApiControllerDocs {
             @Parameter(description = "통계 대상 날짜 (yyyy-MM-dd, 예: 2026-04-08)", required = true)
             @RequestParam("statDate") String statDate
     );
+
+    @Operation(summary = "네이버 캠페인 예산 수정", description = "캠페인의 일일 예산 및 예산 사용 여부를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정된 캠페인 정보 반환"),
+            @ApiResponse(responseCode = "500", description = "네이버 API 호출 실패")
+    })
+    ResponseEntity<DataResponse<NaverDTO.CampaignResponse>> updateCampaignBudget(
+            @Parameter(description = "네이버 커넥션 ID", example = "1", required = true)
+            @PathVariable Long connectionId,
+            @Parameter(description = "수정할 캠페인 ID", required = true)
+            @PathVariable String campaignId,
+            @RequestBody NaverDTO.UpdateCampaignBudgetRequest request
+    );
+
+    @Operation(summary = "네이버 광고그룹 예산 수정", description = "광고그룹의 일일 예산, 예산 사용 여부, 입찰가를 수정합니다. bidAmt가 null이면 입찰가는 수정하지 않습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정된 광고그룹 정보 반환"),
+            @ApiResponse(responseCode = "500", description = "네이버 API 호출 실패")
+    })
+    ResponseEntity<DataResponse<NaverDTO.AdGroupResponse>> updateAdGroupBudget(
+            @Parameter(description = "네이버 커넥션 ID", example = "1", required = true)
+            @PathVariable Long connectionId,
+            @Parameter(description = "수정할 광고그룹 ID", required = true)
+            @PathVariable String adgroupId,
+            @RequestBody NaverDTO.UpdateAdGroupBudgetRequest request
+    );
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/NaverAdApiControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/NaverAdApiControllerDocs.java
@@ -182,6 +182,7 @@ public interface NaverAdApiControllerDocs {
     @Operation(summary = "네이버 캠페인 예산 수정", description = "캠페인의 일일 예산 및 예산 사용 여부를 수정합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "수정된 캠페인 정보 반환"),
+            @ApiResponse(responseCode = "400", description = "예산이 10의 배수가 아님"),
             @ApiResponse(responseCode = "500", description = "네이버 API 호출 실패")
     })
     ResponseEntity<DataResponse<NaverDTO.CampaignResponse>> updateCampaignBudget(
@@ -195,6 +196,7 @@ public interface NaverAdApiControllerDocs {
     @Operation(summary = "네이버 광고그룹 예산 수정", description = "광고그룹의 일일 예산, 예산 사용 여부, 입찰가를 수정합니다. bidAmt가 null이면 입찰가는 수정하지 않습니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "수정된 광고그룹 정보 반환"),
+            @ApiResponse(responseCode = "400", description = "예산 또는 입찰가가 10의 배수가 아님"),
             @ApiResponse(responseCode = "500", description = "네이버 API 호출 실패")
     })
     ResponseEntity<DataResponse<NaverDTO.AdGroupResponse>> updateAdGroupBudget(

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/NaverAdApiControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/NaverAdApiControllerDocs.java
@@ -197,9 +197,11 @@ public interface NaverAdApiControllerDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "수정된 캠페인 정보 반환"),
             @ApiResponse(responseCode = "400", description = "예산이 10의 배수가 아님"),
+            @ApiResponse(responseCode = "403", description = "조직 미가입 또는 ADMIN 권한 없음"),
             @ApiResponse(responseCode = "500", description = "네이버 API 호출 실패")
     })
     ResponseEntity<DataResponse<NaverDTO.CampaignResponse>> updateCampaignBudget(
+            @Parameter(hidden = true) Long userId,
             @Parameter(description = "네이버 커넥션 ID", example = "1", required = true)
             @PathVariable Long connectionId,
             @Parameter(description = "수정할 캠페인 ID", required = true)
@@ -211,9 +213,11 @@ public interface NaverAdApiControllerDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "수정된 광고그룹 정보 반환"),
             @ApiResponse(responseCode = "400", description = "예산 또는 입찰가가 10의 배수가 아님"),
+            @ApiResponse(responseCode = "403", description = "조직 미가입 또는 ADMIN 권한 없음"),
             @ApiResponse(responseCode = "500", description = "네이버 API 호출 실패")
     })
     ResponseEntity<DataResponse<NaverDTO.AdGroupResponse>> updateAdGroupBudget(
+            @Parameter(hidden = true) Long userId,
             @Parameter(description = "네이버 커넥션 ID", example = "1", required = true)
             @PathVariable Long connectionId,
             @Parameter(description = "수정할 광고그룹 ID", required = true)

--- a/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/naver/client/NaverClient.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/naver/client/NaverClient.java
@@ -5,6 +5,7 @@ import feign.Response;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -76,5 +77,23 @@ public interface NaverClient {
     @GetMapping
     Response downloadStatReport(
             @RequestHeader Map<String, String> headers, URI baseUri
+    );
+
+    // 캠페인 예산 수정
+    @PutMapping("/ncc/campaigns/{campaignId}")
+    NaverDTO.CampaignResponse updateCampaignBudget(
+            @RequestHeader Map<String, String> headers,
+            @PathVariable("campaignId") String campaignId,
+            @RequestParam("fields") String fields,
+            @RequestBody NaverDTO.UpdateCampaignBudgetBody body
+    );
+
+    // 광고그룹 예산 수정
+    @PutMapping("/ncc/adgroups/{adgroupId}")
+    NaverDTO.AdGroupResponse updateAdGroupBudget(
+            @RequestHeader Map<String, String> headers,
+            @PathVariable("adgroupId") String adgroupId,
+            @RequestParam("fields") String fields,
+            @RequestBody NaverDTO.UpdateAdGroupBudgetBody body
     );
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/naver/converter/NaverConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/naver/converter/NaverConverter.java
@@ -60,6 +60,8 @@ public class NaverConverter {
                 .targetingInfo(extractTargetingInfo(keywords))
                 .status(mapToDomainStatus(dto.status()))
                 .adCampaign(campaign)
+                .budget(dto.useDailyBudget() != null && dto.useDailyBudget() ? dto.dailyBudget() : null)
+                .bidAmount(dto.bidAmt())
                 .build();
     }
 
@@ -69,6 +71,10 @@ public class NaverConverter {
                 dto.name(),
                 mapToDomainStatus(dto.status()),
                 extractTargetingInfo(keywords)
+        );
+        entity.updateBudget(
+                dto.useDailyBudget() != null && dto.useDailyBudget() ? dto.dailyBudget() : null,
+                dto.bidAmt()
         );
     }
 

--- a/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/naver/dto/NaverDTO.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/naver/dto/NaverDTO.java
@@ -133,4 +133,32 @@ public class NaverDTO {
             String reportTp,
             String statDt
     ) {}
+
+    // 캠페인 예산 수정 요청 (컨트롤러 입력용, ID X)
+    public record UpdateCampaignBudgetRequest(
+            Boolean useDailyBudget,
+            Long dailyBudget
+    ) {}
+
+    // 캠페인 예산 수정 body (네이버 API 전송용, ID O)
+    public record UpdateCampaignBudgetBody(
+            String nccCampaignId,
+            Boolean useDailyBudget,
+            Long dailyBudget
+    ) {}
+
+    // 광고그룹 예산 수정 요청 (컨트롤러 입력용, ID X)
+    public record UpdateAdGroupBudgetRequest(
+            Boolean useDailyBudget,
+            Long dailyBudget,
+            Long bidAmt
+    ) {}
+
+    // 광고그룹 예산 수정 body (네이버 API 전송용, ID O)
+    public record UpdateAdGroupBudgetBody(
+            String nccAdgroupId,
+            Boolean useDailyBudget,
+            Long dailyBudget,
+            Long bidAmt
+    ) {}
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #141

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

네이버 광고 예산 수정 API를 이용하여 캠페인 or 광고 그룹에 할당된 예산을 수정합니다.
## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- NaverClient 네이버 광고 예산 수정 엔드포인트 추가
- 요청 DTO 추가 및 입력값 검증(예산은 10의 배수)
- 서비스 로직 구현(조직원 및 권한 검증 -> 예산 값 검증 -> 헤더 제작 -> body 제작 -> 네이버 광고 API 호출 및 결과 반환)

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.
- 수정 전 예산 상태(캠페인, 하루 예산: 60원)
<img width="1338" height="129" alt="image" src="https://github.com/user-attachments/assets/ec2e243c-b425-4cc0-8519-f96a53413812" />
<img width="1475" height="217" alt="image" src="https://github.com/user-attachments/assets/3b09fe8b-ff1e-4e3a-a62b-91c1caba7b8c" />

- 캠페인 예산 수정 요청 (하루 예산: 80원으로 수정 요청)
<img width="1607" height="977" alt="image" src="https://github.com/user-attachments/assets/29b44507-029c-4b74-ac25-a60ffba8b96f" />
- 응답 결과
<img width="1598" height="548" alt="image" src="https://github.com/user-attachments/assets/944d0110-0dd4-4e2a-90ee-01837e535236" />
<img width="1469" height="212" alt="image" src="https://github.com/user-attachments/assets/1138f344-bd88-4c24-9784-acb481eb740e" />

- 광고 그룹 예산 상태(기본 입찰가: 70원, 하루 예산 50원)
<img width="1492" height="745" alt="image" src="https://github.com/user-attachments/assets/901f0bf2-59eb-4019-9fc3-b7ed8dd2a848" />

- 광고 그룹 예산 수정 요청(기본 입찰가: 90원, 하루 예산 80원으로 수정 요청)
<img width="1614" height="979" alt="image" src="https://github.com/user-attachments/assets/2049de9c-f3b3-469a-8d51-08798f0489aa" />

- 응답 결과
<img width="1588" height="400" alt="image" src="https://github.com/user-attachments/assets/94c49585-26d1-42c0-ba7a-1c33bfae2cbe" />
<img width="1462" height="618" alt="image" src="https://github.com/user-attachments/assets/a5e3077b-963f-42a6-a871-246398277e01" />

- 하루 예산 (dailyBudget)                                                                                                                                                           
하루 동안 광고에 쓸 수 있는 최대 금액. 이 금액을 다 쓰면 그날 광고가 자동으로 멈춤.
                                                                                                                                                                                    
- 기본 입찰가 (bidAmt)
광고 클릭 1번에 최대 얼마까지 지불할 의향이 있는지 설정하는 금액. 경쟁 광고주보다 입찰가가 높을수록 더 좋은 위치에 광고가 노출됨. 



## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- (예: 이 로직이 최선일까요? P2)
- (예: 예외 처리 누락 여부 확인 부탁드립니다. P1)

- Ad-Group쪽에는 광고 예산을 저장하는 필드가 없는 걸로 아는데 추가하는 편이 괜찮을까요? 그리고 추가한다면 하루 예산이랑 기본 입찰가 2개다 추가하는 것이 괜찮을까요..? 제 생각에는 둘 다 수정가능한 값이라 둘 다 저장하는 것이 괜찮을 것 같습니다..! 그리고 저희 서비스 내부에서 수정한 값에 대해서 budget_update_at같은 필드를 또 추가해서 예산 수정 시점을 반환하는 것도 괜찮을 것 같습니다..!

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 네이버 캠페인 일일 예산 수정 기능 추가
  * 네이버 광고그룹 일일 예산 및 입찰가 수정 기능 추가
  * 캠페인/광고그룹 예산·입찰가 입력값 유효성 검증(10배수 및 허용 범위) 강화
* **Security / Access**
  * 연결된 조직에 대해 관리자 권한 검증을 적용해 요청을 제어
* **Documentation**
  * 관련 API 문서(캠페인/광고그룹 예산 수정) 추가 및 노출 방식 조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->