### PR TITLE
Feat/#146 Meta 예산 수정 API 구현

### DIFF
--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/application/dto/request/AdvertisementRequest.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/application/dto/request/AdvertisementRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 import java.time.LocalDate;
 
@@ -22,4 +23,28 @@ public class AdvertisementRequest {
             return startDate != null && endDate != null && !startDate.isAfter(endDate);
         }
     }
+
+    public record MetaBudgetUpdateRequest(
+            @Positive(message = "일일 예산은 0보다 커야 합니다.")
+            Long dailyBudget,
+            @Positive(message = "총 예산은 0보다 커야 합니다.")
+            Long lifetimeBudget
+    ) {
+        @JsonIgnore
+        @AssertTrue(message = "일일 예산과 총 예산 중 정확히 하나만 입력해야 합니다.")
+        public boolean isExactlyOne() {
+            return (dailyBudget == null) ^ (lifetimeBudget == null);
+        }
+
+        @JsonIgnore
+        public Long amount() {
+            return lifetimeBudget != null ? lifetimeBudget : dailyBudget;
+        }
+
+        @JsonIgnore
+        public String budgetType() {
+            return lifetimeBudget != null ? "LIFETIME" : "DAILY";
+        }
+    }
+
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/MetaAdApiService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/MetaAdApiService.java
@@ -1,6 +1,8 @@
 package com.whereyouad.WhereYouAd.domains.advertisement.domain.service;
 
+import com.whereyouad.WhereYouAd.domains.advertisement.application.dto.request.AdvertisementRequest;
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.service.adapi.meta.MetaAuthService;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.service.adapi.meta.MetaBudgetService;
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.service.adapi.meta.MetaSyncService;
 import com.whereyouad.WhereYouAd.domains.organization.domain.constant.OrgRole;
 import com.whereyouad.WhereYouAd.domains.organization.exception.code.OrgErrorCode;
@@ -19,7 +21,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
 
 @Slf4j
 @Service
@@ -31,6 +32,7 @@ public class MetaAdApiService {
     private final OrgRepository orgRepository;
     private final OrgMemberRepository orgMemberRepository;
     private final RedisUtil redisUtil;
+    private final MetaBudgetService metaBudgetService;
 
     // 사용자 갱신 버튼 기본 범위(7일)
     private static final int USER_REFRESH_DEFAULT_DAYS = 7;
@@ -123,6 +125,20 @@ public class MetaAdApiService {
             redisUtil.deleteData(lockKey);
             redisUtil.setDataExpire(cooldownKey, "1", USER_REFRESH_COOLDOWN_SECONDS);
         }
+    }
+
+    // 캠페인 예산 변경
+    public MetaResponse.BudgetUpdateResponse updateCampaignBudget(
+            Long userId, Long adCampaignId, AdvertisementRequest.MetaBudgetUpdateRequest request) {
+
+        return metaBudgetService.updateCampaignBudget(userId, adCampaignId, request);
+    }
+
+    // 광고그룹 예산 변경
+    public MetaResponse.BudgetUpdateResponse updateAdGroupBudget(
+            Long userId, Long adGroupId, AdvertisementRequest.MetaBudgetUpdateRequest request) {
+
+        return metaBudgetService.updateAdGroupBudget(userId, adGroupId, request);
     }
 
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/adapi/meta/MetaBudgetService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/adapi/meta/MetaBudgetService.java
@@ -30,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.Map;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -64,7 +65,7 @@ public class MetaBudgetService {
 
         // 캠페인의 이전 예산 값 추출, 동일 값 검증
         Long previousBudget = campaign.getBudget();
-        if (previousBudget.equals(request.amount())) {
+        if (Objects.equals(previousBudget, request.amount())) {
             throw new AdApiHandler(AdApiErrorCode.SAME_BUDGET_AMOUNT);
         }
 
@@ -118,7 +119,7 @@ public class MetaBudgetService {
 
         // 이전 광고 그룹 예산 값 추출, 동일값 검증
         Long previousBudget = adGroup.getBudget();
-        if (previousBudget.equals(request.dailyBudget())) {
+        if (Objects.equals(previousBudget, request.dailyBudget())) {
             throw new AdApiHandler(AdApiErrorCode.SAME_BUDGET_AMOUNT);
         }
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/adapi/meta/MetaBudgetService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/adapi/meta/MetaBudgetService.java
@@ -1,0 +1,207 @@
+package com.whereyouad.WhereYouAd.domains.advertisement.domain.service.adapi.meta;
+
+import com.whereyouad.WhereYouAd.domains.advertisement.application.dto.request.AdvertisementRequest;
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
+import com.whereyouad.WhereYouAd.domains.advertisement.exception.AdvertisementHandler;
+import com.whereyouad.WhereYouAd.domains.advertisement.exception.code.AdvertisementErrorCode;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdCampaign;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdGroup;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdCampaignRepository;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdGroupRepository;
+import com.whereyouad.WhereYouAd.domains.platform.domain.constant.Currency;
+import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformAccount;
+import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformConnection;
+import com.whereyouad.WhereYouAd.domains.platform.persistence.repository.PlatformConnectionRepository;
+import com.whereyouad.WhereYouAd.global.adapi.dto.AdAuthRequest;
+import com.whereyouad.WhereYouAd.global.adapi.exception.AdApiHandler;
+import com.whereyouad.WhereYouAd.global.adapi.exception.code.AdApiErrorCode;
+import com.whereyouad.WhereYouAd.global.utils.AdApiAuthUtil;
+import com.whereyouad.WhereYouAd.infrastructure.client.meta.client.MetaClient;
+import com.whereyouad.WhereYouAd.infrastructure.client.meta.converter.MetaConverter;
+import com.whereyouad.WhereYouAd.infrastructure.client.meta.dto.MetaDTO;
+import com.whereyouad.WhereYouAd.infrastructure.client.meta.dto.MetaResponse;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MetaBudgetService {
+
+    private final AdCampaignRepository adCampaignRepository;
+    private final AdGroupRepository adGroupRepository;
+    private final PlatformConnectionRepository platformConnectionRepository;
+    private final AdApiAuthUtil adApiAuthUtil;
+    private final MetaClient metaClient;
+
+    // 통화별 일일 최소 예산 — Meta 노출 과금 기준 하한.
+    // 최적화 기반 광고세트는 이보다 높을 수 있어, 초과분은 Meta 에러 매핑
+    private static final Map<Currency, Long> MIN_BUDGET_BY_CURRENCY = Map.of(
+            Currency.KRW, 1000L,  // 한국 원화로 1000원
+            Currency.USD, 1L  // 미국 달러로 1달러
+    );
+
+    private static final long DEFAULT_MIN_BUDGET = 1L;
+
+    // 캠페인 예산 변경 (dailyBudget / lifetimeBudget 둘 중 하나)
+    @Transactional
+    public MetaResponse.BudgetUpdateResponse updateCampaignBudget(
+            Long userId, Long campaignId, AdvertisementRequest.MetaBudgetUpdateRequest request
+    )
+    {
+        AdCampaign campaign = adCampaignRepository.findById(campaignId)
+                .orElseThrow(() -> new AdvertisementHandler(AdvertisementErrorCode.ADCAMPAIGN_NOT_FOUND));
+
+        // Meta 의 광고가 맞는지 검증
+        if (campaign.getProvider() != Provider.META) {
+            throw new AdApiHandler(AdApiErrorCode.INVALID_PROVIDER_VALUE);
+        }
+
+        PlatformAccount account = campaign.getPlatformAccount();
+        Currency currency = account.getCurrency();
+
+        // dailyBudget·lifetimeBudget 중 입력된 값을 통화별 최소 기준과 비교 검증
+        validateMinBudget(request.amount(), currency);
+
+        // 각 예산 수정 요청 값 (dailyBudget, lifetimeBudget) 을 Meta 에서 사용하는 통화 단위로 변환
+        Long dailyMinor = MetaConverter.toMetaBudget(request.dailyBudget(), currency);
+        Long lifetimeMinor = MetaConverter.toMetaBudget(request.lifetimeBudget(), currency);
+
+        // 사용자 토큰 추출 & 검증
+        String token = resolveOwnerAccessToken(userId, account);
+
+        // Meta 광고 캠페인 예산 수정 API 요청
+        callMetaBudgetUpdate(campaign.getExternalCampaignId(), token, dailyMinor, lifetimeMinor);
+
+        // 엔티티의 예산 값 수정
+        campaign.updateBudget(request.amount());
+
+        return new MetaResponse.BudgetUpdateResponse(
+                campaign.getId(), campaign.getExternalCampaignId(), request.amount(), request.budgetType()
+        );
+    }
+
+    //  광고그룹 예산 변경 (AdSet은 daily_budget만 존재 → DAILY 고정)
+    @Transactional
+    public MetaResponse.BudgetUpdateResponse updateAdGroupBudget(
+            Long userId, Long adGroupId, AdvertisementRequest.MetaBudgetUpdateRequest request)
+    {
+
+        // Meta 의 광고 그룹(AdSet) 은 dailyBudget 만 변경 가능 -> lifetimeBudget 에 값 존재 시 오류
+        if (request.lifetimeBudget() != null) {
+            throw new AdApiHandler(AdApiErrorCode.BUDGET_TYPE_NOT_SUPPORTED);
+        }
+
+        AdGroup adGroup = adGroupRepository.findById(adGroupId)
+                .orElseThrow(() -> new AdvertisementHandler(AdvertisementErrorCode.ADGROUP_NOT_FOUND));
+
+        AdCampaign campaign = adGroup.getAdCampaign();
+
+        // Meta 의 광고가 맞는지 검증
+        if (campaign.getProvider() != Provider.META) {
+            throw new AdApiHandler(AdApiErrorCode.INVALID_PROVIDER_VALUE);
+        }
+
+        PlatformAccount account = campaign.getPlatformAccount();
+        Currency currency = account.getCurrency();
+
+        // 광고 계정에 설정된 통화 단위(원or달러) 에 맞춰 최소 금액 이상으로 요청한게 맞는지 검증
+        validateMinBudget(request.dailyBudget(), currency);
+
+        // 사용자 토큰 추출 & 검증
+        String token = resolveOwnerAccessToken(userId, account);
+
+        // 예산 수정 요청 값 (dailyBudget) 을 Meta 에서 사용하는 통화 단위로 변환
+        Long dailyMinor = MetaConverter.toMetaBudget(request.dailyBudget(), currency);
+
+        // Meta 광고 캠페인 예산 수정 API 요청
+        callMetaBudgetUpdate(adGroup.getExternalGroupId(), token, dailyMinor, null);
+
+        // 엔티티의 예산 값 수정
+        adGroup.updateBudget(request.dailyBudget(), null);
+
+        return new MetaResponse.BudgetUpdateResponse(
+                adGroup.getId(), adGroup.getExternalGroupId(), request.dailyBudget(), request.budgetType()
+        );
+    }
+
+    //  Meta 호출하여 예산 수정 + 예외 매핑
+    private void callMetaBudgetUpdate(String nodeId, String token, Long dailyMinor, Long lifetimeMinor) {
+        try {
+            MetaDTO.UpdateResponse response = metaClient.updateBudget(nodeId, token, dailyMinor, lifetimeMinor);
+
+            if (response == null || !Boolean.TRUE.equals(response.success())) {
+                throw new AdApiHandler(AdApiErrorCode.BUDGET_UPDATE_FAILED);
+            }
+
+        } catch (FeignException e) {
+
+            log.error("[META] 예산 변경 실패 - nodeId={}, status={}, body={}", nodeId, e.status(), e.contentUTF8());
+
+            // 변경하려는 예산 금액이 Meta 의 최소 기준치 미만일 시 오류
+            if (isBudgetTooLowError(e)) {
+                throw new AdApiHandler(AdApiErrorCode.INVALID_BUDGET_AMOUNT);
+            }
+
+            // 캠페인에 설정된 예산 유형(일일/총)과 다른 유형으로 변경 요청 시 오류
+            if (isBudgetTypeMismatchError(e)) {
+                throw new AdApiHandler(AdApiErrorCode.INVALID_BUDGET_TYPE);
+            }
+
+            // 그 외 오류
+            throw new AdApiHandler(AdApiErrorCode.BUDGET_UPDATE_FAILED);
+        }
+    }
+
+
+    // 요청자가 이 계정을 연동한 주인인지 검증 + 해당 사용자의 토큰 추출
+    private String resolveOwnerAccessToken(Long userId, PlatformAccount account) {
+        PlatformConnection connection = platformConnectionRepository
+                .findByUserIdAndPlatformAccountId(userId, account.getId())
+                .filter(c -> c.getRevokedAt() == null)
+                .orElseThrow(() -> new AdApiHandler(AdApiErrorCode.NOT_ACCOUNT_OWNER));
+
+        if (connection.getTokenExpireAt() == null || connection.getTokenExpireAt().isBefore(LocalDateTime.now())) {
+            throw new AdApiHandler(AdApiErrorCode.INVALID_API_CREDENTIALS);
+        }
+
+        try {
+            return adApiAuthUtil.generateAuthHeaders(connection.getId(), AdAuthRequest.empty()).get("access_token");
+
+        } catch (Exception e) {
+
+            log.error("[META] 예산 변경용 인증 데이터 생성 실패 (connId: {})", connection.getId(), e);
+            throw new AdApiHandler(AdApiErrorCode.INVALID_API_CREDENTIALS);
+        }
+    }
+
+    // 예산이 Meta 의 절대적 최소 기준치(1000원/1달러) 이하일 경우 오류 발생 메서드
+    private void validateMinBudget(Long budget, Currency currency) {
+        long min = MIN_BUDGET_BY_CURRENCY.getOrDefault(currency, DEFAULT_MIN_BUDGET);
+        if (budget == null || budget < min) {
+            throw new AdApiHandler(AdApiErrorCode.INVALID_BUDGET_AMOUNT);
+        }
+    }
+
+    // 예산이 Meta 의 광고에서 동적 최소 금액 이하 인 경우 오류 발생 메서드
+    private boolean isBudgetTooLowError(FeignException e) {
+        String body = e.contentUTF8();
+        if (body == null) return false;
+        String lower = body.toLowerCase();
+        return body.contains("1487079") || lower.contains("minimum") || lower.contains("budget is too low");
+    }
+
+    // 일일 예산 캠페인(dailyBudget)에 총 예산(lifetimeBudget) 또는 그 반대로 요청을 보내는 등
+    // 예산 유형이 맞지 않을 때 예외 처리
+    private boolean isBudgetTypeMismatchError(FeignException e) {
+        String body = e.contentUTF8();
+        if (body == null) return false;
+        return body.contains("1885630");
+    }
+}

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/adapi/meta/MetaBudgetService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/adapi/meta/MetaBudgetService.java
@@ -1,6 +1,7 @@
 package com.whereyouad.WhereYouAd.domains.advertisement.domain.service.adapi.meta;
 
 import com.whereyouad.WhereYouAd.domains.advertisement.application.dto.request.AdvertisementRequest;
+import com.whereyouad.WhereYouAd.domains.advertisement.application.mapper.AdvertisementConverter;
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.domains.advertisement.exception.AdvertisementHandler;
 import com.whereyouad.WhereYouAd.domains.advertisement.exception.code.AdvertisementErrorCode;
@@ -8,6 +9,7 @@ import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdCamp
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdGroup;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdCampaignRepository;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.AdGroupRepository;
+import com.whereyouad.WhereYouAd.domains.advertisement.persistence.repository.BudgetHistoryRepository;
 import com.whereyouad.WhereYouAd.domains.platform.domain.constant.Currency;
 import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformAccount;
 import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformConnection;
@@ -37,6 +39,7 @@ public class MetaBudgetService {
     private final AdCampaignRepository adCampaignRepository;
     private final AdGroupRepository adGroupRepository;
     private final PlatformConnectionRepository platformConnectionRepository;
+    private final BudgetHistoryRepository budgetHistoryRepository;
     private final AdApiAuthUtil adApiAuthUtil;
     private final MetaClient metaClient;
 
@@ -57,6 +60,13 @@ public class MetaBudgetService {
     {
         AdCampaign campaign = adCampaignRepository.findById(campaignId)
                 .orElseThrow(() -> new AdvertisementHandler(AdvertisementErrorCode.ADCAMPAIGN_NOT_FOUND));
+
+
+        // 캠페인의 이전 예산 값 추출, 동일 값 검증
+        Long previousBudget = campaign.getBudget();
+        if (previousBudget.equals(request.amount())) {
+            throw new AdApiHandler(AdApiErrorCode.SAME_BUDGET_AMOUNT);
+        }
 
         // Meta 의 광고가 맞는지 검증
         if (campaign.getProvider() != Provider.META) {
@@ -82,6 +92,11 @@ public class MetaBudgetService {
         // 엔티티의 예산 값 수정
         campaign.updateBudget(request.amount());
 
+        // 캠페인 예산 변경 이력 추가 (BudgetHistory 엔티티 추가)
+        budgetHistoryRepository.save(AdvertisementConverter.toCampaignBudgetHistory(
+                campaign, previousBudget, request.amount(), userId, Provider.META
+        ));
+
         return new MetaResponse.BudgetUpdateResponse(
                 campaign.getId(), campaign.getExternalCampaignId(), request.amount(), request.budgetType()
         );
@@ -100,6 +115,12 @@ public class MetaBudgetService {
 
         AdGroup adGroup = adGroupRepository.findById(adGroupId)
                 .orElseThrow(() -> new AdvertisementHandler(AdvertisementErrorCode.ADGROUP_NOT_FOUND));
+
+        // 이전 광고 그룹 예산 값 추출, 동일값 검증
+        Long previousBudget = adGroup.getBudget();
+        if (previousBudget.equals(request.dailyBudget())) {
+            throw new AdApiHandler(AdApiErrorCode.SAME_BUDGET_AMOUNT);
+        }
 
         AdCampaign campaign = adGroup.getAdCampaign();
 
@@ -125,6 +146,11 @@ public class MetaBudgetService {
 
         // 엔티티의 예산 값 수정
         adGroup.updateBudget(request.dailyBudget(), null);
+
+        // 광고 그룹 예산 변경 이력 추가 (BudgetHistory 엔티티 추가)
+        budgetHistoryRepository.save(AdvertisementConverter.toAdGroupBudgetHistory(
+                adGroup, previousBudget, request.dailyBudget(), userId, Provider.META
+        ));
 
         return new MetaResponse.BudgetUpdateResponse(
                 adGroup.getId(), adGroup.getExternalGroupId(), request.dailyBudget(), request.budgetType()

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/adapi/meta/MetaSyncService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/adapi/meta/MetaSyncService.java
@@ -173,7 +173,7 @@ public class MetaSyncService {
 
                 // 페이지 단위 배치 UPSERT — campaignMap을 넘겨 부모 스코프 적용
                 Map<String, AdGroup> pageResult =
-                        metaUpsertService.upsertAdGroups(adSetsResp.data(), campaignMap);
+                        metaUpsertService.upsertAdGroups(adSetsResp.data(), campaignMap, pAccountEntity);
                 adSetMap.putAll(pageResult);
                 adSetCount += pageResult.size();
 

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/adapi/meta/MetaUpsertService.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/domain/service/adapi/meta/MetaUpsertService.java
@@ -70,12 +70,12 @@ public class MetaUpsertService {
 
     // Meta AdSet 페이지 -> AdGroup 배치 UPSERT (externalGroupId + 부모 Campaign 스코프)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public Map<String, AdGroup> upsertAdGroups(List<MetaDTO.AdSet> adSets, Map<String, AdCampaign> campaignMap) {
+    public Map<String, AdGroup> upsertAdGroups(List<MetaDTO.AdSet> adSets, Map<String, AdCampaign> campaignMap, PlatformAccount platformAccount) {
         Map<String, AdGroup> result = new HashMap<>();
         for (MetaDTO.AdSet src : adSets) {
             AdCampaign parentCampaign = campaignMap.get(src.campaignId());
             if (parentCampaign == null) continue;
-            AdGroup newData = MetaConverter.toAdGroup(src, parentCampaign);
+            AdGroup newData = MetaConverter.toAdGroup(src, parentCampaign, platformAccount);
             AdGroup saved = adGroupRepository
                     .findByExternalGroupIdAndAdCampaign(src.id(), parentCampaign)
                     .map(existing -> {
@@ -83,6 +83,7 @@ public class MetaUpsertService {
                                 newData.getName(),
                                 newData.getStatus(),
                                 newData.getTargetingInfo());
+                        existing.updateBudget(newData.getBudget(), null);
                         return adGroupRepository.save(existing);
                     })
                     .orElseGet(() -> adGroupRepository.save(newData));

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdCampaign.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdCampaign.java
@@ -94,4 +94,8 @@ public class AdCampaign extends BaseEntity {
             this.description = description;
         }
     }
+
+    public void updateBudget(Long budget) {
+        if (budget != null) this.budget = budget;
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdCampaign.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdCampaign.java
@@ -96,6 +96,6 @@ public class AdCampaign extends BaseEntity {
     }
 
     public void updateBudget(Long budget) {
-        if (budget != null) this.budget = budget;
+        this.budget = budget;
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdGroup.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdGroup.java
@@ -43,6 +43,12 @@ public class AdGroup extends BaseEntity {
     @OneToMany(mappedBy = "adGroup", cascade = CascadeType.ALL)
     private List<AdContent> adContents = new ArrayList<>();
 
+    @Column(name = "budget")
+    private Long budget;
+
+    @Column(name = "bid_amount")
+    private Long bidAmount;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "ad_campaign_id")
     private AdCampaign adCampaign;

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdGroup.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdGroup.java
@@ -1,5 +1,6 @@
 package com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity;
 
+import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Provider;
 import com.whereyouad.WhereYouAd.domains.advertisement.domain.constant.Status;
 import com.whereyouad.WhereYouAd.global.common.BaseEntity;
 import jakarta.persistence.*;
@@ -63,7 +64,14 @@ public class AdGroup extends BaseEntity {
     }
 
     public void updateBudget(Long budget, Long bidAmount) {
-        if (budget != null) this.budget = budget;
-        if (bidAmount != null) this.bidAmount = bidAmount;
+        if (this.adCampaign.getProvider() == Provider.NAVER) {
+            if (budget != null) this.budget = budget;
+            if (bidAmount != null) this.bidAmount = bidAmount;
+        }
+
+        if (this.adCampaign.getProvider() == Provider.META) {
+            this.budget = budget;
+            if (bidAmount != null) this.bidAmount = bidAmount;
+        }
     }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdGroup.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/persistence/entity/AdGroup.java
@@ -61,4 +61,9 @@ public class AdGroup extends BaseEntity {
             this.targetingInfo = targetingInfo;
         }
     }
+
+    public void updateBudget(Long budget, Long bidAmount) {
+        if (budget != null) this.budget = budget;
+        if (bidAmount != null) this.bidAmount = bidAmount;
+    }
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/MetaAdApiController.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/MetaAdApiController.java
@@ -107,6 +107,30 @@ public class MetaAdApiController implements MetaAdApiControllerDocs {
         );
     }
 
+    // 5. 캠페인 예산 변경
+    @PatchMapping("/campaigns/{adCampaignId}/budget")
+    public ResponseEntity<DataResponse<MetaResponse.BudgetUpdateResponse>> updateCampaignBudget(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long adCampaignId,
+            @RequestBody @Valid AdvertisementRequest.MetaBudgetUpdateRequest request)
+    {
+        MetaResponse.BudgetUpdateResponse response =
+                metaAdApiService.updateCampaignBudget(userId, adCampaignId, request);
+        return ResponseEntity.ok(DataResponse.from(response));
+    }
+
+    // 6. 광고그룹 예산 변경
+    @PatchMapping("/adgroups/{adGroupId}/budget")
+    public ResponseEntity<DataResponse<MetaResponse.BudgetUpdateResponse>> updateAdGroupBudget(
+            @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long adGroupId,
+            @RequestBody @Valid AdvertisementRequest.MetaBudgetUpdateRequest request)
+    {
+        MetaResponse.BudgetUpdateResponse response =
+                metaAdApiService.updateAdGroupBudget(userId, adGroupId, request);
+        return ResponseEntity.ok(DataResponse.from(response));
+    }
+
     //===내부 편의 메서드===
     //콜백 실패시 프론트 리다이렉트 메서드
     private ResponseEntity<Void> redirectToFrontend(String status, String detail) {

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/MetaAdApiControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/MetaAdApiControllerDocs.java
@@ -121,7 +121,8 @@ public interface MetaAdApiControllerDocs {
             @ApiResponse(responseCode = "200", description = "예산 변경 성공"),
             @ApiResponse(responseCode = "400", description = "COMMON_400_2 : 요청 본문 검증 실패(일일/총 예산 중 정확히 하나만 입력), "
                     + "ADAPI_400_2 : 메타 광고그룹이 아닌 대상에 대한 요청, ADAPI_400_6 : 예산이 Meta 최소 기준 미만, "
-                    + "ADAPI_400_7 : 광고그룹(AdSet)에 총 예산 변경 요청, ADAPI_400_8 : 기존과 다른 예산 유형으로 변경 요청"),
+                    + "ADAPI_400_7 : 광고그룹(AdSet)에 총 예산 변경 요청, ADAPI_400_8 : 기존과 다른 예산 유형으로 변경 요청, "
+            + "ADAPI_400_9 : 기존 예산 값과 같은 값으로 변경 불가"),
             @ApiResponse(responseCode = "401", description = "ADAPI_401_1 : 연동 인증 정보(토큰)가 유효하지 않거나 만료됨"),
             @ApiResponse(responseCode = "403", description = "ADAPI_403_2 : 해당 광고 계정을 연동한 사용자가 아닌 회원의 요청"),
             @ApiResponse(responseCode = "404", description = "AD_404_2 : 존재하지 않는 광고그룹 ID"),

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/MetaAdApiControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/MetaAdApiControllerDocs.java
@@ -99,7 +99,8 @@ public interface MetaAdApiControllerDocs {
             @ApiResponse(responseCode = "200", description = "예산 변경 성공"),
             @ApiResponse(responseCode = "400", description = "COMMON_400_2 : 요청 본문 검증 실패(일일/총 예산 중 정확히 하나만 입력)\n\n "
                     + "ADAPI_400_2 : 메타 캠페인이 아닌 대상에 대한 요청\n\n ADAPI_400_6 : 예산이 Meta 최소 기준 미만\n\n"
-                    + "ADAPI_400_8 : 기존과 다른 예산 유형으로 변경 요청"),
+                    + "ADAPI_400_8 : 기존과 다른 예산 유형으로 변경 요청"
+                    + "ADAPI_400_9 : 기존 예산 값과 같은 값으로 변경 불가"),
             @ApiResponse(responseCode = "401", description = "ADAPI_401_1 : 연동 인증 정보(토큰)가 유효하지 않거나 만료됨"),
             @ApiResponse(responseCode = "403", description = "ADAPI_403_2 : 해당 광고 계정을 연동한 사용자가 아닌 회원의 요청"),
             @ApiResponse(responseCode = "404", description = "AD_404_1 : 존재하지 않는 캠페인 ID"),

--- a/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/MetaAdApiControllerDocs.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/domains/advertisement/presentation/docs/MetaAdApiControllerDocs.java
@@ -88,4 +88,48 @@ public interface MetaAdApiControllerDocs {
             @Parameter(hidden = true) @AuthenticationPrincipal(expression = "userId") Long userId,
             @PathVariable Long orgId
     );
+
+    @Operation(
+            summary = "메타 캠페인 예산 변경",
+            description = "메타 캠페인의 예산을 변경합니다. 일일 예산(dailyBudget)과 총 예산(lifetimeBudget) 중 정확히 하나만 입력해야 하며, "
+                    + "캠페인에 기존에 설정된 예산 유형과 동일한 유형으로만 변경할 수 있습니다.\n\n"
+                    + "해당 광고 계정을 연동한 사용자(소유자)만 변경할 수 있습니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "예산 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "COMMON_400_2 : 요청 본문 검증 실패(일일/총 예산 중 정확히 하나만 입력)\n\n "
+                    + "ADAPI_400_2 : 메타 캠페인이 아닌 대상에 대한 요청\n\n ADAPI_400_6 : 예산이 Meta 최소 기준 미만\n\n"
+                    + "ADAPI_400_8 : 기존과 다른 예산 유형으로 변경 요청"),
+            @ApiResponse(responseCode = "401", description = "ADAPI_401_1 : 연동 인증 정보(토큰)가 유효하지 않거나 만료됨"),
+            @ApiResponse(responseCode = "403", description = "ADAPI_403_2 : 해당 광고 계정을 연동한 사용자가 아닌 회원의 요청"),
+            @ApiResponse(responseCode = "404", description = "AD_404_1 : 존재하지 않는 캠페인 ID"),
+            @ApiResponse(responseCode = "502", description = "ADAPI_502_3 : Meta 예산 변경 요청 실패")
+    })
+    ResponseEntity<DataResponse<MetaResponse.BudgetUpdateResponse>> updateCampaignBudget(
+            @Parameter(hidden = true) @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long adCampaignId,
+            @RequestBody @Valid AdvertisementRequest.MetaBudgetUpdateRequest request
+    );
+
+    @Operation(
+            summary = "메타 광고그룹 예산 변경",
+            description = "메타 광고그룹(AdSet)의 예산을 변경합니다. 광고그룹은 일일 예산(dailyBudget)만 변경할 수 있으며, "
+                    + "총 예산(lifetimeBudget)은 캠페인에서 설정해야 합니다.\n\n"
+                    + "해당 광고 계정을 연동한 사용자(소유자)만 변경할 수 있습니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "예산 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "COMMON_400_2 : 요청 본문 검증 실패(일일/총 예산 중 정확히 하나만 입력), "
+                    + "ADAPI_400_2 : 메타 광고그룹이 아닌 대상에 대한 요청, ADAPI_400_6 : 예산이 Meta 최소 기준 미만, "
+                    + "ADAPI_400_7 : 광고그룹(AdSet)에 총 예산 변경 요청, ADAPI_400_8 : 기존과 다른 예산 유형으로 변경 요청"),
+            @ApiResponse(responseCode = "401", description = "ADAPI_401_1 : 연동 인증 정보(토큰)가 유효하지 않거나 만료됨"),
+            @ApiResponse(responseCode = "403", description = "ADAPI_403_2 : 해당 광고 계정을 연동한 사용자가 아닌 회원의 요청"),
+            @ApiResponse(responseCode = "404", description = "AD_404_2 : 존재하지 않는 광고그룹 ID"),
+            @ApiResponse(responseCode = "502", description = "ADAPI_502_3 : Meta 예산 변경 요청 실패")
+    })
+    ResponseEntity<DataResponse<MetaResponse.BudgetUpdateResponse>> updateAdGroupBudget(
+            @Parameter(hidden = true) @AuthenticationPrincipal(expression = "userId") Long userId,
+            @PathVariable Long adGroupId,
+            @RequestBody @Valid AdvertisementRequest.MetaBudgetUpdateRequest request
+    );
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/global/adapi/exception/code/AdApiErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/adapi/exception/code/AdApiErrorCode.java
@@ -15,6 +15,12 @@ public enum AdApiErrorCode implements BaseErrorCode {
     TOKEN_EXCHANGE_FAILED(HttpStatus.BAD_REQUEST, "ADAPI_400_3", "액세스 토큰을 발급받거나 장기 토큰으로 연장하는 데 실패했습니다. 인증이 만료되었거나 유효하지 않습니다."),
     AD_ACCOUNT_FETCH_FAILED(HttpStatus.BAD_REQUEST, "ADAPI_400_4", "광고 플랫폼에서 연동할 수 있는 광고 계정 목록을 조회하는 데 실패했습니다."),
     NO_LINKABLE_AD_ACCOUNT(HttpStatus.BAD_REQUEST, "ADAPI_400_5", "연동할 수 있는 광고 계정이 존재하지 않습니다. 플랫폼 관리자 센터에서 광고 계정을 먼저 생성해주세요."),
+    INVALID_BUDGET_AMOUNT(HttpStatus.BAD_REQUEST, "ADAPI_400_6", "예산이 Meta 최소 기준 미만입니다. 통화·최적화 방식에 따라 최소 예산이 다를 수 있습니다."),
+    BUDGET_TYPE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "ADAPI_400_7", "Meta 의 광고그룹(AdSet)은 일일 예산만 변경할 수 있습니다. 총 예산은 캠페인에서 설정해주세요."),
+    INVALID_BUDGET_TYPE(HttpStatus.BAD_REQUEST, "ADAPI_400_8", "현재 설정된 예산 유형과 다른 유형으로 변경할 수 없습니다. 기존에 설정된 예산 유형(일일 예산/총 예산)에 맞춰 요청해주세요."),
+
+    // 403
+    NOT_ACCOUNT_OWNER(HttpStatus.FORBIDDEN, "ADAPI_403_2", "해당 광고 계정을 연동한 사용자만 예산을 변경할 수 있습니다."),
 
     // 409
     SYNC_IN_PROGRESS(HttpStatus.CONFLICT, "ADAPI_409_1", "해당 조직의 광고 데이터 동기화가 이미 진행 중입니다. 잠시 후 다시 시도해주세요."),
@@ -26,6 +32,7 @@ public enum AdApiErrorCode implements BaseErrorCode {
     CONNECTION_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "ADAPI_500_2", "광고 플랫폼 연동 정보(토큰 등)를 암호화하여 저장하는 중 내부 서버 에러가 발생했습니다."),
     EXTERNAL_API_COMMUNICATION_ERROR(HttpStatus.BAD_GATEWAY, "ADAPI_502_1", "외부 광고 플랫폼 API 통신 중 에러가 발생했습니다."),
     TOKEN_RESPONSE_EMPTY(HttpStatus.BAD_GATEWAY, "ADAPI_502_2", "광고 플랫폼으로부터 비어있는 토큰 응답을 받았습니다."),
+    BUDGET_UPDATE_FAILED(HttpStatus.BAD_GATEWAY, "ADAPI_502_3", "예산 변경에 실패했습니다."),
 
     // OAuth 연동 관련
     INVALID_OAUTH_STATE(HttpStatus.BAD_REQUEST, "ADAPI_400_1", "유효하지 않거나 만료된 구글 연동 요청입니다."),

--- a/src/main/java/com/whereyouad/WhereYouAd/global/adapi/exception/code/AdApiErrorCode.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/global/adapi/exception/code/AdApiErrorCode.java
@@ -18,6 +18,7 @@ public enum AdApiErrorCode implements BaseErrorCode {
     INVALID_BUDGET_AMOUNT(HttpStatus.BAD_REQUEST, "ADAPI_400_6", "예산이 Meta 최소 기준 미만입니다. 통화·최적화 방식에 따라 최소 예산이 다를 수 있습니다."),
     BUDGET_TYPE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "ADAPI_400_7", "Meta 의 광고그룹(AdSet)은 일일 예산만 변경할 수 있습니다. 총 예산은 캠페인에서 설정해주세요."),
     INVALID_BUDGET_TYPE(HttpStatus.BAD_REQUEST, "ADAPI_400_8", "현재 설정된 예산 유형과 다른 유형으로 변경할 수 없습니다. 기존에 설정된 예산 유형(일일 예산/총 예산)에 맞춰 요청해주세요."),
+    SAME_BUDGET_AMOUNT(HttpStatus.BAD_REQUEST, "ADAPI_400_9", "예산 값을 이전 예산과 동일한 값으로 수정할 수 없습니다."),
 
     // 403
     NOT_ACCOUNT_OWNER(HttpStatus.FORBIDDEN, "ADAPI_403_2", "해당 광고 계정을 연동한 사용자만 예산을 변경할 수 있습니다."),

--- a/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/meta/client/MetaClient.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/meta/client/MetaClient.java
@@ -4,6 +4,7 @@ import com.whereyouad.WhereYouAd.infrastructure.client.meta.dto.MetaDTO;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(
@@ -69,4 +70,11 @@ public interface MetaClient {
             @RequestParam("time_increment") String timeIncrement,
             @RequestParam(value = "after", required = false) String afterCursor);
 
+    @PostMapping("/{nodeId}")
+    MetaDTO.UpdateResponse updateBudget(
+            @PathVariable("nodeId") String nodeId,
+            @RequestParam("access_token") String accessToken,
+            @RequestParam(value = "daily_budget", required = false) Long dailyBudget,
+            @RequestParam(value = "lifetime_budget", required = false) Long lifetimeBudget
+    );
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/meta/config/MetaAdConfig.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/meta/config/MetaAdConfig.java
@@ -27,7 +27,7 @@ public class MetaAdConfig {
                 .pathSegment(graphApiVersion, "dialog", "oauth")
                 .queryParam("client_id", appId)
                 .queryParam("redirect_uri", redirectUri)
-                .queryParam("scope", "ads_read,business_management")
+                .queryParam("scope", "ads_read,ads_management,business_management") // 추가 -> 예산 수정을 위한 ads_management 권한
                 .queryParam("response_type", "code")
                 .queryParam("state", state)  //  orgId-userId 조각
                 .build()

--- a/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/meta/converter/MetaConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/meta/converter/MetaConverter.java
@@ -70,10 +70,16 @@ public class MetaConverter {
         }
 
         Long budget = null;
-        if (src.dailyBudget() != null && !src.dailyBudget().isEmpty()) {
-            budget = parseLong(src.dailyBudget());
-            Currency currency = (platformAccount != null) ? platformAccount.getCurrency() : null;
-            budget = fromMetaBudget(budget, currency);
+
+        if (src.dailyBudget() != null && !src.dailyBudget().isBlank()) {
+            try {
+                long minorBudget = Long.parseLong(src.dailyBudget());
+                Currency currency = (platformAccount != null) ? platformAccount.getCurrency() : null;
+                budget = fromMetaBudget(minorBudget, currency);
+            } catch (NumberFormatException e) {
+                log.warn("[META] dailyBudget 파싱 실패 - value: {}", src.dailyBudget());
+                budget = null; // 실패값을 0이 아닌 null 로 저장
+            }
         }
 
         return AdGroup.builder()

--- a/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/meta/converter/MetaConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/meta/converter/MetaConverter.java
@@ -262,7 +262,7 @@ public class MetaConverter {
             return null;
         }
 
-        if (currency == null || currency.name().equalsIgnoreCase("KRW")) {
+        if (currency == null || currency == Currency.KRW) {
             return budget;
 
         }
@@ -276,7 +276,7 @@ public class MetaConverter {
             return null;
         }
 
-        if (currency == null || currency.name().equalsIgnoreCase("KRW")) {
+        if (currency == null || currency == Currency.KRW) {
             return minorBudget;
         }
 

--- a/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/meta/converter/MetaConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/meta/converter/MetaConverter.java
@@ -286,7 +286,11 @@ public class MetaConverter {
             return minorBudget;
         }
 
-        return minorBudget / 100;
+        if (minorBudget % 100 != 0) {
+            log.warn("[META] 비 KRW 예산 단위가 100 의 배수가 아닙니다. (반올림 처리): {} {}", minorBudget, currency);
+        }
+
+        return Math.round(minorBudget / 100.0);
     }
 
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/meta/converter/MetaConverter.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/meta/converter/MetaConverter.java
@@ -9,6 +9,7 @@ import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdCont
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.AdGroup;
 import com.whereyouad.WhereYouAd.domains.advertisement.persistence.entity.MetricFact;
 import com.whereyouad.WhereYouAd.domains.organization.persistence.entity.Organization;
+import com.whereyouad.WhereYouAd.domains.platform.domain.constant.Currency;
 import com.whereyouad.WhereYouAd.domains.platform.persistence.entity.PlatformAccount;
 import com.whereyouad.WhereYouAd.infrastructure.client.meta.dto.MetaDTO;
 import com.whereyouad.WhereYouAd.infrastructure.client.meta.dto.MetaResponse;
@@ -62,16 +63,25 @@ public class MetaConverter {
     }
 
     // Meta AdSet -> AdGroup
-    public static AdGroup toAdGroup(MetaDTO.AdSet src, AdCampaign campaign) {
+    public static AdGroup toAdGroup(MetaDTO.AdSet src, AdCampaign campaign, PlatformAccount platformAccount) {
         String targetingInfo = null;
         if (src.targeting() != null) {
             targetingInfo = buildTargetingInfo(src.targeting());
         }
+
+        Long budget = null;
+        if (src.dailyBudget() != null && !src.dailyBudget().isEmpty()) {
+            budget = parseLong(src.dailyBudget());
+            Currency currency = (platformAccount != null) ? platformAccount.getCurrency() : null;
+            budget = fromMetaBudget(budget, currency);
+        }
+
         return AdGroup.builder()
                 .externalGroupId(src.id())
                 .name(src.name())
                 .status(mapStatus(src.status()))
                 .targetingInfo(targetingInfo)
+                .budget(budget)
                 .adCampaign(campaign)
                 .build();
     }
@@ -244,4 +254,33 @@ public class MetaConverter {
                                                              java.util.List<String> failedAccountIds) {
         return new MetaResponse.MetaSyncSummary(campaignCount, adGroupCount, adContentCount, metricCount, failedAccountIds);
     }
+
+    // 로컬 budget(원 단위) → Meta 의 통화 단위로 변환
+    // Meta 는 금액을 최소 단위로 받는다 ex) USD 10$ -> 1000(센트) , KRW 1000 -> 1000
+    public static Long toMetaBudget(Long budget, Currency currency) {
+        if (budget == null) {
+            return null;
+        }
+
+        if (currency == null || currency.name().equalsIgnoreCase("KRW")) {
+            return budget;
+
+        }
+
+        return budget * 100;   // USD 등 소수점 통화는 센트 단위로 전송
+    }
+
+    // Meta 통화 단위 → 로컬 budget 단위 변환
+    private static Long fromMetaBudget(Long minorBudget, Currency currency) {
+        if (minorBudget == null) {
+            return null;
+        }
+
+        if (currency == null || currency.name().equalsIgnoreCase("KRW")) {
+            return minorBudget;
+        }
+
+        return minorBudget / 100;
+    }
+
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/meta/dto/MetaDTO.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/meta/dto/MetaDTO.java
@@ -150,4 +150,11 @@ public class MetaDTO {
             String before,
             String after
     ) {}
+
+    // 추가 : 예산 변경
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record UpdateResponse(
+            Boolean success,
+            String id
+    ) {}
 }

--- a/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/meta/dto/MetaResponse.java
+++ b/src/main/java/com/whereyouad/WhereYouAd/infrastructure/client/meta/dto/MetaResponse.java
@@ -15,4 +15,11 @@ public class MetaResponse {
             int metricCount,
             List<String> failedAccountIds
     ) {}
+
+    public record BudgetUpdateResponse(
+            Long targetId,
+            String externalId,
+            Long updatedBudget,
+            String budgetType
+    ) {}
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Close #146 

## 🚀 개요
> 이번 PR에서 변경된 핵심 내용을 요약해주세요.

Meta 광고 플랫폼 광고 캠페인(AdCampaign), 광고 그룹(AdGroup) 예산값 변경 API 추가

## 📄 작업 내용
> 구체적인 작업 내용을 설명해주세요.
- Meta 광고 캠페인 예산 수정 API 추가
- Meta 광고 그룹 예산 수정 API 추가

## 📸 스크린샷 / 테스트 결과 (선택)
> 결과물 확인을 위한 사진이나 테스트 로그를 첨부해주세요.

기존 DB 의 AdCampaign 과 메타 마케팅 콘솔에서의 예산값 (id = 1 인 AdCampaign 은 AdGroup 에 예산 할당되어있음, 나머지 캠페인은 모두 일일예산 2000원)
<img width="670" height="112" alt="image" src="https://github.com/user-attachments/assets/cbc956e7-c48b-461b-8bc9-5a6e93ace794" />
<img width="1188" height="317" alt="image" src="https://github.com/user-attachments/assets/757aef71-f8fe-416b-b73c-b140fa64a492" />

id = 2 인 AdCampaign 의 예산을 2000원 -> 2500원 수정 요청 결과
<img width="1049" height="496" alt="image" src="https://github.com/user-attachments/assets/c173d4dd-4973-48ea-9832-831600867efd" />
<img width="673" height="121" alt="image" src="https://github.com/user-attachments/assets/4be9cd35-d7a7-4784-8d87-0f7653f87d21" />
<img width="1195" height="293" alt="image" src="https://github.com/user-attachments/assets/3a1ee8a4-609d-410e-9fd7-35e602521df8" />

BudgetHistory 엔티티 정상 생성
<img width="791" height="117" alt="image" src="https://github.com/user-attachments/assets/92dc10b3-8ae5-4fe3-824a-7b499001cb00" />

기존 DB 의 AdGroup 과 메타 마케팅 콘솔에서의 예산값 (id = 1 인 AdGroup 만 일일예산 2000원 할당 상태)
<img width="797" height="100" alt="image" src="https://github.com/user-attachments/assets/f3fb0495-ab70-4da5-a7ed-e5c1cb3d760b" />
<img width="1200" height="267" alt="image" src="https://github.com/user-attachments/assets/c59e5f04-da49-45c2-bcf1-3c3cb1b4af8d" />

id = 1 인 AdGroup 의 예산을 2000원 -> 2500원 수정 요청 결과
<img width="1047" height="535" alt="image" src="https://github.com/user-attachments/assets/8f126f0c-1af3-4657-bab9-cc593b68d0de" />
<img width="800" height="123" alt="image" src="https://github.com/user-attachments/assets/a849c133-0ca0-44eb-85c1-543228ea38d5" />
<img width="1207" height="292" alt="image" src="https://github.com/user-attachments/assets/5b7aadbc-fd49-4102-a9d1-1d56ef9bd805" />

BudgetHistory 엔티티 정상 생성
<img width="791" height="139" alt="image" src="https://github.com/user-attachments/assets/73818be0-51d1-4835-9f00-46a5406260fb" />


## ✅ 체크리스트
- [x] 브랜치 전략(GitHub Flow)을 준수했나요?
- [x] 메서드 단위로 코드가 잘 쪼개져 있나요?
- [x] 테스트 통과 확인
- [x] 서버 실행 확인
- [x] API 동작 확인

---
## 🔍 리뷰 포인트 (Review Points)
> 리뷰어가 중점적으로 확인했으면 하는 부분을 적어주세요. (P1~P4 적용 가이드)
- AdGroup 의 경우 Meta 에서 AdSet 에 해당하는데, 여기에 예산을 부여하는 경우는 lifetimeBudget 과 dailyBudget 중 dailyBudget 만 사용이 가능하다고 하여 AdGroup 예산 수정 요청으로 lifetimeBudget 에 null 아닌 값이 들어오면 오류를 발생하도록 했습니다.
- 추가로 AdGroup 엔티티에 민규님이 updateBudget 메서드를 budget 과 bidAmount 모두 null 값이 아닐때만 갱신 가능하도록 설계하셨는데 Meta 에서는 AdCampaign 이나 AdGroup 둘 중 하나에만 예산 할당이 가능한 구조라 최초 Meta 동기화 시 AdGroup 쪽에 예산이 null 값이 들어올 수 있도록 해야해서... Provider 가 Meta 면 budget 값이 null 이여도 반영 가능하도록 분기하는 방식으로 했는데 이렇게 해도 괜찮을까요...? 아니면 별도의 메서드로 분리하는게 좋을까요? (AdGroup 엔티티 내부 updateBudget 메서드 참고)

> 💬 리뷰어 가이드 (P-Rules)
> **P1: 필수 반영 (Critical)** - 버그 가능성, 컨벤션 위반. 해결 전 머지 불가.
> **P2: 적극 권장 (Recommended)** - 더 나은 대안 제시. 가급적 반영 권장.
> **P3: 제안 (Suggestion)** - 아이디어 공유. 반영 여부는 드라이버 자율.
> **P4: 단순 확인/칭찬 (Nit)** - 사소한 오타, 칭찬 등 피드백.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Meta 캠페인의 일일 또는 총 예산을 업데이트할 수 있는 새로운 API 엔드포인트 추가
  * Meta 광고그룹의 일일 예산을 업데이트할 수 있는 새로운 API 엔드포인트 추가
  * 예산 업데이트 시 금액 검증 및 통화별 최소 예산 확인 기능 추가
  * Meta 플랫폼 연동 계정 소유권 검증 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->