### PR TITLE
Feat/#143 응답 통일 - GlobalExceptionHandler 구체화

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/global/exception/AppException.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/exception/AppException.java
@@ -2,13 +2,22 @@ package com.whereyouad.WhereYouAd.global.exception;
 
 import lombok.Getter;
 
+import java.util.Map;
+
 @Getter
 public class AppException extends RuntimeException {
 
     private final BaseErrorCode errorCode;
+    private final Map<String, String> bind;
 
     public AppException(BaseErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
+        this.bind = null;
+    }
+
+    public AppException(BaseErrorCode errorCode, Map<String, String> bind) {
+        this.errorCode = errorCode;
+        this.bind = bind;
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/global/exception/AppException.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/exception/AppException.java
@@ -17,6 +17,7 @@ public class AppException extends RuntimeException {
     }
 
     public AppException(BaseErrorCode errorCode, Map<String, String> bind) {
+        super(errorCode.getMessage());
         this.errorCode = errorCode;
         this.bind = bind;
     }

--- a/src/main/java/com/whereyouad/WhereYouAd/global/exception/ErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/exception/ErrorCode.java
@@ -13,14 +13,16 @@ public enum ErrorCode implements BaseErrorCode{
     // 400
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.", "COMMON_400_1"),
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 잘못되었습니다.", "COMMON_400_2"),
-    NOT_SUPPORT_HTTP_METHOD(HttpStatus.BAD_REQUEST, "잘못된 HTTP 메서드 입니다.", "COMMON_400_3"),
-    JSON_PARSE_FAIL(HttpStatus.BAD_REQUEST, "JSON 파싱에 실패했습니다. Request body를 확인해주세요", "COMMON_400_4"),
-    PARAMETER_MISMATCH(HttpStatus.BAD_REQUEST, "쿼리 파라미터 타입이 맞지 않습니다.", "COMMON_400_5"),
+    JSON_PARSE_FAIL(HttpStatus.BAD_REQUEST, "JSON 파싱에 실패했습니다. Request body를 확인해주세요", "COMMON_400_3"),
+    PARAMETER_MISMATCH(HttpStatus.BAD_REQUEST, "쿼리 파라미터 타입이 맞지 않습니다.", "COMMON_400_4"),
 
     // 404
     NOT_FOUND(HttpStatus.NOT_FOUND, "찾을 수 없습니다.", "COMMON_404_1"),
     NOT_FOUND_REQUEST_BODY(HttpStatus.NOT_FOUND, "Request body가 없습니다.", "COMMON_404_2"),
     NOT_FOUND_URI(HttpStatus.NOT_FOUND, "존재하지 않는 URI입니다.", "COMMON_404_3"),
+
+    // 405
+    NOT_SUPPORT_HTTP_METHOD(HttpStatus.METHOD_NOT_ALLOWED, "잘못된 HTTP 메서드 입니다.", "COMMON_405_1"),
 
     // 415
     NOT_SUPPORT_CONTENT_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 Content-Type 입니다.", "COMMON_415_1"),

--- a/src/main/java/com/whereyouad/WhereYouAd/global/exception/ErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/exception/ErrorCode.java
@@ -14,9 +14,12 @@ public enum ErrorCode implements BaseErrorCode{
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.", "COMMON-001"),
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 잘못되었습니다.", "COMMON-002"),
     NOT_FOUND(HttpStatus.NOT_FOUND, "찾을 수 없습니다.", "COMMON-003"),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.", "COMMON_400_1"),
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 잘못되었습니다.", "COMMON_400_2"),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "찾을 수 없습니다.", "COMMON_404_1"),
 
-    //500
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 에러가 발생하였습니다.", "COMMON-004"),
+    // 500
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 에러가 발생하였습니다.", "COMMON_500_1"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/whereyouad/WhereYouAd/global/exception/ErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/exception/ErrorCode.java
@@ -15,11 +15,11 @@ public enum ErrorCode implements BaseErrorCode{
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 잘못되었습니다.", "COMMON_400_2"),
     JSON_PARSE_FAIL(HttpStatus.BAD_REQUEST, "JSON 파싱에 실패했습니다. Request body를 확인해주세요", "COMMON_400_3"),
     PARAMETER_MISMATCH(HttpStatus.BAD_REQUEST, "쿼리 파라미터 타입이 맞지 않습니다.", "COMMON_400_4"),
+    NOT_FOUND_REQUEST_BODY(HttpStatus.BAD_REQUEST, "Request body가 없습니다.", "COMMON_400_5"),
 
     // 404
     NOT_FOUND(HttpStatus.NOT_FOUND, "찾을 수 없습니다.", "COMMON_404_1"),
-    NOT_FOUND_REQUEST_BODY(HttpStatus.NOT_FOUND, "Request body가 없습니다.", "COMMON_404_2"),
-    NOT_FOUND_URI(HttpStatus.NOT_FOUND, "존재하지 않는 URI입니다.", "COMMON_404_3"),
+    NOT_FOUND_URI(HttpStatus.NOT_FOUND, "존재하지 않는 URI입니다.", "COMMON_404_2"),
 
     // 405
     NOT_SUPPORT_HTTP_METHOD(HttpStatus.METHOD_NOT_ALLOWED, "잘못된 HTTP 메서드 입니다.", "COMMON_405_1"),

--- a/src/main/java/com/whereyouad/WhereYouAd/global/exception/ErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/exception/ErrorCode.java
@@ -10,13 +10,20 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode implements BaseErrorCode{
 
-    //400
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.", "COMMON-001"),
-    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 잘못되었습니다.", "COMMON-002"),
-    NOT_FOUND(HttpStatus.NOT_FOUND, "찾을 수 없습니다.", "COMMON-003"),
+    // 400
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.", "COMMON_400_1"),
     INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "요청 파라미터가 잘못되었습니다.", "COMMON_400_2"),
+    NOT_SUPPORT_HTTP_METHOD(HttpStatus.BAD_REQUEST, "잘못된 HTTP 메서드 입니다.", "COMMON_400_3"),
+    JSON_PARSE_FAIL(HttpStatus.BAD_REQUEST, "JSON 파싱에 실패했습니다. Request body를 확인해주세요", "COMMON_400_4"),
+    PARAMETER_MISMATCH(HttpStatus.BAD_REQUEST, "쿼리 파라미터 타입이 맞지 않습니다.", "COMMON_400_5"),
+
+    // 404
     NOT_FOUND(HttpStatus.NOT_FOUND, "찾을 수 없습니다.", "COMMON_404_1"),
+    NOT_FOUND_REQUEST_BODY(HttpStatus.NOT_FOUND, "Request body가 없습니다.", "COMMON_404_2"),
+    NOT_FOUND_URI(HttpStatus.NOT_FOUND, "존재하지 않는 URI입니다.", "COMMON_404_3"),
+
+    // 415
+    NOT_SUPPORT_CONTENT_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 Content-Type 입니다.", "COMMON_415_1"),
 
     // 500
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 에러가 발생하였습니다.", "COMMON_500_1"),

--- a/src/main/java/com/whereyouad/WhereYouAd/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/exception/GlobalExceptionHandler.java
@@ -16,15 +16,37 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    // NPE — 주로 DTO 검증 누락이나 비즈니스 로직에서 발생
+    @ExceptionHandler(NullPointerException.class)
+    public ResponseEntity<ErrorResponse> handleNullPointerException(NullPointerException e, HttpServletRequest request) {
+        log.error("NullPointerException 발생 — 파일: {}, 라인: {}",
+                e.getStackTrace()[0].getFileName(), e.getStackTrace()[0].getLineNumber());
+        log.error("에러가 발생한 지점 {}, {}", request.getMethod(), request.getRequestURI());
+
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR, request));
+    }
 
     // 처리되지 않은 모든 예외를 잡는 핸들러
     @ExceptionHandler(Exception.class)
@@ -44,7 +66,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleAppCustomException(AppException e, HttpServletRequest request) {
         log.error("AppException 발생: {}", e.getErrorCode().getMessage());
         log.error("에러가 발생한 지점 {}, {}", request.getMethod(), request.getRequestURI());
-        ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode(), request);
+        ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode(), request, e.getBind());
         return ResponseEntity
                 .status(e.getErrorCode().getHttpStatus())
                 .body(errorResponse);
@@ -53,17 +75,20 @@ public class GlobalExceptionHandler {
     //@Valid 검사 실패(필수 파라미터가 null 또는 공백) 인 경우 예외를 잡는 핸들러
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleNotValidException(MethodArgumentNotValidException e, HttpServletRequest request) {
-        // 예시 결과: "email: 이메일 형식이 아닙니다, password: 비밀번호는 필수입니다"
-        String errorMessage = e.getBindingResult().getFieldErrors().stream()
-                .map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
-                .collect(Collectors.joining(", "));
+        Map<String, String> errors = e.getBindingResult().getFieldErrors().stream()
+                .collect(Collectors.toMap(
+                        fieldError -> fieldError.getField(),
+                        fieldError -> fieldError.getDefaultMessage(),
+                        (existing, duplicate) -> existing
+                ));
 
-        log.error("MethodArgumentNotValidException 발생: {}", errorMessage);
+        log.error("MethodArgumentNotValidException 발생: {}", errors);
         log.error("에러가 발생한 지점 {}, {}", request.getMethod(), request.getRequestURI());
 
         ErrorResponse errorResponse = ErrorResponse.of(
                 ErrorCode.INVALID_PARAMETER,
-                request
+                request,
+                errors
         );
 
         return ResponseEntity
@@ -161,13 +186,181 @@ public class GlobalExceptionHandler {
         }
 
         // Enum 변환 실패가 아닌 일반적인 타입 매스매치(예: Long 타입에 문자열 입력)인 경우
+        Map<String, String> errors = new HashMap<>();
+        errors.put(e.getName(), e.getValue() != null ? e.getValue().toString() : "null");
+
         ErrorResponse errorResponse = ErrorResponse.of(
-                ErrorCode.INVALID_PARAMETER,
-                request
+                ErrorCode.PARAMETER_MISMATCH,
+                request,
+                errors
         );
 
         return ResponseEntity
-                .status(ErrorCode.INVALID_PARAMETER.getHttpStatus())
+                .status(ErrorCode.PARAMETER_MISMATCH.getHttpStatus())
                 .body(errorResponse);
+    }
+
+    // @Valid 쿼리 파라미터 유효성 검사 실패
+    @ExceptionHandler(HandlerMethodValidationException.class)
+    public ResponseEntity<ErrorResponse> handleHandlerMethodValidationException(
+            HandlerMethodValidationException e,
+            HttpServletRequest request
+    ) {
+
+        Map<String, String> errors = new HashMap<>();
+        e.getParameterValidationResults().forEach(result ->
+                errors.put(
+                        result.getMethodParameter().getParameterName(),
+                        result.getResolvableErrors().get(0).getDefaultMessage()
+                )
+        );
+
+        log.error("HandlerMethodValidationException 발생: {}", errors);
+        log.error("에러가 발생한 지점 {}, {}", request.getMethod(), request.getRequestURI());
+
+        ErrorResponse errorResponse = ErrorResponse.of(
+                ErrorCode.INVALID_PARAMETER,
+                request,
+                errors
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(errorResponse);
+    }
+
+    // 필수 @RequestParam 누락
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(
+            MissingServletRequestParameterException e,
+            HttpServletRequest request
+    ) {
+
+        Map<String, String> errors = new HashMap<>();
+        errors.put(e.getParameterName(), "필수 파라미터입니다.");
+
+        log.error("MissingServletRequestParameterException 발생: 누락된 파라미터 '{}'", e.getParameterName());
+        log.error("에러가 발생한 지점 {}, {}", request.getMethod(), request.getRequestURI());
+
+        ErrorResponse errorResponse = ErrorResponse.of(
+                ErrorCode.INVALID_PARAMETER,
+                request,
+                errors
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(errorResponse);
+    }
+
+    // @Validated 제약 조건 위반
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(
+            ConstraintViolationException e,
+            HttpServletRequest request
+    ) {
+        Map<String, String> errors = new HashMap<>();
+        e.getConstraintViolations().forEach(violation -> {
+            String propertyPath = violation.getPropertyPath().toString();
+            String fieldName = propertyPath.contains(".")
+                    ? propertyPath.substring(propertyPath.lastIndexOf(".") + 1)
+                    : propertyPath;
+            errors.put(fieldName, violation.getMessage());
+        });
+
+        log.error("ConstraintViolationException 발생: {}", errors);
+        log.error("에러가 발생한 지점 {}, {}", request.getMethod(), request.getRequestURI());
+
+        ErrorResponse errorResponse = ErrorResponse.of(
+                ErrorCode.INVALID_PARAMETER,
+                request,
+                errors
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(errorResponse);
+    }
+
+    // Request Body JSON 파싱 실패 또는 Body 누락
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e, HttpServletRequest request) {
+
+        // 특정 필드의 타입 변환 실패 (예: String 필드에 숫자 타입 등)
+        if (e.getCause() instanceof InvalidFormatException cause) {
+            Map<String, String> errors = new HashMap<>();
+            String fieldName = cause.getPath().get(0).getFieldName();
+
+            if (cause.getValue().toString().isEmpty()) {
+                errors.put(fieldName, "빈칸을 변환할 수 없습니다.");
+            } else {
+                errors.put(fieldName, "'" + cause.getValue() + "'을(를) 변환할 수 없습니다.");
+            }
+
+            log.error("InvalidFormatException 발생: {}", errors);
+            log.error("에러가 발생한 지점 {}, {}", request.getMethod(), request.getRequestURI());
+
+            return ResponseEntity
+                    .status(ErrorCode.JSON_PARSE_FAIL.getHttpStatus())
+                    .body(ErrorResponse.of(ErrorCode.JSON_PARSE_FAIL, request, errors));
+        }
+
+        // JSON 문법 자체가 잘못된 경우 (중괄호 누락, 따옴표 오류 등)
+        if (e.getMessage() != null && e.getMessage().contains("JSON parse error")) {
+            log.error("HttpMessageNotReadableException 발생: JSON 파싱 실패 - {}", e.getMessage());
+            log.error("에러가 발생한 지점 {}, {}", request.getMethod(), request.getRequestURI());
+
+            return ResponseEntity
+                    .status(ErrorCode.JSON_PARSE_FAIL.getHttpStatus())
+                    .body(ErrorResponse.of(ErrorCode.JSON_PARSE_FAIL, request));
+        }
+
+        // Request Body 자체가 없는 경우
+        log.error("HttpMessageNotReadableException 발생: Request Body 없음");
+        log.error("에러가 발생한 지점 {}, {}", request.getMethod(), request.getRequestURI());
+
+        return ResponseEntity
+                .status(ErrorCode.NOT_FOUND_REQUEST_BODY.getHttpStatus())
+                .body(ErrorResponse.of(ErrorCode.NOT_FOUND_REQUEST_BODY, request));
+    }
+
+    // 지원하지 않는 HTTP 메서드
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e, HttpServletRequest request) {
+        log.error("HttpRequestMethodNotSupportedException 발생: 지원하지 않는 메서드 '{}'", e.getMethod());
+        log.error("에러가 발생한 지점 {}, {}", request.getMethod(), request.getRequestURI());
+
+        Map<String, String[]> errors = new HashMap<>();
+        errors.put("지원하는 메서드", e.getSupportedMethods());
+
+        return ResponseEntity
+                .status(ErrorCode.NOT_SUPPORT_HTTP_METHOD.getHttpStatus())
+                .body(ErrorResponse.of(ErrorCode.NOT_SUPPORT_HTTP_METHOD, request, errors));
+    }
+
+    // 존재하지 않는 URI
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoResourceFoundException(NoResourceFoundException e, HttpServletRequest request) {
+        log.error("NoResourceFoundException 발생: 존재하지 않는 URI '{}'", request.getRequestURI());
+
+        return ResponseEntity
+                .status(ErrorCode.NOT_FOUND_URI.getHttpStatus())
+                .body(ErrorResponse.of(ErrorCode.NOT_FOUND_URI, request));
+    }
+
+    // 지원하지 않는 Content-Type
+    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMediaTypeNotSupportedException(HttpMediaTypeNotSupportedException e, HttpServletRequest request) {
+        log.error("HttpMediaTypeNotSupportedException 발생: 지원하지 않는 Content-Type '{}'", e.getContentType());
+        log.error("에러가 발생한 지점 {}, {}", request.getMethod(), request.getRequestURI());
+
+        Map<String, String> errors = new HashMap<>();
+        if (e.getContentType() != null) {
+            errors.put("요청한 Content-Type", e.getContentType().toString());
+        }
+
+        return ResponseEntity
+                .status(ErrorCode.NOT_SUPPORT_CONTENT_TYPE.getHttpStatus())
+                .body(ErrorResponse.of(ErrorCode.NOT_SUPPORT_CONTENT_TYPE, request, errors));
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/global/response/ErrorResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/response/ErrorResponse.java
@@ -13,13 +13,15 @@ public class ErrorResponse extends BaseResponse {
     private final String message;
     private final String method;
     private final String requestURI;
+    private final Object errors;
 
-    private ErrorResponse(String code, String message, String method, String requestURI, HttpStatus httpStatus) {
+    private ErrorResponse(String code, String message, String method, String requestURI, HttpStatus httpStatus, Object errors) {
         super(httpStatus);
         this.code = code;
         this.message = message;
         this.method = method;
         this.requestURI = requestURI;
+        this.errors = errors;
     }
 
     public static ErrorResponse of(BaseErrorCode errorCode, HttpServletRequest request) {
@@ -28,7 +30,19 @@ public class ErrorResponse extends BaseResponse {
                 errorCode.getMessage(),
                 request.getMethod(),
                 request.getRequestURI(),
-                errorCode.getHttpStatus()
+                errorCode.getHttpStatus(),
+                null
+        );
+    }
+
+    public static ErrorResponse of(BaseErrorCode errorCode, HttpServletRequest request, Object errors) {
+        return new ErrorResponse(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                request.getMethod(),
+                request.getRequestURI(),
+                errorCode.getHttpStatus(),
+                errors
         );
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #143

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

서버에서 내려주는 500 error를 잡기 위해 GlobalException을 구체화했습니다.

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- Global Error Code 확장
- Error Response에 errors 필드 추가
- AppException에 bind필드 추가

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.

### @Valid DTO 유효성 검사 실패
- 기존
<img width="1098" height="785" alt="image" src="https://github.com/user-attachments/assets/838d946a-f393-442b-8df2-5834bc634cb7" />

- 변경
<img width="1085" height="901" alt="image" src="https://github.com/user-attachments/assets/2a079276-7417-42ed-a46e-e80053be1a94" />

### 필수 @RequestParam 누락
- 기존
<img width="1095" height="776" alt="image" src="https://github.com/user-attachments/assets/2c50914c-8ef5-4757-b009-c9f5c1bf4fcb" />

- 변경
<img width="1100" height="855" alt="image" src="https://github.com/user-attachments/assets/27e1c987-6775-4ed0-ad07-24f3344ce9f7" />

### @RequestParam 타입 불일치
- 기존
<img width="1107" height="805" alt="image" src="https://github.com/user-attachments/assets/135c2cbc-0f9c-4af1-81a6-e83a74fe240f" />

- 변경
<img width="1089" height="849" alt="image" src="https://github.com/user-attachments/assets/fbc2cd14-3a61-43d5-ac1a-1381412f0e6f" />

### JSON 특정 필드 타입 변환 실패
- 기존
<img width="1093" height="804" alt="image" src="https://github.com/user-attachments/assets/352d31b6-e6d3-4439-b5e8-d6f0c5ba9234" />

- 변경
<img width="1078" height="833" alt="image" src="https://github.com/user-attachments/assets/665bd3c0-df94-415a-8cf8-da938a012b6c" />


### JSON 문법 오류
- 기존
<img width="1084" height="798" alt="image" src="https://github.com/user-attachments/assets/21dff2d6-16fc-4880-afbc-9cd075f5adca" />

- 변경
<img width="1062" height="814" alt="image" src="https://github.com/user-attachments/assets/d30a1231-43c3-4e5b-b016-f26eec890b0c" />

### Request Body 자체 누락
- 기존
<img width="1098" height="774" alt="image" src="https://github.com/user-attachments/assets/58b6ee06-061b-4719-870d-ce9bf3895d27" />

- 변경
<img width="1075" height="816" alt="image" src="https://github.com/user-attachments/assets/63d0dcd8-658d-4b64-a5c9-bb5f3dfdbdd2" />

### 지원하지 않는 HTTP 메서드
- 기존
<img width="1083" height="769" alt="image" src="https://github.com/user-attachments/assets/95b8f8be-de15-4301-90f8-94ecd6e36091" />

- 변경
<img width="1070" height="886" alt="image" src="https://github.com/user-attachments/assets/21c6b64b-4ee8-483c-aba0-24637518fd8e" />

### 존재하지 않는 URI
- 기존
<img width="1112" height="768" alt="image" src="https://github.com/user-attachments/assets/4197ef01-4197-4862-a4f1-3da11e7c48a0" />

- 변경
<img width="1092" height="788" alt="image" src="https://github.com/user-attachments/assets/2046f162-cf8d-4419-b368-a2db958ea419" />

### 지원하지 않는 Content-Type
- 기존
<img width="1086" height="777" alt="image" src="https://github.com/user-attachments/assets/2753c355-dd71-4c6d-9f2a-e34c3e2ac3c1" />

- 변경
<img width="1088" height="852" alt="image" src="https://github.com/user-attachments/assets/96041f73-fda9-43a9-8121-5c442b1bd844" />



## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- (예: 이 로직이 최선일까요? P2)
- (예: 예외 처리 누락 여부 확인 부탁드립니다. P1)

- P1: 혹시 더 추가할 부분이 있을까요?
- P1: 프론트 응답 쪽에서는 error필드만 추가되는 건데 괜찮겠죠..?

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 예외 처리 범위 및 안정성 대폭 개선 — 다양한 요청 오류에 대한 일관된 응답 제공
  * 기존 에러 코드 포맷 및 매핑 정비로 진단 정확도 향상

* **New Features**
  * 에러 응답에 상세한 필드별 정보(errors) 포함 — 문제 원인 파악 및 사용자 안내 강화
  * 파라미터 불일치·바디 파싱·미지원 메서드·미지원 컨텐츠 타입 등 세분화된 오류 구분 및 응답 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->