### PR TITLE
Feat/#147 예산 수정 - 예산 변경 이력 추적

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/application/mapper/AdvertisementConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/application/mapper/AdvertisementConverter.java
@@ -1,17 +1,18 @@
 package com.whereyouad.WhereYouAd.domains.advertisement.application.mapper;
 
 import com.whereyouad.WhereYouAd.domains.advertisement.application.dto.response.AdvertisementResponse;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.BudgetFieldType;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Grain;
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdCampaign;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdContent;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdGroup;
-
-import java.util.List;
-import java.time.LocalDateTime;
-
-import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Grain;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.BudgetHistory;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.MetricFact;
 import com.whereyouad.WhereYouAd.domains.project.persistence.entity.Project;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public class AdvertisementConverter {
 
@@ -62,6 +63,39 @@ public class AdvertisementConverter {
                 .project(project)
                 .conversions(null)
                 .revenue(null)
+                .build();
+    }
+
+    public static BudgetHistory toCampaignBudgetHistory(AdCampaign campaign, Long previousValue, Long newValue, Long changedBy, Provider provider) {
+        return BudgetHistory.builder()
+                .adCampaign(campaign)
+                .fieldType(BudgetFieldType.CAMPAIGN_BUDGET)
+                .previousValue(previousValue)
+                .newValue(newValue)
+                .changedBy(changedBy)
+                .provider(provider)
+                .build();
+    }
+
+    public static BudgetHistory toAdGroupBudgetHistory(AdGroup adGroup, Long previousValue, Long newValue, Long changedBy, Provider provider) {
+        return BudgetHistory.builder()
+                .adGroup(adGroup)
+                .fieldType(BudgetFieldType.AD_GROUP_BUDGET)
+                .previousValue(previousValue)
+                .newValue(newValue)
+                .changedBy(changedBy)
+                .provider(provider)
+                .build();
+    }
+
+    public static BudgetHistory toBidAmountHistory(AdGroup adGroup, Long previousValue, Long newValue, Long changedBy, Provider provider) {
+        return BudgetHistory.builder()
+                .adGroup(adGroup)
+                .fieldType(BudgetFieldType.BID_AMOUNT)
+                .previousValue(previousValue)
+                .newValue(newValue)
+                .changedBy(changedBy)
+                .provider(provider)
                 .build();
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/constant/BudgetFieldType.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/constant/BudgetFieldType.java
@@ -1,0 +1,7 @@
+package com.whereyouad.WhereYouAd.domains.advertisement.domain.constant;
+
+public enum BudgetFieldType {
+    CAMPAIGN_BUDGET,
+    AD_GROUP_BUDGET,
+    BID_AMOUNT
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
@@ -1,9 +1,10 @@
 package com.whereyouad.WhereYouAd.domains.advertisement.domain.service;
 
-import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdCampaign;
-import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdGroup;
+import com.whereyouad.WhereYouAd.domains.advertisement.application.mapper.AdvertisementConverter;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdCampaignRepository;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdGroupRepository;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.BudgetHistoryRepository;
 import com.whereyouad.WhereYouAd.domains.organization.domain.constant.OrgRole;
 import com.whereyouad.WhereYouAd.domains.organization.exception.handler.OrgHandler;
 import com.whereyouad.WhereYouAd.domains.organization.exception.code.OrgErrorCode;
@@ -40,6 +41,7 @@ public class NaverAdApiService {
     private final NaverClient naverClient;
     private final AdGroupRepository adGroupRepository;
     private final AdCampaignRepository adCampaignRepository;
+    private final BudgetHistoryRepository budgetHistoryRepository;
 
     // 캠페인 목록 조회
     @Transactional(readOnly = true)
@@ -200,7 +202,12 @@ public class NaverAdApiService {
 
             adCampaignRepository
                     .findByPlatformAccountAndExternalCampaignId(connection.getPlatformAccount(), campaignId)
-                    .ifPresent(campaign -> campaign.updateBudget(request.dailyBudget()));
+                    .ifPresent(campaign -> {
+                        Long previousBudget = campaign.getBudget();
+                        campaign.updateBudget(request.dailyBudget());
+                        budgetHistoryRepository.save(AdvertisementConverter.toCampaignBudgetHistory(
+                                campaign, previousBudget, request.dailyBudget(), userId, Provider.NAVER));
+                    });
 
             return result;
         } catch (Exception e) {
@@ -245,7 +252,19 @@ public class NaverAdApiService {
 
             adGroupRepository
                     .findByAdCampaign_PlatformAccountAndExternalGroupId(connection.getPlatformAccount(), adgroupId)
-                    .ifPresent(adGroup -> adGroup.updateBudget(request.dailyBudget(), request.bidAmt()));
+                    .ifPresent(adGroup -> {
+                        if (request.dailyBudget() != null) {
+                            Long previousBudget = adGroup.getBudget();
+                            budgetHistoryRepository.save(AdvertisementConverter.toAdGroupBudgetHistory(
+                                    adGroup, previousBudget, request.dailyBudget(), userId, Provider.NAVER));
+                        }
+                        if (request.bidAmt() != null) {
+                            Long previousBidAmount = adGroup.getBidAmount();
+                            budgetHistoryRepository.save(AdvertisementConverter.toBidAmountHistory(
+                                    adGroup, previousBidAmount, request.bidAmt(), userId, Provider.NAVER));
+                        }
+                        adGroup.updateBudget(request.dailyBudget(), request.bidAmt());
+                    });
 
             return result;
         } catch (Exception e) {

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
@@ -247,10 +247,11 @@ public class NaverAdApiService {
         Optional<AdGroup> adGroupOpt = adGroupRepository
                 .findByAdCampaign_PlatformAccountAndExternalGroupId(connection.getPlatformAccount(), adgroupId);
         adGroupOpt.ifPresent(adGroup -> {
-            if (request.dailyBudget() != null && request.dailyBudget().equals(adGroup.getBudget())) {
-                throw new AdvertisementHandler(NaverAdErrorCode.NAVER_SAME_BUDGET_VALUE);
-            }
-            if (request.bidAmt() != null && request.bidAmt().equals(adGroup.getBidAmount())) {
+            boolean budgetUnchanged = request.dailyBudget() == null
+                    || request.dailyBudget().equals(adGroup.getBudget());
+            boolean bidAmtUnchanged = request.bidAmt() == null
+                    || request.bidAmt().equals(adGroup.getBidAmount());
+            if (budgetUnchanged && bidAmtUnchanged) {
                 throw new AdvertisementHandler(NaverAdErrorCode.NAVER_SAME_BUDGET_VALUE);
             }
         });

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/NaverAdApiService.java
@@ -2,6 +2,8 @@ package com.whereyouad.WhereYouAd.domains.advertisement.domain.service;
 
 import com.whereyouad.WhereYouAd.domains.advertisement.application.mapper.AdvertisementConverter;
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdCampaign;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdGroup;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdCampaignRepository;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdGroupRepository;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.BudgetHistoryRepository;
@@ -29,6 +31,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -193,6 +196,13 @@ public class NaverAdApiService {
                 throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BUDGET_RANGE);
             }
         }
+        Optional<AdCampaign> campaignOpt = adCampaignRepository
+                .findByPlatformAccountAndExternalCampaignId(connection.getPlatformAccount(), campaignId);
+        campaignOpt.ifPresent(campaign -> {
+            if (request.dailyBudget() != null && request.dailyBudget().equals(campaign.getBudget())) {
+                throw new AdvertisementHandler(NaverAdErrorCode.NAVER_SAME_BUDGET_VALUE);
+            }
+        });
         try {
             Map<String, String> headers = adApiAuthUtil.generateAuthHeaders(
                     connectionId, AdAuthRequest.forMethodAndPath("PUT", "/ncc/campaigns/" + campaignId));
@@ -200,14 +210,12 @@ public class NaverAdApiService {
                     new NaverDTO.UpdateCampaignBudgetBody(campaignId, request.useDailyBudget(), request.dailyBudget());
             NaverDTO.CampaignResponse result = naverClient.updateCampaignBudget(headers, campaignId, "budget", body);
 
-            adCampaignRepository
-                    .findByPlatformAccountAndExternalCampaignId(connection.getPlatformAccount(), campaignId)
-                    .ifPresent(campaign -> {
-                        Long previousBudget = campaign.getBudget();
-                        campaign.updateBudget(request.dailyBudget());
-                        budgetHistoryRepository.save(AdvertisementConverter.toCampaignBudgetHistory(
-                                campaign, previousBudget, request.dailyBudget(), userId, Provider.NAVER));
-                    });
+            campaignOpt.ifPresent(campaign -> {
+                Long previousBudget = campaign.getBudget();
+                campaign.updateBudget(request.dailyBudget());
+                budgetHistoryRepository.save(AdvertisementConverter.toCampaignBudgetHistory(
+                        campaign, previousBudget, request.dailyBudget(), userId, Provider.NAVER));
+            });
 
             return result;
         } catch (Exception e) {
@@ -236,6 +244,16 @@ public class NaverAdApiService {
                 throw new AdvertisementHandler(NaverAdErrorCode.NAVER_INVALID_BID_AMOUNT_RANGE);
             }
         }
+        Optional<AdGroup> adGroupOpt = adGroupRepository
+                .findByAdCampaign_PlatformAccountAndExternalGroupId(connection.getPlatformAccount(), adgroupId);
+        adGroupOpt.ifPresent(adGroup -> {
+            if (request.dailyBudget() != null && request.dailyBudget().equals(adGroup.getBudget())) {
+                throw new AdvertisementHandler(NaverAdErrorCode.NAVER_SAME_BUDGET_VALUE);
+            }
+            if (request.bidAmt() != null && request.bidAmt().equals(adGroup.getBidAmount())) {
+                throw new AdvertisementHandler(NaverAdErrorCode.NAVER_SAME_BUDGET_VALUE);
+            }
+        });
         try {
             Map<String, String> headers = adApiAuthUtil.generateAuthHeaders(
                     connectionId, AdAuthRequest.forMethodAndPath("PUT", "/ncc/adgroups/" + adgroupId));
@@ -250,9 +268,7 @@ public class NaverAdApiService {
                         new NaverDTO.UpdateAdGroupBudgetBody(adgroupId, null, null, request.bidAmt()));
             }
 
-            adGroupRepository
-                    .findByAdCampaign_PlatformAccountAndExternalGroupId(connection.getPlatformAccount(), adgroupId)
-                    .ifPresent(adGroup -> {
+            adGroupOpt.ifPresent(adGroup -> {
                         if (request.dailyBudget() != null) {
                             Long previousBudget = adGroup.getBudget();
                             budgetHistoryRepository.save(AdvertisementConverter.toAdGroupBudgetHistory(

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/exception/code/NaverAdErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/exception/code/NaverAdErrorCode.java
@@ -14,6 +14,7 @@ public enum NaverAdErrorCode implements BaseErrorCode {
     NAVER_INVALID_BUDGET_VALUE(HttpStatus.BAD_REQUEST, "NAVER_400_2", "예산 및 입찰가는 10원 단위로 입력해야 합니다."),
     NAVER_INVALID_BUDGET_RANGE(HttpStatus.BAD_REQUEST, "NAVER_400_3", "예산은 50원 이상 1,000,000,000원 이하로 입력해야 합니다."),
     NAVER_INVALID_BID_AMOUNT_RANGE(HttpStatus.BAD_REQUEST, "NAVER_400_4", "입찰가는 70원 이상 100,000원 이하로 입력해야 합니다."),
+    NAVER_SAME_BUDGET_VALUE(HttpStatus.BAD_REQUEST, "NAVER_400_5", "이전 예산과 동일한 값으로 수정할 수 없습니다."),
 
     // 404
     NAVER_CONNECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "NAVER_404_1", "플랫폼 연결 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/BudgetHistory.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/BudgetHistory.java
@@ -5,6 +5,8 @@ import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Table(name = "budget_history")
@@ -39,9 +41,11 @@ public class BudgetHistory extends BaseEntity {
     // 연관 관계 (nullable로 2개 중에 1개만 연결 가능)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ad_campaign_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private AdCampaign adCampaign;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ad_group_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private AdGroup adGroup;
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/BudgetHistory.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/BudgetHistory.java
@@ -1,0 +1,47 @@
+package com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity;
+
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.BudgetFieldType;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
+import com.whereyouad.WhereYouAd.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "budget_history")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class BudgetHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "budget_history_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "field_type", nullable = false)
+    private BudgetFieldType fieldType;
+
+    @Column(name = "previous_value")
+    private Long previousValue;
+
+    @Column(name = "new_value")
+    private Long newValue;
+
+    @Column(name = "changed_by", nullable = false)
+    private Long changedBy;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider", nullable = false)
+    private Provider provider;
+
+    // 연관 관계 (nullable로 2개 중에 1개만 연결 가능)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ad_campaign_id")
+    private AdCampaign adCampaign;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ad_group_id")
+    private AdGroup adGroup;
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/BudgetHistoryRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/BudgetHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository;
+
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.BudgetHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BudgetHistoryRepository extends JpaRepository<BudgetHistory, Long> {
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/BudgetHistoryRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/repository/BudgetHistoryRepository.java
@@ -2,6 +2,25 @@ package com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository;
 
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.BudgetHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface BudgetHistoryRepository extends JpaRepository<BudgetHistory, Long> {
+
+    @Query("""
+        SELECT bh FROM BudgetHistory bh
+        LEFT JOIN bh.adCampaign ac
+        LEFT JOIN bh.adGroup ag
+        LEFT JOIN ag.adCampaign agc
+        WHERE (ac.organization.id = :orgId OR agc.organization.id = :orgId)
+          AND bh.createdAt BETWEEN :start AND :end
+        ORDER BY bh.createdAt DESC
+    """)
+    List<BudgetHistory> findByOrgAndPeriod(
+            @Param("orgId") Long orgId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/application/dto/response/DashboardResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/application/dto/response/DashboardResponse.java
@@ -1,9 +1,11 @@
 package com.whereyouad.WhereYouAd.domains.dashboard.application.dto.response;
 
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.BudgetFieldType;
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.domains.click.application.dto.response.ClickResponse;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class DashboardResponse {
@@ -96,5 +98,20 @@ public class DashboardResponse {
             LocalDate endDate,
             DailyMetricFactResponse total,              // 기간 전체 합계 지표
             List<DailyMetricFactResponse> dailyMetrics  // 일자별 지표 리스트
+    ) {}
+
+    public record BudgetHistoryItem(
+            BudgetFieldType fieldType,
+            String targetName,
+            Long previousValue,
+            Long newValue,
+            LocalDateTime changedAt,
+            Provider provider
+    ) {}
+
+    public record BudgetHistoryListResponse(
+            LocalDate startDate,
+            LocalDate endDate,
+            List<BudgetHistoryItem> histories
     ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/application/mapper/DashboardConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/application/mapper/DashboardConverter.java
@@ -1,13 +1,13 @@
 package com.whereyouad.WhereYouAd.domains.dashboard.application.mapper;
 
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.BudgetHistory;
 import com.whereyouad.WhereYouAd.domains.click.application.dto.response.ClickResponse;
 import com.whereyouad.WhereYouAd.domains.dashboard.application.dto.response.DashboardResponse;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
-
-import java.math.BigDecimal;
 
 public class DashboardConverter {
 
@@ -51,6 +51,22 @@ public class DashboardConverter {
                 .mapToLong(DashboardResponse.OngoingPlatformAdCount::count)
                 .sum();
         return new DashboardResponse.OngoingPlatformAdCountResponse(startDate, endDate, totalCount, providerCount);
+    }
+
+    public static List<DashboardResponse.BudgetHistoryItem> toBudgetHistoryItems(List<BudgetHistory> histories) {
+        return histories.stream().map(bh -> {
+            String targetName = bh.getAdCampaign() != null
+                    ? bh.getAdCampaign().getName()
+                    : bh.getAdGroup().getName();
+            return new DashboardResponse.BudgetHistoryItem(
+                    bh.getFieldType(),
+                    targetName,
+                    bh.getPreviousValue(),
+                    bh.getNewValue(),
+                    bh.getCreatedAt(),
+                    bh.getProvider()
+            );
+        }).toList();
     }
 
     //Data -> DTO

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/domain/service/DashboardService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/domain/service/DashboardService.java
@@ -20,4 +20,8 @@ public interface DashboardService {
     // 플랫폼 대시보드의 일자별 지표(MetricFact) 조회
     DashboardResponse.PlatformMetricFactSummaryResponse getPlatformMetricFacts(
             Long userId, Long orgId, String providerType, Integer days);
+
+    // 기간별 예산 변경 이력 조회
+    DashboardResponse.BudgetHistoryListResponse getBudgetHistory(
+            Long userId, Long orgId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/domain/service/DashboardServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/domain/service/DashboardServiceImpl.java
@@ -3,8 +3,11 @@ package com.whereyouad.WhereYouAd.domains.dashboard.domain.service;
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
 import com.whereyouad.WhereYouAd.domains.advertisement.exception.AdvertisementHandler;
 import com.whereyouad.WhereYouAd.domains.advertisement.exception.code.AdvertisementErrorCode;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.BudgetFieldType;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.BudgetHistory;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdCampaignRepository;
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.BudgetHistoryRepository;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.MetricFactRepository;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.projection.MetricSumProjection;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.projection.RoasProjection;
@@ -41,6 +44,7 @@ public class DashboardServiceImpl implements DashboardService {
 
     private final AdCampaignRepository adCampaignRepository;
     private final MetricFactRepository metricFactRepository;
+    private final BudgetHistoryRepository budgetHistoryRepository;
     private final OrgMemberRepository orgMemberRepository;
     private final OrgRepository orgRepository;
     private final BudgetCalculator budgetCalculator;
@@ -403,5 +407,26 @@ public class DashboardServiceImpl implements DashboardService {
                 totalMetric,
                 dailyMetrics
         );
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public DashboardResponse.BudgetHistoryListResponse getBudgetHistory(
+            Long userId, Long orgId, LocalDate startDate, LocalDate endDate) {
+
+        orgRepository.findById(orgId)
+                .orElseThrow(() -> new DashboardException(OrgErrorCode.ORG_NOT_FOUND));
+        orgMemberRepository.findByUserIdAndOrgId(userId, orgId)
+                .orElseThrow(() -> new DashboardException(DashboardErrorCode.ACCESS_FORBIDDEN));
+
+        List<BudgetHistory> histories = budgetHistoryRepository.findByOrgAndPeriod(
+                orgId,
+                startDate.atStartOfDay(),
+                endDate.plusDays(1).atStartOfDay()
+        );
+
+        List<DashboardResponse.BudgetHistoryItem> items = DashboardConverter.toBudgetHistoryItems(histories);
+
+        return new DashboardResponse.BudgetHistoryListResponse(startDate, endDate, items);
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/presentation/DashboardController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/presentation/DashboardController.java
@@ -96,6 +96,16 @@ public class DashboardController implements DashboardControllerDocs {
         return ResponseEntity.ok(DataResponse.from(response));
     }
 
+    @GetMapping("/{orgId}/budget-history")
+    public ResponseEntity<DataResponse<DashboardResponse.BudgetHistoryListResponse>> getBudgetHistory(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long orgId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+        return ResponseEntity.ok(DataResponse.from(
+                dashboardService.getBudgetHistory(userId, orgId, startDate, endDate)));
+    }
+
     @GetMapping(value = "/{orgId}/clicks/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public ResponseEntity<SseEmitter> streamRealClicks(
             @AuthenticationPrincipal(expression = "userId") Long userId,

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/presentation/docs/DashboardControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/dashboard/presentation/docs/DashboardControllerDocs.java
@@ -116,6 +116,23 @@ public interface DashboardControllerDocs {
     );
 
     @Operation(
+            summary = "대시보드 - 예산 변경 이력 조회 API",
+            description = "조직 내 캠페인 및 광고그룹의 예산/입찰가 변경 이력을 기간별로 조회합니다.\n\n" +
+                          "fieldType: CAMPAIGN_BUDGET(캠페인 예산), AD_GROUP_BUDGET(광고그룹 예산), BID_AMOUNT(입찰가)"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공"),
+            @ApiResponse(responseCode = "403", description = "해당 조직에 대한 접근 권한이 없는 경우"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 조직")
+    })
+    ResponseEntity<DataResponse<DashboardResponse.BudgetHistoryListResponse>> getBudgetHistory(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @Parameter(description = "조직 ID", required = true, example = "1") @PathVariable Long orgId,
+            @Parameter(description = "조회 시작일 (YYYY-MM-DD)", required = true, example = "2025-01-01") @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @Parameter(description = "조회 종료일 (YYYY-MM-DD)", required = true, example = "2025-12-31") @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+    );
+
+    @Operation(
             summary = "대시보드 - 실시간 클릭수 스트림 출력 API",
             description = "해당 조직의 최근 60분간 실시간 클릭수 추이와 이상 징후(봇) 감지 여부를 스트림으로 보내주는 API입니다.\n\n" +
                     "파라미터로 `mode`를 받아 `dummy`이면 서버 내에서 생성하는 가상 트래픽을, `real`일 경우 실제 수집된 클릭 데이터를 기반으로 반환합니다.\n\n" +

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/timeline/application/dto/response/TimelineResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/timeline/application/dto/response/TimelineResponse.java
@@ -1,5 +1,7 @@
 package com.whereyouad.WhereYouAd.domains.timeline.application.dto.response;
 
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.BudgetFieldType;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.domains.timeline.domain.constant.MetricType;
 import com.whereyouad.WhereYouAd.domains.timeline.domain.constant.PerformanceStatus;
 
@@ -39,7 +41,17 @@ public class TimelineResponse {
             List<MetricType> metrics,
             String summary,
             List<DailyMetricDTO> dailyTrend,
-            List<PlatformContributionDTO> platformContributions
+            List<PlatformContributionDTO> platformContributions,
+            List<BudgetHistoryItem> budgetHistories
+    ) {}
+
+    public record BudgetHistoryItem(
+            BudgetFieldType fieldType,
+            String targetName,
+            Long previousValue,
+            Long newValue,
+            LocalDateTime changedAt,
+            Provider provider
     ) {}
 
     public record DailyMetricDTO(

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/timeline/application/mapper/TimelineConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/timeline/application/mapper/TimelineConverter.java
@@ -1,5 +1,6 @@
 package com.whereyouad.WhereYouAd.domains.timeline.application.mapper;
 
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.BudgetHistory;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
 import com.whereyouad.WhereYouAd.domains.timeline.application.dto.request.TimelineRequest.TimelineCreateDto;
 import com.whereyouad.WhereYouAd.domains.timeline.application.dto.response.TimelineResponse;
@@ -57,7 +58,8 @@ public class TimelineConverter {
             Timeline timeline,
             List<MetricType> metrics,
             List<TimelineResponse.DailyMetricDTO> dailyTrend,
-            List<TimelineResponse.PlatformContributionDTO> platformContributions
+            List<TimelineResponse.PlatformContributionDTO> platformContributions,
+            List<TimelineResponse.BudgetHistoryItem> budgetHistories
     ) {
         return new TimelineResponse.TimelineDetailDTO(
                 timeline.getId(),
@@ -68,8 +70,25 @@ public class TimelineConverter {
                 metrics,
                 timeline.getSummary(),
                 dailyTrend,
-                platformContributions
+                platformContributions,
+                budgetHistories
         );
+    }
+
+    public static List<TimelineResponse.BudgetHistoryItem> toBudgetHistoryItems(List<BudgetHistory> histories) {
+        return histories.stream().map(bh -> {
+            String targetName = bh.getAdCampaign() != null
+                    ? bh.getAdCampaign().getName()
+                    : bh.getAdGroup().getName();
+            return new TimelineResponse.BudgetHistoryItem(
+                    bh.getFieldType(),
+                    targetName,
+                    bh.getPreviousValue(),
+                    bh.getNewValue(),
+                    bh.getCreatedAt(),
+                    bh.getProvider()
+            );
+        }).toList();
     }
 
     // entity -> dto

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/timeline/domain/service/TimelineServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/timeline/domain/service/TimelineServiceImpl.java
@@ -20,6 +20,8 @@ import com.whereyouad.WhereYouAd.domains.timeline.persistence.entity.Timeline;
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Grain;
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.MetricFact;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.BudgetHistory;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.BudgetHistoryRepository;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.MetricFactRepository;
 import com.whereyouad.WhereYouAd.domains.timeline.persistence.repository.TimelineRepository;
 import lombok.AccessLevel;
@@ -46,6 +48,7 @@ public class TimelineServiceImpl implements TimelineService {
 
     private final TimelineRepository timelineRepository;
     private final MetricFactRepository metricFactRepository;
+    private final BudgetHistoryRepository budgetHistoryRepository;
     private final OrgRepository orgRepository;
     private final OrgMemberRepository orgMemberRepository;
     private final TimelineUtil timelineUtil;
@@ -254,7 +257,15 @@ public class TimelineServiceImpl implements TimelineService {
         // 플랫폼별 기여도 반환
         List<TimelineResponse.PlatformContributionDTO> platformContributions = buildPlatformContributions(facts, timeline);
 
-        return TimelineConverter.toTimelineDetailDTO(timeline, metrics, dailyTrend, platformContributions);
+        // 타임라인 기간 내 예산 변경 이력 조회
+        List<BudgetHistory> histories = budgetHistoryRepository.findByOrgAndPeriod(
+                orgId,
+                timeline.getStartDate().atStartOfDay(),
+                timeline.getEndDate().plusDays(1).atStartOfDay()
+        );
+        List<TimelineResponse.BudgetHistoryItem> budgetHistories = TimelineConverter.toBudgetHistoryItems(histories);
+
+        return TimelineConverter.toTimelineDetailDTO(timeline, metrics, dailyTrend, platformContributions, budgetHistories);
     }
 
     @Override


### PR DESCRIPTION
## 📌 관련 이슈
- Close #147
- Related to #142

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.
예산 변경(BudgetHistory) 엔티티를 만들고 관련 엔티티를 활용할 수 있는 도메인에 추가
- 타임라인 상세조회 응답에 추가
- 대시보드 예산 변경 이력 조회API 추가 

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- BudgetHistory 엔티티 생성
- 예산 수정 시 BudgetHistory 저장
- 타임라인 상세 조회 응답에 예산 변경 이력 추가
- 대시보드 예산 변경 이력 조회 API 추가

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.
### 예산 수정 시 DB 저장
1. Campaign 예산 수정
<img width="1616" height="684" alt="image" src="https://github.com/user-attachments/assets/96821e5b-6b93-4b18-afd2-1ff66150fddf" />

<img width="1557" height="72" alt="image" src="https://github.com/user-attachments/assets/61d9bb0d-a28e-4be7-b28a-c14f5029cae2" />

2. Ad_group 예산 수정
<img width="1613" height="686" alt="image" src="https://github.com/user-attachments/assets/88f1242c-dadc-4d62-84fb-8a488c3b8083" />
<img width="1556" height="146" alt="image" src="https://github.com/user-attachments/assets/b20c18a9-bb2c-461b-99ff-bf8a322d1a7f" />

### 대시보드 예산 변경 이력 조회 API
<img width="1608" height="699" alt="image" src="https://github.com/user-attachments/assets/ddf6cf71-4a9c-48f6-9162-e12cee5475a8" />
<img width="1610" height="521" alt="image" src="https://github.com/user-attachments/assets/84b11e38-8bfc-4553-8c2a-c79e65f0a5b8" />

### 타임라인 상세 조회
- 타임라인 생성
<img width="1613" height="678" alt="image" src="https://github.com/user-attachments/assets/9af73aa9-6f78-4ce7-bddb-95298e98b77c" />

- 타임라인 엔티티 상세조회 시 예산 변경 추가 반환
<img width="1605" height="563" alt="image" src="https://github.com/user-attachments/assets/5e663ff2-093c-498f-889c-d188add765d9" />


## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- (예: 이 로직이 최선일까요? P2)
- (예: 예외 처리 누락 여부 확인 부탁드립니다. P1)

P4: 예산 변경을 필드로만 관리하면 가장 최근 값 밖에 조회하지 못하고 수정 시점을 추적하기 위해서는 따로 테이블로 분리해서 관리하는 방법밖에 없을 것 같아서 따로 테이블로 분리해서 구현해봤습니다!
P4: 기존 브랜치(#142 )에 작업하면 pr 단위가 커질 것 같아서 따로 올렸습니다!
P2: 변경 이력을 또 적용할 다른 도메인이 있을까요? 
P4: 타임라인 엔티티 AI 요약에 추가하는 건 따로 이슈파서 진행하겠습니다!

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 캠페인의 일일 예산을 언제든지 수정할 수 있는 기능이 추가되었습니다.
  * 광고그룹의 예산과 입찰가를 개별적으로 수정할 수 있습니다.
  * 모든 예산 변경 내역을 추적할 수 있으며, 대시보드에서 기간별로 조회할 수 있습니다.
  * 타임라인 상세 정보에 예산 변경 이력이 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->