### PR TITLE
Feat/#151 알림 - 알림 엔티티 및 구조 추가

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/application/dto/request/NotificationRequest.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/application/dto/request/NotificationRequest.java
@@ -1,0 +1,4 @@
+package com.whereyouad.WhereYouAd.domains.notification.application.dto.request;
+
+public class NotificationRequest {
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/application/dto/response/NotificationResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/application/dto/response/NotificationResponse.java
@@ -1,0 +1,4 @@
+package com.whereyouad.WhereYouAd.domains.notification.application.dto.response;
+
+public class NotificationResponse {
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/application/mapper/NotificationConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/application/mapper/NotificationConverter.java
@@ -1,0 +1,4 @@
+package com.whereyouad.WhereYouAd.domains.notification.application.mapper;
+
+public class NotificationConverter {
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/domain/service/NotificationService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/domain/service/NotificationService.java
@@ -1,0 +1,4 @@
+package com.whereyouad.WhereYouAd.domains.notification.domain.service;
+
+public interface NotificationService {
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/domain/service/NotificationServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/domain/service/NotificationServiceImpl.java
@@ -5,5 +5,5 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class NotificationServiceImpl {
+public class NotificationServiceImpl implements NotificationService {
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/domain/service/NotificationServiceImpl.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/domain/service/NotificationServiceImpl.java
@@ -1,0 +1,9 @@
+package com.whereyouad.WhereYouAd.domains.notification.domain.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl {
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/exception/NotificationException.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/exception/NotificationException.java
@@ -1,0 +1,10 @@
+package com.whereyouad.WhereYouAd.domains.notification.exception;
+
+import com.whereyouad.WhereYouAd.global.exception.AppException;
+import com.whereyouad.WhereYouAd.global.exception.BaseErrorCode;
+
+public class NotificationException extends AppException {
+    public NotificationException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/exception/code/NotificationErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/exception/code/NotificationErrorCode.java
@@ -1,0 +1,18 @@
+package com.whereyouad.WhereYouAd.domains.notification.exception.code;
+
+import com.whereyouad.WhereYouAd.global.exception.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationErrorCode implements BaseErrorCode {
+
+    ,
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/exception/code/NotificationErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/exception/code/NotificationErrorCode.java
@@ -9,7 +9,6 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum NotificationErrorCode implements BaseErrorCode {
 
-    ,
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/persistence/entity/Notification.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/persistence/entity/Notification.java
@@ -1,0 +1,45 @@
+package com.whereyouad.WhereYouAd.domains.notification.persistence.entity;
+
+import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notification")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "message", nullable = false, length = 2000)
+    private String message;
+
+    @Column(name = "link_url", length = 1024)
+    private String linkUrl;
+
+    @Column(name = "metadata_json", length = 4000)
+    private String metadataJson;
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    // 연관 관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "org_id", nullable = false)
+    private Organization organization;
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/persistence/entity/OrgMemberNotificationSetting.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/persistence/entity/OrgMemberNotificationSetting.java
@@ -37,6 +37,9 @@ public class OrgMemberNotificationSetting extends BaseEntity {
     @Column(name = "is_discord_enabled", nullable = false)
     private boolean isDiscordEnabled;
 
+    @Column(name = "alert_budget_50", nullable = false)
+    private boolean alertBudget50;
+
     @Column(name = "alert_budget_80", nullable = false)
     private boolean alertBudget80;
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/persistence/entity/OrgMemberNotificationSetting.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/persistence/entity/OrgMemberNotificationSetting.java
@@ -1,0 +1,48 @@
+package com.whereyouad.WhereYouAd.domains.notification.persistence.entity;
+
+import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.OrgMember;
+import com.whereyouad.WhereYouAd.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "org_member_notification_setting")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrgMemberNotificationSetting extends BaseEntity {
+
+    @Id
+    @Column(name = "membership_id")
+    private Long membershipId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId // PK == FK(식별 관계)
+    @JoinColumn(name = "membership_id")
+    private OrgMember orgMember;
+
+    @Column(name = "is_master_enabled", nullable = false)
+    private boolean isMasterEnabled;
+
+    @Column(name = "is_browser_push_enabled", nullable = false)
+    private boolean isBrowserPushEnabled;
+
+    @Column(name = "is_email_enabled", nullable = false)
+    private boolean isEmailEnabled;
+
+    @Column(name = "is_slack_enabled", nullable = false)
+    private boolean isSlackEnabled;
+
+    @Column(name = "slack_webhook_url", length = 255)
+    private String slackWebhookUrl;
+
+    @Column(name = "alert_budget_80", nullable = false)
+    private boolean alertBudget80;
+
+    @Column(name = "alert_budget_100", nullable = false)
+    private boolean alertBudget100;
+
+    @Column(name = "alert_rapid_clicks", nullable = false)
+    private boolean alertRapidClicks;
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/persistence/entity/OrgMemberNotificationSetting.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/persistence/entity/OrgMemberNotificationSetting.java
@@ -34,8 +34,8 @@ public class OrgMemberNotificationSetting extends BaseEntity {
     @Column(name = "is_slack_enabled", nullable = false)
     private boolean isSlackEnabled;
 
-    @Column(name = "slack_webhook_url", length = 255)
-    private String slackWebhookUrl;
+    @Column(name = "is_discord_enabled", nullable = false)
+    private boolean isDiscordEnabled;
 
     @Column(name = "alert_budget_80", nullable = false)
     private boolean alertBudget80;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/persistence/entity/OrgNotificationSetting.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/persistence/entity/OrgNotificationSetting.java
@@ -1,0 +1,30 @@
+package com.whereyouad.WhereYouAd.domains.notification.persistence.entity;
+
+import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
+import com.whereyouad.WhereYouAd.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "org_notification_setting")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrgNotificationSetting extends BaseEntity {
+
+    @Id
+    @Column(name = "org_id")
+    private Long orgId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId // PK == FK(식별 관계)
+    @JoinColumn(name = "org_id")
+    private Organization organization;
+
+    @Column(name = "slack_webhook_url", length = 512)
+    private String slackWebhookUrl;
+
+    @Column(name = "discord_webhook_url", length = 512)
+    private String discordWebhookUrl;
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/persistence/entity/UserNotification.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/persistence/entity/UserNotification.java
@@ -1,0 +1,38 @@
+package com.whereyouad.WhereYouAd.domains.notification.persistence.entity;
+
+import com.whereyouad.WhereYouAd.domains.user.persistence.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_notification")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserNotification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_notification_id")
+    private Long id;
+
+    @ColumnDefault("false")
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+    // 연관관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notification_id", nullable = false)
+    private Notification notification;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/persistence/repository/NotificationRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/persistence/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.whereyouad.WhereYouAd.domains.notification.persistence.repository;
+
+import com.whereyouad.WhereYouAd.domains.notification.persistence.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/persistence/repository/OrgMemberNotificationSettingRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/persistence/repository/OrgMemberNotificationSettingRepository.java
@@ -1,0 +1,7 @@
+package com.whereyouad.WhereYouAd.domains.notification.persistence.repository;
+
+import com.whereyouad.WhereYouAd.domains.notification.persistence.entity.OrgMemberNotificationSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrgMemberNotificationSettingRepository extends JpaRepository<OrgMemberNotificationSetting, Long> {
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/persistence/repository/OrgNotificationSettingRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/persistence/repository/OrgNotificationSettingRepository.java
@@ -1,0 +1,7 @@
+package com.whereyouad.WhereYouAd.domains.notification.persistence.repository;
+
+import com.whereyouad.WhereYouAd.domains.notification.persistence.entity.OrgNotificationSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrgNotificationSettingRepository extends JpaRepository<OrgNotificationSetting, Long> {
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/persistence/repository/UserNotificationRepository.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/persistence/repository/UserNotificationRepository.java
@@ -1,0 +1,7 @@
+package com.whereyouad.WhereYouAd.domains.notification.persistence.repository;
+
+import com.whereyouad.WhereYouAd.domains.notification.persistence.entity.UserNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserNotificationRepository extends JpaRepository<UserNotification, Long> {
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/presentation/NotificationController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/presentation/NotificationController.java
@@ -1,0 +1,12 @@
+package com.whereyouad.WhereYouAd.domains.notification.presentation;
+
+import com.whereyouad.WhereYouAd.domains.notification.presentation.docs.NotificationControllerDocs;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/notification")
+@RequiredArgsConstructor
+public class NotificationController implements NotificationControllerDocs {
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/notification/presentation/docs/NotificationControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/notification/presentation/docs/NotificationControllerDocs.java
@@ -1,0 +1,4 @@
+package com.whereyouad.WhereYouAd.domains.notification.presentation.docs;
+
+public interface NotificationControllerDocs {
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Close #151

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.
알림 엔티티 및 도메인 구조 추가

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- 알림 도메인 구조 추가
- 알림 엔티티(OrgMemberNotificationSetting, Notification, UserNotification, OrgNotificationSetting) 추가
## Notification

알림 원본 데이터를 저장하는 엔티티입니다.

* `created_at`만 필요하여 `BaseEntity` 대신 `@EntityListeners` + `@CreatedDate`를 사용
* `updated_at` 컬럼 생성 방지
* `link_url` : 알림 클릭 시 이동할 URL (nullable)
* `metadata_json` : 추가 정보를 JSON 문자열 형태로 저장
* 조직(`Organization`) 기준으로 알림 관리

---

## UserNotification

`Notification`과 `User`를 연결하는 중간 엔티티이며, 사용자별 읽음 상태를 관리합니다.

* `Notification ↔ User` N:M 관계 해소
* `isRead`, `readAt`을 통해 개별 읽음 여부 관리
* 조회 패턴이 항상 사용자 기준이므로 `Notification` 측 컬렉션은 제거
* `@ManyToOne` 단방향 연관관계만 사용

---

## OrgMemberNotificationSetting

조직 멤버별 알림 수신 설정을 관리합니다.

* `OrgMember`와 1:1 식별 관계(Identifying Relationship)
* `@MapsId`를 사용하여 `membership_id`를 PK이자 FK로 사용

### 관리 항목

* 전체 알림 활성화 여부
* Browser Push / Email / Slack / Discord 수신 여부
* 예산 80%, 예산 100%, 급격한 클릭 증가 등 이벤트별 알림 설정

※ Slack·Discord Webhook URL은 조직 단위 설정(`OrgNotificationSetting`)에서 관리하고, 본 엔티티는 수신 여부만 관리합니다.

---

## OrgNotificationSetting

조직 단위 알림 채널 연동 정보를 관리합니다.

* `Organization`과 1:1 식별 관계
* `org_id`를 PK이자 FK로 사용 (`@MapsId`)
* 조직별 외부 알림 채널 설정 저장

### 관리 항목

* Slack Webhook URL
* Discord Webhook URL

※ URL이 `null`이면 해당 채널은 미연동 상태를 의미합니다.


## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.
### ERD
<img width="1537" height="903" alt="image" src="https://github.com/user-attachments/assets/68d765df-7422-4767-a47b-c362b25a1bf0" />



## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인


---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- (예: 이 로직이 최선일까요? P2)
- (예: 예외 처리 누락 여부 확인 부탁드립니다. P1)

알림 설정 관련해서 엔티티 구조 설계해봤습니다. `OrgMemberNotificationSetting`에서는 개인별 설정(boolean 값으로 해당 채널에 대한 알림을 받을지 말지)을, `OrgNotificationSetting`은 조직에서 슬랙이나 디스코드 연동하면 관리하는 값입니다.
혹시 수정하거나 추가해야할 필드가 있다면 알려주시면 감사하겠습니다!

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 알림 도메인 인프라 추가: 조직/회원별 알림 설정(채널 활성, 알림 예산) 및 알림 데이터 저장 기능 제공
  * 다양한 채널 지원 기반 마련: 브라우저 푸시, 이메일, Slack/Discord(웹훅 URL) 설정 항목 추가
  * 사용자별 알림 읽음 상태 추적(읽음 여부 및 시각) 기능 추가
  * `/api/notification` REST 컨트롤러 및 관련 DTO/예외 체계의 기본 구조 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->